### PR TITLE
Restore a `_unauthorized` hook on the response object.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ https://zope.readthedocs.io/en/2.13/CHANGES.html
 Bugs Fixed
 ++++++++++
 
+- Restore a `_unauthorized` hook on the response object.
+
 Features Added
 ++++++++++++++
 

--- a/src/Testing/ZopeTestCase/zopedoctest/FunctionalDocTest.txt
+++ b/src/Testing/ZopeTestCase/zopedoctest/FunctionalDocTest.txt
@@ -99,6 +99,7 @@ Test Unauthorized
   ... GET /test_folder_1_/index_html HTTP/1.1
   ... """, handle_errors=True))
   HTTP/1.1 401 Unauthorized
+  ...
   WWW-Authenticate: basic realm=...
 
 Test Basic Authentication

--- a/src/ZPublisher/HTTPResponse.py
+++ b/src/ZPublisher/HTTPResponse.py
@@ -674,6 +674,11 @@ class HTTPBaseResponse(BaseResponse):
         result.extend(self.accumulated_headers)
         return result
 
+    def _unauthorized(self):
+        realm = self.realm
+        if realm:
+            self.setHeader('WWW-Authenticate', 'basic realm="%s"' % realm, 1)
+
 
 class HTTPResponse(HTTPBaseResponse):
 
@@ -783,11 +788,6 @@ class HTTPResponse(HTTPBaseResponse):
             "Make sure to specify all required parameters, " +
             "and try the request again.</p>"
         ))
-
-    def _unauthorized(self):
-        realm = self.realm
-        if realm:
-            self.setHeader('WWW-Authenticate', 'basic realm="%s"' % realm, 1)
 
     def unauthorized(self):
         m = "You are not authorized to access this resource."
@@ -997,9 +997,6 @@ class WSGIResponse(HTTPBaseResponse):
             'Make sure to specify all required parameters, '
             'and try the request again.</p>' % name)
         raise exc
-
-    def _unauthorized(self):
-        pass
 
     def unauthorized(self):
         message = 'You are not authorized to access this resource.'

--- a/src/ZPublisher/HTTPResponse.py
+++ b/src/ZPublisher/HTTPResponse.py
@@ -998,6 +998,9 @@ class WSGIResponse(HTTPBaseResponse):
             'and try the request again.</p>' % name)
         raise exc
 
+    def _unauthorized(self):
+        pass
+
     def unauthorized(self):
         message = 'You are not authorized to access this resource.'
         exc = Unauthorized(message)
@@ -1023,6 +1026,9 @@ class WSGIResponse(HTTPBaseResponse):
             t, v, tb = info
         else:
             t, v, tb = sys.exc_info()
+
+        if issubclass(t, Unauthorized):
+            self._unauthorized()
 
         reraise(t, v, tb)
 

--- a/src/ZPublisher/WSGIPublisher.py
+++ b/src/ZPublisher/WSGIPublisher.py
@@ -177,11 +177,13 @@ def _publish_response(request, response, module_info, _publish=publish):
         if not isinstance(exc, t):
             exc = t(str(exc))
 
-        # This should happen inside zExceptions, but the realm is only
-        # defined on the premade response or in the module_info and
-        # can be changed during publishing.
         if isinstance(exc, Unauthorized):
-            exc.setRealm(response.realm)
+            # _unauthorized modifies the response in-place in unknown
+            # ways, so we have to trust and return it, and ignore
+            # the exception instance.
+            response._unauthorized()
+            response.setStatus(exc.getStatus())
+            return response
 
         view = queryMultiAdapter((exc, request), name=u'index.html')
         if view is not None:

--- a/src/ZPublisher/tests/test_WSGIPublisher.py
+++ b/src/ZPublisher/tests/test_WSGIPublisher.py
@@ -150,6 +150,15 @@ class WSGIResponseTests(unittest.TestCase):
         response.setBody('TESTING')
         self.assertRaises(NotImplementedError, lambda: str(response))
 
+    def test_exception_calls_unauthorized(self):
+        from zExceptions import Unauthorized
+        response = self._makeOne()
+        _unauthorized = DummyCallable()
+        response._unauthorized = _unauthorized
+        with self.assertRaises(Unauthorized):
+            response.exception(info=(Unauthorized, Unauthorized('fail'), None))
+        self.assertEqual(_unauthorized._called_with, ((), {}))
+
 
 class TestPublish(unittest.TestCase):
 

--- a/src/ZPublisher/tests/test_WSGIPublisher.py
+++ b/src/ZPublisher/tests/test_WSGIPublisher.py
@@ -448,7 +448,7 @@ class TestPublishModule(unittest.TestCase, PlacelessSetup):
         app_iter = self._callFUT(environ, start_response, _publish)
         body = ''.join(app_iter)
         self.assertEqual(start_response._called_with[0][0], '401 Unauthorized')
-        self.assertTrue('Exception View: Unauthorized' in body)
+        self.assertFalse('Exception View' in body)
 
     def testCustomExceptionViewForbidden(self):
         from zExceptions import Forbidden


### PR DESCRIPTION
This is used as a hook by PluggableAuthService.

The HTTPResponse module has a new base class and two variants of the HTTP response class. You probably need to update the patch in PAS, to patch both `HTTPResponse.HTTPResponse` and `HTTPResponse.WSGIResponse`, as the `_unauthorized` method is defined on each of those classes.