### PR TITLE
Explicitly require Manager role for `AltDatabaseManager`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ notifications:
 
 install:
     - pip install zc.buildout==2.3.1
-    - bin/buildout
+    - buildout
 
 script:
     - bin/alltests

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ notifications:
     - tseaver@palladion.com
 
 install:
-    - python bootstrap.py
-    - bin/buildout -n
+    - pip install zc.buildout==2.3.1
+    - bin/buildout
 
 script:
     - bin/alltests

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ notifications:
 
 install:
     - python bootstrap.py
-    - bin/buildout
+    - bin/buildout -n
 
 script:
     - bin/alltests

--- a/doc/CHANGES.rst
+++ b/doc/CHANGES.rst
@@ -8,6 +8,7 @@ http://docs.zope.org/zope2/
 2.13.27 (unreleased)
 --------------------
 
+- Explicitly require Manager role for ``AltDatabaseManager``.  [maurits]
 
 
 2.13.26 (2017-02-20)

--- a/src/App/ApplicationManager.py
+++ b/src/App/ApplicationManager.py
@@ -482,6 +482,7 @@ class ApplicationManager(Folder,CacheManager):
 class AltDatabaseManager(DatabaseManager, CacheManager):
     """ Database management DBTab-style
     """
+    __roles__ = ('Manager', )
     db_name = ApplicationManager.db_name.im_func
     db_size = ApplicationManager.db_size.im_func
     manage_pack = ApplicationManager.manage_pack.im_func


### PR DESCRIPTION
If you use [`experimental.publishtraverse`](https://pypi.python.org/pypi/experimental.publishtraverse) and try to call `manage_pack`, it warns that the object (the `manage_pack` function) has no roles. In strict mode it will fail.

This is an indication that the function *might* be available for anonymous users. That is not the case here, but being strict seems good.