### PR TITLE
Fix extends

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(name='Zope2',
     description='Zope2 application server / web framework',
     author='Zope Foundation and Contributors',
     author_email='zope-dev@zope.org',
-    long_description=file("README.txt").read() + "\n" +
+    long_description=file("README.rst").read() + "\n" +
                      file(os.path.join("doc", "CHANGES.rst")).read(),
     classifiers=[
         'Development Status :: 6 - Mature',

--- a/sources.cfg
+++ b/sources.cfg
@@ -1,5 +1,5 @@
 [buildout]
-extends = http://svn.zope.org/repos/main/zopetoolkit/trunk/ztk-sources.cfg
+extends = http://svn.zope.org/zopetoolkit/trunk/ztk-sources.cfg?revision=130246
 
 [remotes]
 github = git://github.com/zopefoundation

--- a/versions.cfg
+++ b/versions.cfg
@@ -1,5 +1,5 @@
 [buildout]
-extends = http://svn.zope.org/repos/main/zopetoolkit/trunk/ztk-versions.cfg
+extends = http://svn.zope.org/zopetoolkit/trunk/ztk-versions.cfg?revision=130246
 versions = versions
 
 [versions]


### PR DESCRIPTION
Looks like the URL on svn.zope.org changed recently from http://svn.zope.org/repos/main/zopetoolkit… to http://svn.zope.org/zopetoolkit…. Also fix setup.py's reference to README.rst
