### PR TITLE
Fixing permission handling 

### DIFF
--- a/src/OFS/dtml/access.dtml
+++ b/src/OFS/dtml/access.dtml
@@ -81,7 +81,7 @@ a permission in addition to selecting to acquire permissions.
 
   <dtml-unless isTopLevelPrincipiaApplicationObject>
   <td align="left" valign="top">
-  <input type="checkbox" name="a&dtml-sequence-index;" &dtml-acquire; />
+  <input type="checkbox" name="acquire_&dtml-hashed_name;" &dtml-acquire; />
   </td>
   </dtml-unless>
   <td align="left" nowrap>

--- a/src/OFS/role.py
+++ b/src/OFS/role.py
@@ -25,6 +25,7 @@ from AccessControl.rolemanager import reqattr
 from AccessControl.Permission import Permission
 from AccessControl.Permissions import change_permissions
 from AccessControl.requestmethod import requestmethod
+from AccessControl.rolemanager import _string_hash
 
 
 class RoleManager(BaseRoleManager):
@@ -104,14 +105,18 @@ class RoleManager(BaseRoleManager):
         permissions=self.ac_inherited_permissions(1)
         fails = []
         for ip in range(len(permissions)):
+            permission_name = permissions[ip][0]
+            permission_hash = _string_hash(permission_name)
             roles = []
-            for ir in indexes:
-                if have("p%dr%d" % (ip, ir)):
-                    roles.append(valid_roles[ir])
+            for role in valid_roles:
+                role_name = role
+                role_hash = _string_hash(role_name)
+                if have("permission_%srole_%s" % (permission_hash, role_hash)):
+                    roles.append(role)
             name, value = permissions[ip][:2]
             try:
                 p = Permission(name, value, self)
-                if not have('a%d' % ip):
+                if not have('acquire_%s' % permission_hash):
                     roles=tuple(roles)
                 p.setRoles(roles)
             except:


### PR DESCRIPTION
Using hashed permission names instead of columns and rows numbers eliminates a security issue when the permission (or role) count changes. See <https://github.com/zopefoundation/Zope/issues/57> for more information.