### PR TITLE
Prevent leaked connections when broken 'EndRequestEvent' subscribers raise

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@ http://docs.zope.org/zope2/
 Bugs Fixed
 ++++++++++
 
+- Issue #16: prevent leaked connections when broken ``EndRequestEvent``
+  subscribers raise exceptions.
+
 - Ensure that the ``WSGIPublisher`` begins and ends an *interaction*
   at the request/response barrier. This is required for instance for
   the ``checkPermission`` call to function without an explicit

--- a/src/ZPublisher/BaseRequest.py
+++ b/src/ZPublisher/BaseRequest.py
@@ -215,10 +215,12 @@ class BaseRequest:
         self._held=None
 
     def close(self):
-        notify(EndRequestEvent(None, self))
-        # subscribers might need the zodb, so `clear` must come afterwards
-        # (since `self._held=None` might close the connection, see above)
-        self.clear()
+        try:
+            notify(EndRequestEvent(None, self))
+        finally:
+            # subscribers might need the zodb, so `clear` must come afterwards
+            # (since `self._held=None` might close the connection, see above)
+            self.clear()
 
     def processInputs(self):
         """Do any input processing that could raise errors


### PR DESCRIPTION
Fixes #16 on the master branch.