### PR TITLE
Bugfix. unrestrictedTraverse fails when no REQUEST present.

### DIFF
--- a/src/OFS/Traversable.py
+++ b/src/OFS/Traversable.py
@@ -221,8 +221,11 @@ class Traversable:
                         # Process URI segment parameters.
                         ns, nm = nsParse(name)
                         try:
-                            next = namespaceLookup(
-                                ns, nm, obj, aq_acquire(self, 'REQUEST'))
+                            request = aq_acquire(self, 'REQUEST')
+                        except AttributeError:
+                            request = None
+                        try:
+                            next = namespaceLookup(ns, nm, obj, request)
                             if IAcquirer.providedBy(next):
                                 next = next.__of__(obj)
                             if restricted and not validate(


### PR DESCRIPTION
unrestrictedTraverse shouldn't assume that a REQUEST attribute is always
available in the acquisition chain.

Products such as plone.app.async and collective.xmpp.core sometimes
asynchronously connect to the ZServer without an HTTP request.

They should still be able to use unrestrictedTraverse to traverse namespace adapters.

zope.traversing.namespace.namespacelookup doesn't require a Request object to
be available for it to do namespace adapter lookups.

Thanks to @reinhardt who noticed this issue when testing plone.app.async with an object accessed via a namespace adapter.