### PR TITLE
More Python 3 fixes.

### DIFF
--- a/src/App/ImageFile.py
+++ b/src/App/ImageFile.py
@@ -69,9 +69,8 @@ class ImageFile(Explicit):
 
         if content_type == 'failed':
             # This failed, lets look into the file content
-            img = open(path, 'rb')
-            data = img.read(1024)  # 1k should be enough
-            img.close()
+            with open(path, 'rb') as img:
+                data = img.read(1024)  # 1k should be enough
 
             content_type, enc = guess_content_type(path, data)
 

--- a/src/OFS/CopySupport.py
+++ b/src/OFS/CopySupport.py
@@ -553,7 +553,7 @@ class CopySource(Base):
                     # We do not use cp._delObject, because this would fire
                     # events that are needless for objects that are not even in
                     # an Acquisition chain yet.
-                    logger.warn(
+                    logger.warning(
                         'While copying %s to %s, removed %s from copy '
                         'because user is not allowed to view the original.',
                         '/'.join(self.getPhysicalPath()),

--- a/src/OFS/DTMLMethod.py
+++ b/src/OFS/DTMLMethod.py
@@ -249,7 +249,7 @@ class DTMLMethod(RestrictedDTML,
         if isinstance(data, TaintedString):
             data = data.quoted()
 
-        if not isinstance(data, binary_type):
+        if hasattr(data, 'read'):
             data = data.read()
         self.munge(data)
         self.ZCacheable_invalidate()

--- a/src/OFS/Image.py
+++ b/src/OFS/Image.py
@@ -315,9 +315,13 @@ class File(Persistent, Implicit, PropertyManager,
                             b'Content-Type: ' +
                             self.content_type.encode('ascii') + b'\r\n')
                         RESPONSE.write(
-                            b'Content-Range: bytes ' + bytes(start) +
-                            b'-' + bytes(end - 1) +
-                            b'/' + bytes(self.size) + b'\r\n\r\n')
+                            b'Content-Range: bytes ' +
+                            str(start).encode('ascii') +
+                            b'-' +
+                            str(end - 1).encode('ascii') +
+                            b'/' +
+                            str(self.size).encode('ascii') +
+                            b'\r\n\r\n')
 
                         if isinstance(data, binary_type):
                             RESPONSE.write(data[start:end])

--- a/src/OFS/tests/test_DTMLMethod.py
+++ b/src/OFS/tests/test_DTMLMethod.py
@@ -22,7 +22,7 @@ class DTMLMethodTests(unittest.TestCase):
         data = TaintedString('hello<br/>')
 
         doc.manage_edit(data, 'title')
-        self.assertEqual(doc.read(), b'hello&lt;br/&gt;')
+        self.assertEqual(doc.read(), 'hello&lt;br/&gt;')
 
 
 class FactoryTests(unittest.TestCase):

--- a/src/Products/PageTemplates/ZopePageTemplate.py
+++ b/src/Products/PageTemplates/ZopePageTemplate.py
@@ -111,7 +111,8 @@ class ZopePageTemplate(Script, PageTemplate, Cacheable,
         self.output_encoding = output_encoding
         # default content
         if not text:
-            text = open(self._default_content_fn).read()
+            with open(self._default_content_fn) as fd:
+                text = fd.read()
             content_type = 'text/html'
         self.pt_edit(text, content_type)
 

--- a/src/Products/PageTemplates/tests/input/TeeShop1.html
+++ b/src/Products/PageTemplates/tests/input/TeeShop1.html
@@ -73,7 +73,7 @@
 </div>
 <p>&nbsp;</p><table width="100%" border="0" cellspacing="1" cellpadding="3" align="center">
   <tr > 
-    <td align="center" bgcolor="#FFFFFF" class="bodylist"> Copyright © 2000 <a href="http://www.4-am.com">4AM 
+    <td align="center" bgcolor="#FFFFFF" class="bodylist"> Copyright Â© 2000 <a href="http://www.4-am.com">4AM
       Productions, Inc.</a>. All rights reserved. <br>
       Questions or problems should be directed to <a href="mailto:webmaster@teamzonline.com"> 
       the webmaster</a>, 254-412-0846. </td>

--- a/src/Products/PageTemplates/tests/testZopePageTemplate.py
+++ b/src/Products/PageTemplates/tests/testZopePageTemplate.py
@@ -378,7 +378,8 @@ class ZPTRegressions(unittest.TestCase):
 
     def testAddWithoutParams(self):
         pt = self._addPT('pt1')
-        default_text = open(pt._default_content_fn).read()
+        with open(pt._default_content_fn) as fd:
+            default_text = fd.read()
         self.assertEqual(pt.title, '')
         self.assertEqual(pt.document_src().strip(), default_text.strip())
 

--- a/src/Products/PageTemplates/tests/test_engine.py
+++ b/src/Products/PageTemplates/tests/test_engine.py
@@ -19,11 +19,15 @@ class TestPatches(Sandboxed, ZopeTestCase):
         template = PageTemplate()
 
         # test rendering engine
-        template.write(open(os.path.join(path, "simple.pt")).read())
+        with open(os.path.join(path, "simple.pt")) as fd:
+            data = fd.read()
+        template.write(data)
         self.assertTrue('world' in template())
 
         # test arguments
-        template.write(open(os.path.join(path, "options.pt")).read())
+        with open(os.path.join(path, "options.pt")) as fd:
+            data = fd.read()
+        template.write(data)
         self.assertTrue('Hello world' in template(greeting='Hello world'))
 
     def test_pagetemplatefile(self):
@@ -51,11 +55,15 @@ class TestPatches(Sandboxed, ZopeTestCase):
         template = template.__of__(self.folder)
 
         # test rendering engine
-        template.write(open(os.path.join(path, "simple.pt")).read())
+        with open(os.path.join(path, "simple.pt")) as fd:
+            data = fd.read()
+        template.write(data)
         self.assertTrue('world' in template())
 
         # test arguments
-        template.write(open(os.path.join(path, "options.pt")).read())
+        with open(os.path.join(path, "options.pt")) as fd:
+            data = fd.read()
+        template.write(data)
         self.assertTrue('Hello world' in template(
             greeting='Hello world'))
 
@@ -72,7 +80,9 @@ class TestPatches(Sandboxed, ZopeTestCase):
         template = template.__of__(self.folder)
 
         # test rendering engine
-        template.write(open(os.path.join(path, "pi.pt")).read())
+        with open(os.path.join(path, "pi.pt")) as fd:
+            data = fd.read()
+        template.write(data)
         self.assertIn('world', template())
 
 

--- a/src/Testing/ZopeTestCase/ZopeLite.py
+++ b/src/Testing/ZopeTestCase/ZopeLite.py
@@ -28,6 +28,7 @@ import sys
 import time
 
 from six import exec_
+from six import PY2
 
 from Testing.ZopeTestCase import layer
 
@@ -35,7 +36,8 @@ from Testing.ZopeTestCase import layer
 os.environ['ZOPETESTCASE'] = '1'
 
 # Increase performance on MP hardware
-sys.setcheckinterval(2500)
+if PY2:
+    sys.setcheckinterval(2500)
 
 # Always shut up
 _quiet = True

--- a/src/ZTUtils/Zope.py
+++ b/src/ZTUtils/Zope.py
@@ -19,6 +19,7 @@ from AccessControl import getSecurityManager
 from AccessControl.unauthorized import Unauthorized
 from AccessControl.ZopeGuards import guarded_getitem
 from DateTime.DateTime import DateTime
+from six import text_type
 from six.moves.urllib.parse import quote, unquote
 
 from ZTUtils.Batch import Batch
@@ -204,7 +205,7 @@ def make_query(*args, **kwargs):
     qlist = complex_marshal(list(d.items()))
     for i in range(len(qlist)):
         k, m, v = qlist[i]
-        if isinstance(v, unicode):
+        if isinstance(v, text_type):
             v = v.encode(_default_encoding())
         qlist[i] = '%s%s=%s' % (quote(k), m, quote(str(v)))
 
@@ -293,7 +294,7 @@ def complex_marshal(pairs):
 def simple_marshal(v):
     if isinstance(v, str):
         return ''
-    if isinstance(v, unicode):
+    if isinstance(v, text_type):
         encoding = _default_encoding()
         return ':%s:ustring' % (encoding,)
     if isinstance(v, bool):

--- a/src/Zope2/Startup/starter.py
+++ b/src/Zope2/Startup/starter.py
@@ -17,6 +17,7 @@ import sys
 import re
 from socket import gethostbyaddr
 
+from six import PY2
 from ZConfig import ConfigurationError
 from zope.event import notify
 from zope.processlifetime import ProcessStarting
@@ -45,7 +46,9 @@ class WSGIStarter(object):
 
     def setupInterpreter(self):
         # make changes to the python interpreter environment
-        sys.setcheckinterval(self.cfg.python_check_interval)
+        if PY2:
+            # Check interval is gone in supported Python 3 versions.
+            sys.setcheckinterval(self.cfg.python_check_interval)
 
     def setupLocale(self):
         # set a locale if one has been specified in the config

--- a/src/Zope2/Startup/tests/test_starter.py
+++ b/src/Zope2/Startup/tests/test_starter.py
@@ -91,6 +91,7 @@ class WSGIStarterTestCase(unittest.TestCase):
             # reset to system-defined locale
             locale.setlocale(locale.LC_ALL, '')
 
+    @unittest.skipUnless(six.PY2, 'Python 2 specfiic checkinterval test.')
     def testConfigureInterpreter(self):
         oldcheckinterval = sys.getcheckinterval()
         newcheckinterval = oldcheckinterval + 1


### PR DESCRIPTION
Special call out to `bytes(3)`, which produces `'3'` in Python 2 and `b'\x00\x00\x00'` in Python 3. I also like Python 3.5 and bringing back % formatting for bytes :(

This fixes another round of test failures. Logging in via basic auth is still broken, and request/response issues around headers and the body being str/bytes.

Python 3.4: 1118 tests, 45 failures, 36 errors and 1 skipped in 8.470 seconds.