### PR TITLE
Remove the dependency on sourcecodegen.

### DIFF
--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -31,7 +31,6 @@ pbr==3.0.0
 persistent==4.2.2
 pytz==2017.2
 six==1.10.0
-sourcecodegen==0.6.14
 transaction==2.1.2
 waitress==1.0.2
 z3c.pt==3.0

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,6 @@ setup(
         'ZODB',
         'setuptools',
         'six',
-        'sourcecodegen',
         'transaction',
         'waitress',
         'zExceptions >= 3.4',

--- a/src/Products/PageTemplates/expression.py
+++ b/src/Products/PageTemplates/expression.py
@@ -1,6 +1,5 @@
-from ast import NodeTransformer
+from ast import NodeTransformer, parse
 from types import ClassType
-from compiler import parse as ast24_parse
 
 from OFS.interfaces import ITraversable
 from zExceptions import NotFound, Unauthorized
@@ -23,7 +22,6 @@ from AccessControl.ZopeGuards import protected_inplacevar
 from chameleon.astutil import Symbol
 from chameleon.astutil import Static
 from chameleon.codegen import template
-from sourcecodegen import generate_code
 
 from z3c.pt import expressions
 import collections
@@ -170,13 +168,10 @@ class UntrustedPythonExpr(expressions.PythonExpr):
 
     def parse(self, string):
         encoded = string.encode('utf-8')
-        node = ast24_parse(encoded, 'eval').node
+        node = parse(encoded, mode='eval')
         MutatingWalker.walk(node, self.rm)
-        string = generate_code(node)
-        decoded = string.decode('utf-8')
-        value = super(UntrustedPythonExpr, self).parse(decoded)
 
         # Run restricted python transform
-        self.rt.visit(value)
+        self.rt.visit(node)
 
-        return value
+        return node

--- a/versions-prod.cfg
+++ b/versions-prod.cfg
@@ -27,7 +27,6 @@ pytz = 2017.2
 Record = 3.2
 RestrictedPython = 3.6.0
 six = 1.10.0
-sourcecodegen = 0.6.14
 transaction = 2.1.2
 waitress = 1.0.2
 WebOb = 1.7.2


### PR DESCRIPTION
We do not need to convert the ast to source code before passing it to the
RestrictedPython machinery. It takes the result of the ast.parse() in Python 2.7 as well.

For Python 3 `slice()` has to be available as built-in so that has to be allowed as s in RestrictedPython.