### PR TITLE
Add support for optional 'SameSite' cookie attribute

### DIFF
--- a/doc/CHANGES.rst
+++ b/doc/CHANGES.rst
@@ -18,6 +18,9 @@ http://docs.zope.org/zope2/
 - Removed docstrings from some methods to avoid publishing them.  From
   Products.PloneHotfix20160419.  [maurits]
 
+- Add support to SameSite cookie in ``ZPublisher.HTTPResponse``:
+  https://tools.ietf.org/html/draft-west-first-party-cookies-07
+
 
 2.13.24 (2016-02-29)
 --------------------

--- a/src/ZPublisher/HTTPResponse.py
+++ b/src/ZPublisher/HTTPResponse.py
@@ -903,6 +903,8 @@ class HTTPResponse(BaseResponse):
                 # and block read/write access via JavaScript
                 elif name == 'http_only' and v:
                     cookie = '%s; HTTPOnly' % cookie
+                elif name == 'same_site':
+                    cookie = '%s; SameSite=%s' % (cookie, v)
             cookie_list.append(('Set-Cookie', cookie))
 
         # Should really check size of cookies here!

--- a/src/ZPublisher/HTTPResponse.py
+++ b/src/ZPublisher/HTTPResponse.py
@@ -903,6 +903,10 @@ class HTTPResponse(BaseResponse):
                 # and block read/write access via JavaScript
                 elif name == 'http_only' and v:
                     cookie = '%s; HTTPOnly' % cookie
+                # Some browsers recognize the SameSite cookie attribute
+                # and do not send the cookie along with cross-site requests
+                # providing some protection against CSRF attacks
+                # https://tools.ietf.org/html/draft-west-first-party-cookies-07
                 elif name == 'same_site':
                     cookie = '%s; SameSite=%s' % (cookie, v)
             cookie_list.append(('Set-Cookie', cookie))

--- a/src/ZPublisher/tests/testHTTPResponse.py
+++ b/src/ZPublisher/tests/testHTTPResponse.py
@@ -319,6 +319,19 @@ class HTTPResponseTests(unittest.TestCase):
         self.assertEqual(len(cookie_list), 1)
         self.assertEqual(cookie_list[0], ('Set-Cookie', 'foo="bar"'))
 
+    def test_setCookie_w_same_site(self):
+        response = self._makeOne()
+        response.setCookie('foo', 'bar', same_site='Strict')
+        cookie = response.cookies.get('foo', None)
+        self.assertEqual(len(cookie), 3)
+        self.assertEqual(cookie.get('value'), 'bar')
+        self.assertEqual(cookie.get('same_site'), 'Strict')
+        self.assertEqual(cookie.get('quoted'), True)
+        cookies = response._cookie_list()
+        self.assertEqual(len(cookies), 1)
+        self.assertEqual(cookies[0],
+                         ('Set-Cookie', 'foo="bar"; SameSite=Strict'))
+
     def test_setCookie_unquoted(self):
         response = self._makeOne()
         response.setCookie('foo', 'bar', quoted=False)


### PR DESCRIPTION
As described in the definition document by the ietf:
https://tools.ietf.org/html/draft-west-first-party-cookies-07

"The 'SameSite' attribute allows servers to assert that a cookie
ought not to be sent along with cross-site requests. This assertion
allows user agents to mitigate the risk of cross-origin information
leakage, and provides some protection against cross-site request
forgery attacks."