### PR TITLE
Restore exception views for unauthorized, closes #116.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ https://zope.readthedocs.io/en/2.13/CHANGES.html
 Bugs Fixed
 ++++++++++
 
+- #116: Restore exception views for unauthorized.
+
 - Restore a `_unauthorized` hook on the response object.
 
 - Restore `HTTPResponse.redirect` behaviour of not raising an exception.

--- a/src/ZPublisher/tests/test_WSGIPublisher.py
+++ b/src/ZPublisher/tests/test_WSGIPublisher.py
@@ -448,7 +448,7 @@ class TestPublishModule(unittest.TestCase, PlacelessSetup):
         app_iter = self._callFUT(environ, start_response, _publish)
         body = ''.join(app_iter)
         self.assertEqual(start_response._called_with[0][0], '401 Unauthorized')
-        self.assertFalse('Exception View' in body)
+        self.assertTrue('Exception View: Unauthorized' in body)
 
     def testCustomExceptionViewForbidden(self):
         from zExceptions import Forbidden


### PR DESCRIPTION
This should bring back the ability to register exception views for Unauthorized, without making any other changes. It does not address the issues raised in #106.