### PR TITLE
Fix two issues

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,11 @@ http://docs.zope.org/zope2/
 Bugs Fixed
 ++++++++++
 
+- bobo_traverse of ProductDispatcher did not correctly invalidate cache
+  when a product was not initializes after first access of the cache. Types
+  that were added in test-profiles were not useable.
+  [pbauer, jensens]
+
 - Fix pt_editForm after the help-system was removed.
   [pbauer]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@ http://docs.zope.org/zope2/
 Bugs Fixed
 ++++++++++
 
+- Fix pt_editForm after the help-system was removed.
+  [pbauer]
+
 - Skipped ipv6 test on Travis, because Travis no longer supports this.
 
 - LP #789863:  Ensure that Request objects cannot be published / traversed

--- a/src/App/FactoryDispatcher.py
+++ b/src/App/FactoryDispatcher.py
@@ -79,8 +79,8 @@ class ProductDispatcher(Implicit):
         # Try to get a custom dispatcher from a Python product
         global _packages
         try:
-            package = _packages.get(name, None)
-        except NameError:
+            package = _packages[name]
+        except (NameError, KeyError):
             _packages = _product_packages()
             package = _packages.get(name, None)
 

--- a/src/Products/PageTemplates/ZopePageTemplate.py
+++ b/src/Products/PageTemplates/ZopePageTemplate.py
@@ -32,7 +32,7 @@ from OFS.History import Historical, html_diff
 from OFS.Cache import Cacheable
 from OFS.Traversable import Traversable
 from OFS.PropertyManager import PropertyManager
-from Shared.DC.Scripts.Script import Script 
+from Shared.DC.Scripts.Script import Script
 from Shared.DC.Scripts.Signature import FuncCode
 from webdav.Lockable import ResourceLockedError
 
@@ -83,8 +83,7 @@ class ZopePageTemplate(Script, PageTemplate, Historical, Cacheable,
                                        'www', 'default.html')
 
     manage_options = (
-        {'label':'Edit', 'action':'pt_editForm',
-         'help': ('PageTemplates', 'PageTemplate_Edit.stx')},
+        {'label':'Edit', 'action':'pt_editForm'},
         {'label':'Test', 'action':'ZScriptHTML_tryForm'},
         ) + PropertyManager.manage_options \
         + Historical.manage_options \
@@ -106,10 +105,10 @@ class ZopePageTemplate(Script, PageTemplate, Historical, Cacheable,
     security.declareProtected(view_management_screens,
                               'read', 'ZScriptHTML_tryForm')
 
-    def __init__(self, id, text=None, content_type='text/html', strict=True, 
+    def __init__(self, id, text=None, content_type='text/html', strict=True,
                  output_encoding='utf-8'):
         self.id = id
-        self.expand = 0                                                               
+        self.expand = 0
         self.ZBindings_edit(self._default_bindings)
         self.output_encoding = output_encoding
         # default content
@@ -123,7 +122,7 @@ class ZopePageTemplate(Script, PageTemplate, Historical, Cacheable,
     def pt_edit(self, text, content_type, keep_output_encoding=False):
 
         text = text.strip()
-        
+
         is_unicode = isinstance(text, unicode)
         encoding = None
         output_encoding = None
@@ -162,7 +161,7 @@ class ZopePageTemplate(Script, PageTemplate, Historical, Cacheable,
                                                preferred_encodings)
             output_encoding = encoding
 
-        # for content updated through WebDAV, FTP 
+        # for content updated through WebDAV, FTP
         if not keep_output_encoding:
             self.output_encoding = output_encoding
 
@@ -191,7 +190,7 @@ class ZopePageTemplate(Script, PageTemplate, Historical, Cacheable,
         # The ZMI edit view uses utf-8! So we can safely assume
         # that 'title' and 'text' are utf-8 encoded strings - hopefully
 
-        self.pt_setTitle(title, 'utf-8') 
+        self.pt_setTitle(title, 'utf-8')
         text = unicode(text, 'utf-8')
 
         self.pt_edit(text, content_type, True)
@@ -226,12 +225,12 @@ class ZopePageTemplate(Script, PageTemplate, Historical, Cacheable,
             filename = None
             text = file
         else:
-            if not file: 
+            if not file:
                 raise ValueError('File not specified')
             filename = file.filename
             text = file.read()
 
-        content_type = guess_type(filename, text)   
+        content_type = guess_type(filename, text)
 #        if not content_type in ('text/html', 'text/xml'):
 #            raise ValueError('Unsupported mimetype: %s' % content_type)
 
@@ -293,7 +292,7 @@ class ZopePageTemplate(Script, PageTemplate, Historical, Cacheable,
     def write(self, text):
 
         if not isinstance(text, unicode):
-            text, encoding = convertToUnicode(text, 
+            text, encoding = convertToUnicode(text,
                                               self.content_type,
                                               preferred_encodings)
             self.output_encoding = encoding
@@ -350,7 +349,7 @@ class ZopePageTemplate(Script, PageTemplate, Historical, Cacheable,
         self.dav__init(REQUEST, RESPONSE)
         self.dav__simpleifhandler(REQUEST, RESPONSE, refresh=1)
         text = REQUEST.get('BODY', '')
-        content_type = guess_type('', text) 
+        content_type = guess_type('', text)
         self.pt_edit(text, content_type)
         RESPONSE.setStatus(204)
         return RESPONSE
@@ -368,7 +367,7 @@ class ZopePageTemplate(Script, PageTemplate, Historical, Cacheable,
     security.declareProtected(view_management_screens, 'html')
     def html(self):
         return self.content_type == 'text/html'
-        
+
     security.declareProtected(view_management_screens, 'get_size')
     def get_size(self):
         return len(self.read())
@@ -403,16 +402,16 @@ class ZopePageTemplate(Script, PageTemplate, Historical, Cacheable,
 
     def __setstate__(self, state):
         # Perform on-the-fly migration to unicode.
-        # Perhaps it might be better to work with the 'generation' module 
+        # Perhaps it might be better to work with the 'generation' module
         # here?
         _text = state.get('_text')
         if _text is not None and not isinstance(state['_text'], unicode):
-            text, encoding = convertToUnicode(state['_text'], 
-                                    state.get('content_type', 'text/html'), 
+            text, encoding = convertToUnicode(state['_text'],
+                                    state.get('content_type', 'text/html'),
                                     preferred_encodings)
             state['_text'] = text
             state['output_encoding'] = encoding
-        self.__dict__.update(state) 
+        self.__dict__.update(state)
 
 
     def pt_render(self, source=False, extra_context={}):
@@ -449,7 +448,7 @@ def manage_addPageTemplate(self, id, title='', text='', encoding='utf-8',
         if headers and headers.has_key('content_type'):
             content_type = headers['content_type']
         else:
-            content_type = guess_type(filename, text) 
+            content_type = guess_type(filename, text)
 
 
     else:
@@ -460,7 +459,7 @@ def manage_addPageTemplate(self, id, title='', text='', encoding='utf-8',
             if headers and headers.has_key('content_type'):
                 content_type = headers['content_type']
             else:
-                content_type = guess_type(filename, text) 
+                content_type = guess_type(filename, text)
 
     # ensure that we pass unicode to the constructor to
     # avoid further hassles with pt_edit()
@@ -473,12 +472,12 @@ def manage_addPageTemplate(self, id, title='', text='', encoding='utf-8',
     self._setObject(id, zpt)
     zpt = getattr(self, id)
 
-    if RESPONSE:    
+    if RESPONSE:
         if submit == " Add and Edit ":
             RESPONSE.redirect(zpt.absolute_url() + '/pt_editForm')
         else:
             RESPONSE.redirect(self.absolute_url() + '/manage_main')
-    else:        
+    else:
         return zpt
 
 


### PR DESCRIPTION
These were discovered while trying to use the newest zope-packages for Plone (https://github.com/plone/Products.CMFPlone/issues/1351)

1. Cache-invalidation for FactoryDispatcher was broken for packages that are added after first initialization
2. No longer try to get removed help-file PageTemplate_Edit.stx