### PR TITLE
Prevent leaked connections when broken 'EndRequestEvent' subscribers raise

### DIFF
--- a/doc/CHANGES.rst
+++ b/doc/CHANGES.rst
@@ -8,6 +8,9 @@ http://docs.zope.org/zope2/
 2.13.23 (unreleased)
 --------------------
 
+- Issue #16:  prevent leaked connections when broken ``EndRequestEvent``
+  subscribers raise exceptions.
+
 - LP #1387225:  Zope 2.13.x w/ zope.browserpage 4.x doesn't start.
 
 - LP #1387138:  Zope 2.13.x w/ zope.pagetemplate 4.x doesn't start.

--- a/src/ZPublisher/BaseRequest.py
+++ b/src/ZPublisher/BaseRequest.py
@@ -215,10 +215,12 @@ class BaseRequest:
         self._held=None
 
     def close(self):
-        notify(EndRequestEvent(None, self))
-        # subscribers might need the zodb, so `clear` must come afterwards
-        # (since `self._held=None` might close the connection, see above)
-        self.clear()
+        try:
+            notify(EndRequestEvent(None, self))
+        finally:
+            # subscribers might need the zodb, so `clear` must come afterwards
+            # (since `self._held=None` might close the connection, see above)
+            self.clear()
 
     def processInputs(self):
         """Do any input processing that could raise errors


### PR DESCRIPTION
Fixes #16 on the 2.13 branch.