### PR TITLE
More Python 3 fixes.

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -20,6 +20,7 @@ parts =
     requirements
 sources-dir = develop
 auto-checkout =
+    AccessControl
     DocumentTemplate
     Products.BTreeFolder2
     Products.MailHost

--- a/src/App/Undo.py
+++ b/src/App/Undo.py
@@ -125,12 +125,12 @@ InitializeClass(UndoSupport)
 
 def encode64(s, b2a=binascii.b2a_base64):
     if len(s) < 58:
-        return b2a(s)
+        return b2a(s).decode('ascii')
     r = []
     a = r.append
     for i in range(0, len(s), 57):
         a(b2a(s[i:i + 57])[:-1])
-    return ''.join(r)
+    return (b''.join(r)).decode('ascii')
 
 
 def decode64(s, a2b=binascii.a2b_base64):

--- a/src/App/dtml/undo.dtml
+++ b/src/App/dtml/undo.dtml
@@ -19,7 +19,7 @@ modified objects that were modified by a selected transaction.
 </p>
 
 <dtml-unless first_transaction>
-<dtml-call "REQUEST.set('first_transaction', _.None)">
+<dtml-call "REQUEST.set('first_transaction', None)">
 </dtml-unless>
 
 <table width="100%" cellspacing="0" cellpadding="2" border="0">

--- a/src/OFS/DTMLDocument.py
+++ b/src/OFS/DTMLDocument.py
@@ -126,7 +126,7 @@ class DTMLDocument(PropertyManager, DTMLMethod):
 InitializeClass(DTMLDocument)
 
 
-default_dd_html = b"""\
+default_dd_html = """\
 <!DOCTYPE html>
 <html>
   <head>
@@ -144,11 +144,11 @@ default_dd_html = b"""\
 addForm = DTMLFile('dtml/documentAdd', globals())
 
 
-def addDTMLDocument(self, id, title='', file=b'', REQUEST=None, submit=None):
+def addDTMLDocument(self, id, title='', file='', REQUEST=None, submit=None):
     """Add a DTML Document object with the contents of file. If
     'file' is empty, default document text is used.
     """
-    if not isinstance(file, binary_type):
+    if hasattr(file, 'read'):
         file = file.read()
     if not file:
         file = default_dd_html

--- a/src/OFS/DTMLMethod.py
+++ b/src/OFS/DTMLMethod.py
@@ -387,7 +387,7 @@ def decapitate(html, RESPONSE=None):
     return html[spos + eolen:]
 
 
-default_dm_html = b"""\
+default_dm_html = """\
 <!DOCTYPE html>
 <html>
   <head>
@@ -406,11 +406,11 @@ default_dm_html = b"""\
 addForm = DTMLFile('dtml/methodAdd', globals())
 
 
-def addDTMLMethod(self, id, title='', file=b'', REQUEST=None, submit=None):
+def addDTMLMethod(self, id, title='', file='', REQUEST=None, submit=None):
     """Add a DTML Method object with the contents of file. If
     'file' is empty, default document text is used.
     """
-    if not isinstance(file, binary_type):
+    if hasattr(file, 'read'):
         file = file.read()
     if not file:
         file = default_dm_html

--- a/src/OFS/dtml/findResult.dtml
+++ b/src/OFS/dtml/findResult.dtml
@@ -3,7 +3,7 @@
 
 <dtml-in expr="('obj_ids', 'obj_metatypes', 'obj_searchterm', 'obj_expr', 'obj_mtime', 'obj_mspec', 'obj_permission', 'obj_roles', 'search_sub')">
 <dtml-else expr="_.hasattr(REQUEST, _['sequence-item'])">
-<dtml-call expr="REQUEST.set(_['sequence-item'], _.None)">
+<dtml-call expr="REQUEST.set(_['sequence-item'], None)">
 </dtml-else>
 </dtml-in>
 

--- a/src/Testing/ZopeTestCase/testFunctional.py
+++ b/src/Testing/ZopeTestCase/testFunctional.py
@@ -27,10 +27,10 @@ from Testing import ZopeTestCase
 from Testing.ZopeTestCase import user_name
 from Testing.ZopeTestCase import user_password
 
-SET_COOKIE_DTML = b'''\
+SET_COOKIE_DTML = '''\
 <dtml-call "RESPONSE.setCookie('foo', 'Bar', path='/')">'''
 
-CHANGE_TITLE_DTML = b'''\
+CHANGE_TITLE_DTML = '''\
 <dtml-call "manage_changeProperties(title=REQUEST.get('title'))">'''
 
 
@@ -41,17 +41,17 @@ class TestFunctional(ZopeTestCase.FunctionalTestCase):
         self.basic_auth = '%s:%s' % (user_name, user_password)
 
         # A simple document
-        self.folder.addDTMLDocument('index_html', file=b'index')
+        self.folder.addDTMLDocument('index_html', file='index')
 
         # A document accessible only to its owner
-        self.folder.addDTMLDocument('secret_html', file=b'secret')
+        self.folder.addDTMLDocument('secret_html', file='secret')
         self.folder.secret_html.manage_permission(view, ['Owner'])
 
         # A method redirecting to the Zope root
-        url = self.app.absolute_url().encode('utf-8')
+        url = self.app.absolute_url()
         self.folder.addDTMLMethod(
             'redirect',
-            file=b'<dtml-call "RESPONSE.redirect(\'' + url + b'\')">')
+            file='<dtml-call "RESPONSE.redirect(\'' + url + '\')">')
 
         # A method setting a cookie
         self.folder.addDTMLMethod('set_cookie', file=SET_COOKIE_DTML)

--- a/src/Testing/ZopeTestCase/zopedoctest/testFunctionalDocTest.py
+++ b/src/Testing/ZopeTestCase/zopedoctest/testFunctionalDocTest.py
@@ -88,7 +88,7 @@ class HTTPHeaderOutputTests(unittest.TestCase):
                          'Content-Type: text/html')
 
 
-SHOW_COOKIES_DTML = b'''\
+SHOW_COOKIES_DTML = '''\
 <dtml-in "REQUEST.cookies.keys()">
 <dtml-var sequence-item>: <dtml-var "REQUEST.cookies[_['sequence-item']]">
 </dtml-in>'''
@@ -113,7 +113,7 @@ def setUp(self):
     from Testing.ZopeTestCase.testFunctional import CHANGE_TITLE_DTML
     from Testing.ZopeTestCase.testFunctional import SET_COOKIE_DTML
 
-    self.folder.addDTMLDocument('index_html', file=b'index')
+    self.folder.addDTMLDocument('index_html', file='index')
     self.folder.addDTMLMethod('change_title', file=CHANGE_TITLE_DTML)
     self.folder.addDTMLMethod('set_cookie', file=SET_COOKIE_DTML)
     self.folder.addDTMLMethod('show_cookies', file=SHOW_COOKIES_DTML)

--- a/src/Zope2/utilities/mkwsgiinstance.py
+++ b/src/Zope2/utilities/mkwsgiinstance.py
@@ -188,10 +188,14 @@ def get_inituser():
 def write_inituser(fn, user, password):
     import binascii
     from hashlib import sha1 as sha
-    fp = open(fn, "w")
     pw = binascii.b2a_base64(sha(password.encode('utf-8')).digest())[:-1]
-    fp.write('%s:{SHA}%s\n' % (user, pw))
-    fp.close()
+    with open(fn, "wb") as fp:
+        fp.write(
+            user.encode('utf-8') +
+            b':{SHA}' +
+            pw +
+            b'\n'
+        )
     os.chmod(fn, 0o644)
 
 


### PR DESCRIPTION
You can now create an instance, log in and browse some of the ZMI via:
```
python 3.4 bootstrap.py
bin/buildout
bin/mkwsgiinstance -d . -u 'admin:admin'
bin/runwsgi etc/zope.ini -v
```

It can help to change the `etc/zope.ini` and inside the `logger_root` section, change `level = WARN` to `level = DEBUG`. To get pdb prompts, one can either remove the `egg:Zope2#httpexceptions` entry from the `zope.ini` `pipeline` section or add a `raise` in `ZPublisher.httpexceptions` in the blanket `except Exception as exc` case.

Adding DTML doc / methods works. Adding Page Templates fails as the old style class `HTTPRequest.FileUpload` is not yet ported.

I've also come to realize that the source code of DTML documents and Page Templates should be text, rather than bytes. Same for their rendered results. Only when they get to the HTTP response, they should be encoded according to the response charset.

Python 3.4: Total: 1118 tests, 45 failures, 35 errors and 1 skipped in 5.635 seconds.