### PR TITLE
make_query unicode support.

### DIFF
--- a/src/ZTUtils/Zope.py
+++ b/src/ZTUtils/Zope.py
@@ -160,6 +160,17 @@ class Batch(Batch):
 # "make_query(bstart=batch.previous.first)" to one and
 # "make_query(bstart=batch.end)" to the other.
 
+
+_DEFAULT_ENCODING = None
+def _default_encoding():  
+    # avoid doing this at module scope!
+    from App.config import getConfiguration
+    global _DEFAULT_ENCODING
+    if _DEFAULT_ENCODING is None:
+        config = getConfiguration()
+        _DEFAULT_ENCODING = config.zpublisher_default_encoding
+
+
 def make_query(*args, **kwargs):
     '''Construct a URL query string, with marshalling markup.
 
@@ -214,7 +225,7 @@ def make_hidden_input(*args, **kwargs):
 
     return '\n'.join(qlist)
 
-def complex_marshal(pairs):
+def complex_marshal(pairs, enc=None):
     '''Add request marshalling information to a list of name-value pairs.
 
     Names must be strings.  Values may be strings,
@@ -225,6 +236,9 @@ def complex_marshal(pairs):
     becomes a (name, marshal, value) triple.  The middle value is the
     request marshalling string.  Integer, float, and DateTime values
     will have ":int", ":float", or ":date" as their marshal string.
+    Unicode values will have ":<encoding>:ustring" as their marshal
+    string, where '<encoding>' is the provided encoding, or default
+    encoding if not provided.
     Lists will be flattened, and the elements given ":list" in
     addition to their simple marshal string.  Dictionaries will be
     flattened and marshalled using ":record".
@@ -238,7 +252,7 @@ def complex_marshal(pairs):
         if isinstance(v, str):
             pass
         if isinstance(v, unicode):
-            m = simple_marshal(v, enc='utf8')
+            m = simple_marshal(v, enc=enc)
             v = v.encode('utf8')
         elif hasattr(v, 'items'):
             sublist = []
@@ -247,7 +261,7 @@ def complex_marshal(pairs):
                     for ssv in sv:
                         sm = simple_marshal(ssv)
                         sublist.append(('%s.%s' % (k, sk), 
-                                            '%s:list:record' % sm, ssv))
+                                        '%s:list:record' % sm, ssv))
                 else:
                     sm = simple_marshal(sv)
                     sublist.append(('%s.%s' % (k, sk), '%s:record' % sm,  sv))
@@ -265,7 +279,7 @@ def complex_marshal(pairs):
 
     return pairs
 
-def simple_marshal(v, enc='utf8'):
+def simple_marshal(v, enc=None):
     if isinstance(v, str):
         return ''
     if isinstance(v, bool):
@@ -277,6 +291,8 @@ def simple_marshal(v, enc='utf8'):
     if isinstance(v, DateTime):
         return ':date'
     if isinstance(v, unicode):
+        if enc is None:
+            enc = _default_encoding()
         return ':%s:ustring' % (enc,)
     return ''
 

--- a/src/ZTUtils/tests/testZope.py
+++ b/src/ZTUtils/tests/testZope.py
@@ -1,6 +1,7 @@
 from unittest import TestCase, makeSuite
 
 import urllib
+import urlparse
 from ZTUtils.Zope import make_query, complex_marshal, simple_marshal
 from ZTUtils.Zope import make_hidden_input
 from DateTime import DateTime
@@ -14,7 +15,9 @@ class QueryTests(TestCase):
         self.assertEqual(simple_marshal(42), ":int")
         self.assertEqual(simple_marshal(3.1415), ":float")
         self.assertEqual(simple_marshal(DateTime()), ":date")
+        self.fail('set zpublisher_default_encoding')
         self.assertEqual(simple_marshal(u'unic\xF3de'), ":utf8:ustring")
+        self.assertEqual(simple_marshal(u'unic\xF3de', enc='latin1'), ":latin1:ustring")
         
     def testMarshallLists(self):
         '''Test marshalling lists'''
@@ -25,6 +28,7 @@ class QueryTests(TestCase):
                           ('list', ':date:list', test_date),
                           ('list', ':list', 'str'),
                           ('list', ':utf8:ustring:list', u'unic\xF3de')]
+        self.fail('set zpublisher_default_encoding')
 
     def testMarshallRecords(self):
         '''Test marshalling records'''
@@ -35,6 +39,8 @@ class QueryTests(TestCase):
                           ('record.arg2', ':date:record', test_date),
                           ('record.arg3', ':record', 'str'),
                           ('record.arg4', ':utf8:ustring:record', u'unic\xF3de')]
+        
+        self.fail('set zpublisher_default_encoding')
 
     def testMarshallListsInRecords(self):
         '''Test marshalling lists inside of records'''
@@ -57,14 +63,57 @@ class QueryTests(TestCase):
         str_ = 'str'
         query = make_query(date=test_date, integer=int_, listing=list_,
                            record=record, string=str_)
+        
+        #consider urlparse.parse_qs and compare dictionaries
         assert query == 'date:date=%s&integer:int=1&listing:int:list=1&listing:date:list=%s&listing:list=str&string=str&record.arg1:int:list:record=1&record.arg1:date:list:record=%s&record.arg1:list:record=str&record.arg2:int:record=1'%(quote_date,quote_date,quote_date)
+
+    def testMakeComplexQueryUnicode(self):
+        """Test that make_query can handle unicode inside records and lists"""
+        test_date = DateTime()
+        quote_date = urllib.quote(str(test_date))
+        test_ucode = u'unic\xF3de'
+        quote_ucode = urllib.quote(test_ucode.encode('utf8'))
+        record = {'arg1': [45, 'str', test_ucode, test_date], 'arg2': test_ucode}
+        list_ = [45, test_string, test_ucode, test_date]
+        int_ = 1
+        str_ = 'str'
+        query = make_query(integer=int_, date=test_date, recordkey=record,
+                           listing=list_, ustr=test_ucode, string=str_)
+        
+        #consider urlparse.parse_qs and compare dictionaries
+        
+        assert query == 'integer:int=1'+ \
+                        '&date:date=%s' % (quote_date) + \
+                        '&listing:int:list=45' + \
+                          '&listing:list=str' + \
+                          '&listing:utf8:ustring=%s' % (quote_ucode,) + \
+                          '&listing:date:list=%s' % (quote_date,) + \
+                        '&string=str'+ \
+                        '&recordkey.arg1:int:list:record=1' + \
+                        '&recordkey.arg1:list:record=str' + \
+                        '&recordkey.arg1:list:utf8:ustring=%s' % (quote_ucode) + \
+                        '&recordkey.arg1:date:list:record=%s' % (quote_date) + \
+                        '&recordkey.arg2:utf8:ustring:record=1' % (quote_ucode) + \
+                        '&ustr=%s' % (quote_ucode)
 
     def testMakeQueryUnicode(self):
         '''test that make_query returns unicode strings correctly.'''
         formdata = {"string" : "str",
                     "ustr" : u'unic\xF3de'}
+        #set 'zpublisher_default_encoding' 
         query = make_query(formdata)
         self.assertEqual(query, "string=str&ustr:utf8:ustring=unic%C3%B3de")
+        self.fail('set zpublisher_default_encoding')
+        
+    def testMakeQueryUnicodeSpecifyEncoding(self):
+        ''' test that makequery returns unicode strings using specified encoding '''
+        formdata = {"string" : "str",
+                    "ustr" : u'unic\xF3de'}   
+        quote_ustr = urllib.quote(formdata['ustr'].encode('latin1'))
+                               
+        query = make_query_encoded(formdata, enc='latin1')
+        self.assertEqual(query, "string=str&ustr:latin1:ustring=%", quote_ustr)
+        
 
     def testMakeHiddenInput(self):
         tag = make_hidden_input(foo='bar')
@@ -78,6 +127,23 @@ class QueryTests(TestCase):
         self.assertEqual(tag, '<input type="hidden" name="foo" value="&lt;bar&gt;">')
         tag = make_hidden_input(foo='"bar"')
         self.assertEqual(tag, '<input type="hidden" name="foo" value="&quot;bar&quot;">')
+        
+    def testMakeHiddenInputUnicode(self):
+        test_ucode = u'unic\xF3de'
+        quote_ucode = urllib.quote(test_ucode.encode('utf8'))
+        tag = make_hidden_input(foo=test_ucode)
+        #set 'zpublisher_default_encoding'  to utf8
+        self.assertEqual(tag, '<input type="hidden" name="foo:utf8:ustring" value="%s">' % (quote_ucode,))
+        self.fail('set zpublisher_default_encoding')
+        
+    def testMakeHiddenInputEncodedUnicode(self):
+        test_ucode = u'unic\xF3de'
+        quote_ucode = urllib.quote(test_ucode.encode('latin1'))
+        tag = make_hidden_input({'foo':'test_ucode'}, enc='latin1')
+        self.assertEqual(tag, '<input type="hidden" name="foo:latin1:ustring" value="%s">' % (quote_ucode,))
+        
+        
+    
 
 def test_suite():
     return makeSuite(QueryTests)


### PR DESCRIPTION
Per my email to the zope-dev mailing list  "ZTUtils make_query and unicode"

```
Specifically, I'm building search results pagination links using CMFPlone.PloneBatch

Here's the senario:

The search form is provided a unicode string.  The query is properly written as "?search_text:utf8:ustring=value"
The search will return many results.

The searchResults browser view will provide a PloneBatch object, making it very easy to display only 30 results, for example, then provide page links at the bottom of the page for the next 30 results, or whatever.

These links will contain the origional query string, but when they are built using make_query(), the result is 
"?search_text=value" 

 What follows is unicode decode errors when the 'next' link is followed - the search_text is marshaled as a 'str', not as a 'unicode'

 The bottom line is that make_query (actually, complex_marshal & simple_marshal) doesn't seem to apply the ':ustring' type prefix when creating query strings.
```
