### PR TITLE
Revert "Optimize 'OFS.ObjectManager.__contains__' method"

### DIFF
--- a/doc/CHANGES.rst
+++ b/doc/CHANGES.rst
@@ -18,8 +18,6 @@ http://docs.zope.org/zope2/
 - Removed docstrings from some methods to avoid publishing them.  From
   Products.PloneHotfix20160419.  [maurits]
 
-- Optimized the `OFS.ObjectManager.__contains__` method to do the
-  least amount of work necessary.
 
 2.13.24 (2016-02-29)
 --------------------

--- a/src/OFS/ObjectManager.py
+++ b/src/OFS/ObjectManager.py
@@ -786,11 +786,7 @@ class ObjectManager(CopyContainer,
         return self._setObject(key, value)
 
     def __contains__(self, name):
-        for ob in self._objects:
-            if name == ob['id']:
-                return True
-
-        return False
+        return name in self.objectIds()
 
     def __iter__(self):
         return iter(self.objectIds())


### PR DESCRIPTION
It causes problems with ZCatalog indexes.
See https://github.com/zopefoundation/Zope/issues/69

This reverts pull request #62 from earlier this year.