### PR TITLE
fix ReST rendering problem in changelog

### DIFF
--- a/doc/CHANGES.rst
+++ b/doc/CHANGES.rst
@@ -33,8 +33,8 @@ http://docs.zope.org/zope2/
 
 - Provide a pip-compatible ``requirements.txt`` file for the release.  E.g.::
 
-  $ /path/to/venv/bin/pip install \
-    https://raw.githubusercontent.com/zopefoundation/Zope/2.13.23/requirements.txt
+      $ /path/to/venv/bin/pip install -r \
+        https://raw.githubusercontent.com/zopefoundation/Zope/2.13.23/requirements.txt
 
 - LP #789863:  Ensure that Request objects cannot be published / traversed
   directly via a URL.
@@ -46,7 +46,7 @@ http://docs.zope.org/zope2/
 
 - Document running Zope as a WSGI application.  See
   https://github.com/zopefoundation/Zope/issues/30
-  
+
 - LP #1465432:  Ensure that WSGIPublisher starts / ends interaction at
   request boundaries (analogous to ZPublisher).  Backport from master.
 


### PR DESCRIPTION
Rendering of RestructuredText on PyPI https://pypi.python.org/pypi/Zope2/2.13.24 is broken. 

This little change fixes it. Looks much better now.

I also found a missing `-r` parameter in the example provided by the change log line and added it.

Hint: [zest.releaser](https://pypi.python.org/pypi/zest.releaser/) is the swiff knife for PyPI releases and besides a streamlined release process it offers the `longtest` script which introspects setup.py and renders README.rst, CHANGES.rst and other involved files as one long file. It reports errors and opens the result in the browser. 