### PR TITLE
Make the WSGI publisher support the test browser's handleErrors = False option

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,11 @@ Bugs Fixed
 - Don't copy items the user is not allowed to view.
   From Products.PloneHotfix20161129.  [maurits]
 
+- Don't render exception views when WSGI publisher is called
+  by the test browser (when 'wsgi.handleErrors' in the request
+  environ is False). This makes it behave more similarly
+  to the ZServer publisher for compatibility with existing tests. [davisagli]
+
 Features Added
 ++++++++++++++
 

--- a/src/ZPublisher/HTTPResponse.py
+++ b/src/ZPublisher/HTTPResponse.py
@@ -1007,8 +1007,9 @@ class WSGIResponse(HTTPBaseResponse):
                            'basic realm="%s"' % self.realm, 1)
 
     def unauthorized(self):
-        exc = Unauthorized()
-        exc.title = 'You are not authorized to access this resource.'
+        message = 'You are not authorized to access this resource.'
+        exc = Unauthorized(message)
+        exc.title = message
         if self.debug_mode:
             if self._auth:
                 exc.detail = 'Username and password are not correct.'

--- a/src/ZPublisher/WSGIPublisher.py
+++ b/src/ZPublisher/WSGIPublisher.py
@@ -169,6 +169,9 @@ def _publish_response(request, response, module_info, _publish=publish):
         with transaction_pubevents(request):
             response = _publish(request, module_info)
     except Exception as exc:
+        if not request.environ.get('wsgi.handleErrors', True):
+            raise
+
         if isinstance(exc, HTTPRedirection):
             response._redirect(exc)
         elif isinstance(exc, Unauthorized):

--- a/src/ZPublisher/tests/test_pubevents.py
+++ b/src/ZPublisher/tests/test_pubevents.py
@@ -180,6 +180,7 @@ class _Request(BaseRequest):
     response = WSGIResponse()
     _hacked_path = False
     args = ()
+    environ = {}
 
     def __init__(self, *args, **kw):
         BaseRequest.__init__(self, *args, **kw)


### PR DESCRIPTION
(to raise exceptions rather than rendering a response)

Also make the repr of the Unauthorized exception raised by the WSGI publisher
backwards-compatible.