### PR TITLE
support IStreamIterator as WSGI response body

### DIFF
--- a/doc/CHANGES.rst
+++ b/doc/CHANGES.rst
@@ -8,6 +8,11 @@ http://docs.zope.org/zope2/
 2.13.23 (unreleased)
 --------------------
 
+- Issue #27: Fix publishing of IStreamIterator. This interface does
+  not have seek or tell.
+  Introduce IUnboundStreamIterator to support publishing iterators
+  of unknown length.
+  
 - LP #1465432:  Ensure that WSGIPublisher starts / ends interaction at
   request boundaries (analogous to ZPublisher).  Backport from master.
 

--- a/src/ZPublisher/Iterators.py
+++ b/src/ZPublisher/Iterators.py
@@ -1,25 +1,31 @@
 from zope.interface import Interface
 from zope.interface import implements
 
-class IStreamIterator(Interface):
+class IUnboundStreamIterator(Interface):
     """
-    An iterator that can be published.
-
-    IStreamIterators must not read from the object database.
-    After the application finishes interpreting a request and 
-    returns an iterator to be processed asynchronously, it closes 
-    the ZODB connection. If the iterator then tries to load some 
-    ZODB object, ZODB would do one of two things.  If the connection 
-    is still closed, ZODB would raise an error. If the connection 
-    happens to be re-opened by another thread, ZODB might allow it, 
-    but it has a chance of going insane if it happens to be loading 
-    or storing something in the other thread at the same time.                      """
+    An iterator with unknown length that can be published.
+    """
 
     def next():
         """
         Return a sequence of bytes out of the bytestream, or raise
         StopIeration if we've reached the end of the bytestream.
         """
+
+
+class IStreamIterator(Interface):
+    """
+    An iterator with known length that can be published.
+
+    IStreamIterators must not read from the object database.
+    After the application finishes interpreting a request and
+    returns an iterator to be processed asynchronously, it closes
+    the ZODB connection. If the iterator then tries to load some
+    ZODB object, ZODB would do one of two things.  If the connection
+    is still closed, ZODB would raise an error. If the connection
+    happens to be re-opened by another thread, ZODB might allow it,
+    but it has a chance of going insane if it happens to be loading
+    or storing something in the other thread at the same time.                      """
 
     def __len__():
         """

--- a/src/ZPublisher/WSGIPublisher.py
+++ b/src/ZPublisher/WSGIPublisher.py
@@ -137,12 +137,12 @@ class WSGIResponse(HTTPResponse):
             body.seek(0)
             self.setHeader('Content-Length', '%d' % length)
             self.body = body
+        elif IStreamIterator.providedBy(body):
+            self.body = body
+            HTTPResponse.setBody(self, '', title, is_error)
         elif IUnboundStreamIterator.providedBy(body):
             self.body = body
             self._streaming = 1
-            HTTPResponse.setBody(self, '', title, is_error)
-        elif IStreamIterator.providedBy(body):
-            self.body = body
             HTTPResponse.setBody(self, '', title, is_error)
         else:
             HTTPResponse.setBody(self, body, title, is_error)

--- a/src/ZPublisher/WSGIPublisher.py
+++ b/src/ZPublisher/WSGIPublisher.py
@@ -32,7 +32,7 @@ from ZPublisher.Publish import dont_publish_class
 from ZPublisher.Publish import get_module_info
 from ZPublisher.Publish import missing_name
 from ZPublisher.pubevents import PubStart, PubBeforeCommit, PubAfterTraversal
-from ZPublisher.Iterators import IStreamIterator
+from ZPublisher.Iterators import IUnboundStreamIterator, IStreamIterator
 
 _NOW = None     # overwrite for testing
 def _now():
@@ -137,9 +137,12 @@ class WSGIResponse(HTTPResponse):
             body.seek(0)
             self.setHeader('Content-Length', '%d' % length)
             self.body = body
-        elif IStreamIterator.providedBy(body):
+        elif IUnboundStreamIterator.providedBy(body):
             self.body = body
             self._streaming = 1
+            HTTPResponse.setBody(self, '', title, is_error)
+        elif IStreamIterator.providedBy(body):
+            self.body = body
             HTTPResponse.setBody(self, '', title, is_error)
         else:
             HTTPResponse.setBody(self, body, title, is_error)

--- a/src/ZPublisher/WSGIPublisher.py
+++ b/src/ZPublisher/WSGIPublisher.py
@@ -130,12 +130,16 @@ class WSGIResponse(HTTPResponse):
         self.stdout.write(data)
 
     def setBody(self, body, title='', is_error=0):
-        if isinstance(body, file) or IStreamIterator.providedBy(body):
+        if isinstance(body, file):
             body.seek(0, 2)
             length = body.tell()
             body.seek(0)
             self.setHeader('Content-Length', '%d' % length)
             self.body = body
+        elif IStreamIterator.providedBy(body):
+            self.body = body
+            self._streaming = 1
+            HTTPResponse.setBody(self, '', title, is_error)
         else:
             HTTPResponse.setBody(self, body, title, is_error)
 

--- a/src/ZPublisher/tests/test_WSGIPublisher.py
+++ b/src/ZPublisher/tests/test_WSGIPublisher.py
@@ -136,6 +136,28 @@ class WSGIResponseTests(unittest.TestCase):
                                 time.gmtime(time.mktime(WHEN)))
         self.assertTrue(('Date', whenstr) in headers)
 
+    def test_setBody_IStreamIterator(self):
+        from ZPublisher.Iterators import IStreamIterator
+        from zope.interface import implements
+
+        class test_streamiterator:
+            implements(IStreamIterator)
+            data = "hello"
+            done = 0
+
+            def next(self):
+                if not self.done:
+                    self.done = 1
+                    return self.data
+                raise StopIteration
+
+        response = self._makeOne()
+        response.setStatus(200)
+        body = test_streamiterator()
+        response.setBody(body)
+        response.finalize()
+        self.assertTrue(body is response.body)
+
     #def test___str__already_wrote_not_chunking(self):
     #    response = self._makeOne()
     #    response._wrote = True

--- a/src/ZPublisher/tests/test_WSGIPublisher.py
+++ b/src/ZPublisher/tests/test_WSGIPublisher.py
@@ -157,6 +157,7 @@ class WSGIResponseTests(unittest.TestCase):
         response.setBody(body)
         response.finalize()
         self.assertTrue(body is response.body)
+        self.assertEqual(response._streaming, 1)
 
     def test_setBody_IStreamIterator(self):
         from ZPublisher.Iterators import IStreamIterator
@@ -182,6 +183,7 @@ class WSGIResponseTests(unittest.TestCase):
         response.setBody(body)
         response.finalize()
         self.assertTrue(body is response.body)
+        self.assertEqual(response._streaming, 0)
 
     #def test___str__already_wrote_not_chunking(self):
     #    response = self._makeOne()

--- a/src/ZPublisher/tests/test_WSGIPublisher.py
+++ b/src/ZPublisher/tests/test_WSGIPublisher.py
@@ -136,6 +136,28 @@ class WSGIResponseTests(unittest.TestCase):
                                 time.gmtime(time.mktime(WHEN)))
         self.assertTrue(('Date', whenstr) in headers)
 
+    def test_setBody_IUnboundStreamIterator(self):
+        from ZPublisher.Iterators import IUnboundStreamIterator
+        from zope.interface import implements
+
+        class test_streamiterator:
+            implements(IUnboundStreamIterator)
+            data = "hello"
+            done = 0
+
+            def next(self):
+                if not self.done:
+                    self.done = 1
+                    return self.data
+                raise StopIteration
+
+        response = self._makeOne()
+        response.setStatus(200)
+        body = test_streamiterator()
+        response.setBody(body)
+        response.finalize()
+        self.assertTrue(body is response.body)
+
     def test_setBody_IStreamIterator(self):
         from ZPublisher.Iterators import IStreamIterator
         from zope.interface import implements
@@ -150,6 +172,9 @@ class WSGIResponseTests(unittest.TestCase):
                     self.done = 1
                     return self.data
                 raise StopIteration
+
+            def __len__(self):
+                return len(self.data)
 
         response = self._makeOne()
         response.setStatus(200)


### PR DESCRIPTION
I had troubles returning an IStreamIterator instance when using the WSGIPublisher.

This PR makes sure that no non iterator methods like seek, len and str are called when publishing an IStreamIterator.

Patch for master branch see: #28 

cheers