### PR TITLE
Fixed dummy runTest on functional test case. [2.13]

### DIFF
--- a/src/Testing/ZopeTestCase/zopedoctest/functional.py
+++ b/src/Testing/ZopeTestCase/zopedoctest/functional.py
@@ -237,8 +237,9 @@ class ZopeSuiteFactory:
 
         # If the test_class does not have a runTest method, we add
         # a dummy attribute so that TestCase construction works.
+        # runTest may get called, so set it to something that works.
         if not hasattr(test_class, 'runTest'):
-            setattr(test_class, 'runTest', None)
+            setattr(test_class, 'runTest', lambda x: None)
 
         # Create a TestCase instance which will be used to execute
         # the setUp and tearDown methods, as well as be passed into
@@ -336,4 +337,3 @@ __all__ = [
     'FunctionalDocTestSuite',
     'FunctionalDocFileSuite',
     ]
-


### PR DESCRIPTION
In functional doc tests you can apparently have a test case that has no runTest method.  Until now the Testing package added a dummy runTest method in that case, and set it to None.

But when this dummy runTest method gets called, you get an error:
    
      Error in test runTest (Testing.ZopeTestCase.ZopeTestCase.FunctionalTestCase)
      Traceback (most recent call last):
        File ".../lib/python2.7/unittest/case.py", line 329, in run
          testMethod()
      TypeError: 'NoneType' object is not callable
    
Simply importing Testing.ZopeTestCase.FunctionalTestCase in a new test file may be enough to trigger this.
    
So this has something to do with the order in which tests are found.
    
I fixed it by making the dummy runTest method callable.

This is related to remarks in https://github.com/zopefoundation/Zope/pull/88, which is where I took this commit from.