### PR TITLE
Patch zope.interface to remove docstrings and avoid publishing.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,8 +11,12 @@ https://zope.readthedocs.io/en/2.13/CHANGES.html
 Bugs Fixed
 ++++++++++
 
+- Patch zope.interface to remove docstrings and avoid publishing.
+  From Products.PloneHotfix20161129.   [maurits]
+
 - Don't copy items the user is not allowed to view.
   From Products.PloneHotfix20161129.  [maurits]
+
 
 Features Added
 ++++++++++++++

--- a/src/Zope2/App/patches/__init__.py
+++ b/src/Zope2/App/patches/__init__.py
@@ -1,0 +1,16 @@
+# Import all patches.
+import persistence
+import publishing
+
+# Have the patches been applied yet?
+_patched = False
+
+
+def apply_patches():
+    global _patched
+    if _patched:
+        return
+    _patched = True
+
+    persistence.apply_patches()
+    publishing.apply_patches()

--- a/src/Zope2/App/patches/persistence.py
+++ b/src/Zope2/App/patches/persistence.py
@@ -1,0 +1,13 @@
+# Has this patch been applied yet?
+_patched = False
+
+
+def apply_patches():
+    global _patched
+    if _patched:
+        return
+    _patched = True
+
+    from Persistence import Persistent
+    from AccessControl.class_init import InitializeClass
+    Persistent.__class_init__ = InitializeClass

--- a/src/Zope2/App/patches/publishing.py
+++ b/src/Zope2/App/patches/publishing.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+
+
+def delete_method_docstring(klass, method_name):
+    # Delete the docstring from the class method.
+    # Objects must have a docstring to be published.
+    # So this avoids them getting published.
+    method = getattr(klass, method_name, None)
+    if (method is not None and hasattr(method, 'im_func') and
+            hasattr(method.im_func, '__doc__')):
+        del method.im_func.__doc__
+
+
+element_methods = [
+    'getDoc',
+    'getName',
+    'getTaggedValue',
+    'getTaggedValueTags',
+    'queryTaggedValue',
+    'setTaggedValue',
+]
+interface_methods = [
+    'changed',
+    'dependents',
+    'direct',
+    'extends',
+    'get',
+    'getBases',
+    'getDescriptionFor',
+    'implementedBy',
+    'interfaces',
+    'isEqualOrExtendedBy',
+    'isOrExtends',
+    'names',
+    'namesAndDescriptions',
+    'providedBy',
+    'queryDescriptionFor',
+    'subscribe',
+    'unsubscribe',
+    'validateInvariants',
+    'weakref',
+]
+
+# Has this patch been applied yet?
+_patched = False
+
+
+def apply_patches():
+    global _patched
+    if _patched:
+        return
+    _patched = True
+
+    from zope.interface import Attribute
+    from zope.interface import Interface
+    from zope.interface.interface import Element
+    from zope.interface.interface import Method
+
+    for klass in [Element, Attribute, Interface, Method]:
+        try:
+            del klass.__doc__
+        except:
+            pass
+        for method_name in element_methods:
+            delete_method_docstring(klass, method_name)
+
+    for method_name in interface_methods:
+        delete_method_docstring(Interface, method_name)

--- a/src/Zope2/App/startup.py
+++ b/src/Zope2/App/startup.py
@@ -47,7 +47,6 @@ deprecated(
 
 app = None
 startup_time = asctime()
-_patched = False
 
 
 def load_zcml():
@@ -60,19 +59,9 @@ def load_zcml():
     configure_vocabulary_registry()
 
 
-def patch_persistent():
-    global _patched
-    if _patched:
-        return
-    _patched = True
-
-    from Persistence import Persistent
-    from AccessControl.class_init import InitializeClass
-    Persistent.__class_init__ = InitializeClass
-
-
 def startup():
-    patch_persistent()
+    from Zope2.App import patches
+    patches.apply_patches()
 
     global app
 

--- a/src/Zope2/App/tests/test_startup.py
+++ b/src/Zope2/App/tests/test_startup.py
@@ -63,6 +63,15 @@ class StartupTests(ZopeTestCase):
         startup()
         self.assertEqual(str(handler), logged)
 
+    def test_interface(self):
+        # We don't want Interface methods to be publishable.
+        # So they should not have a docstring.
+        # This is done in Zope2.App.patches.publishing.
+        from zope.interface import Interface
+        self.assertFalse(Interface.names.__doc__)
+        self.assertFalse(Interface.getTaggedValue.__doc__)
+        self.assertFalse(Interface.setTaggedValue.__doc__)
+
 
 def test_suite():
     suite = unittest.TestSuite()


### PR DESCRIPTION
From Products.PloneHotfix20161129.

See https://github.com/zopefoundation/zope.interface/pull/65