### PR TITLE
render Unauthorized and Redirect exceptions outside of WSGIPublisher

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -19,6 +19,7 @@ parts =
     requirements
 sources-dir = develop
 auto-checkout =
+    zExceptions
 
 
 [test]

--- a/sources.cfg
+++ b/sources.cfg
@@ -14,7 +14,7 @@ five.globalrequest = git ${remotes:github}/five.globalrequest pushurl=${remotes:
 MultiMapping = git ${remotes:github}/MultiMapping pushurl=${remotes:github_push}/MultiMapping
 Persistence = git ${remotes:github}/Persistence pushurl=${remotes:github_push}/Persistence
 RestrictedPython = git ${remotes:github}/RestrictedPython pushurl=${remotes:github_push}/RestrictedPython
-zExceptions = git ${remotes:github}/zExceptions pushurl=${remotes:github_push}/zExceptions
+zExceptions = git ${remotes:github}/zExceptions pushurl=${remotes:github_push}/zExceptions branch=davisagli-exception-headers
 zope.globalrequest = git ${remotes:github}/zope.globalrequest pushurl=${remotes:github_push}/zope.globalrequest
 
 # Optional dependencies

--- a/src/Testing/ZopeTestCase/functional.py
+++ b/src/Testing/ZopeTestCase/functional.py
@@ -103,6 +103,10 @@ class Functional(sandbox.Sandboxed):
         wsgi_headers = BytesIO()
 
         def start_response(status, headers):
+            response.setStatus(status.split()[0])
+            for name, value in headers:
+                response.setHeader(name, value)
+
             wsgi_headers.write('HTTP/1.1 %s\r\n' % status)
             headers = '\r\n'.join([': '.join(x) for x in headers])
             wsgi_headers.write(headers)

--- a/src/Testing/ZopeTestCase/zopedoctest/FunctionalDocTest.txt
+++ b/src/Testing/ZopeTestCase/zopedoctest/FunctionalDocTest.txt
@@ -99,7 +99,6 @@ Test Unauthorized
   ... GET /test_folder_1_/index_html HTTP/1.1
   ... """, handle_errors=True))
   HTTP/1.1 401 Unauthorized
-  ...
   WWW-Authenticate: basic realm=...
 
 Test Basic Authentication

--- a/src/ZPublisher/HTTPResponse.py
+++ b/src/ZPublisher/HTTPResponse.py
@@ -998,17 +998,14 @@ class WSGIResponse(HTTPBaseResponse):
             'and try the request again.</p>' % name)
         raise exc
 
-    def _unauthorized(self, exc=None):
-        # This should be handled by zExceptions
-        status = exc.getStatus() if exc is not None else 401
-        self.setStatus(status)
+    def _unauthorized(self, exc):
         if self.realm:
-            self.setHeader('WWW-Authenticate',
-                           'basic realm="%s"' % self.realm, 1)
+            exc.setHeader('WWW-Authenticate', 'basic realm="%s"' % self.realm)
 
     def unauthorized(self):
-        exc = Unauthorized()
-        exc.title = 'You are not authorized to access this resource.'
+        message = 'You are not authorized to access this resource.'
+        exc = Unauthorized(message)
+        exc.title = message
         if self.debug_mode:
             if self._auth:
                 exc.detail = 'Username and password are not correct.'
@@ -1017,9 +1014,7 @@ class WSGIResponse(HTTPBaseResponse):
         raise exc
 
     def _redirect(self, exc):
-        # This should be handled by zExceptions
-        self.setStatus(exc.getStatus())
-        self.setHeader('Location', str(exc))
+        exc.setHeader('Location', str(exc))
 
     def redirect(self, location, status=302, lock=0):
         """Cause a redirection."""

--- a/src/ZPublisher/tests/test_pubevents.py
+++ b/src/ZPublisher/tests/test_pubevents.py
@@ -180,6 +180,7 @@ class _Request(BaseRequest):
     response = WSGIResponse()
     _hacked_path = False
     args = ()
+    environ = {}
 
     def __init__(self, *args, **kw):
         BaseRequest.__init__(self, *args, **kw)


### PR DESCRIPTION
Instead, add info needed for headers to the exception instances so that zExceptions can render them when invoked by the HTTPExceptionHandler middleware (see zopefoundation/zExceptions#2)