### PR TITLE
Backport to 2.13: Queue additional warning filters at the beginning of the queue in order to allow overrides.

### DIFF
--- a/doc/CHANGES.rst
+++ b/doc/CHANGES.rst
@@ -8,6 +8,9 @@ http://docs.zope.org/zope2/
 2.13.23 (unreleased)
 --------------------
 
+- Fix: Queue additional warning filters at the beginning of the queue in order
+  to allow overrides.
+
 - Issue #16:  prevent leaked connections when broken ``EndRequestEvent``
   subscribers raise exceptions.
 

--- a/src/Zope2/Startup/warnfilter.py
+++ b/src/Zope2/Startup/warnfilter.py
@@ -51,5 +51,5 @@ def warning_filter_handler(section):
     import warnings
     # add the warning filter
     warnings.filterwarnings(section.action, section.message, section.category,
-                            section.module, section.lineno, 1)
+                            section.module, section.lineno)
     return section


### PR DESCRIPTION
backport of #22 to branch 2.13