### PR TITLE
More Python 3 fixes

### DIFF
--- a/src/App/Management.py
+++ b/src/App/Management.py
@@ -89,17 +89,17 @@ class Tabs(Base):
         script = REQUEST['BASEPATH1']
         linkpat = '<a href="%s/manage_workspace">%s</a>'
         out = []
-        url = linkpat % (escape(script, 1), '&nbsp;/')
+        url = linkpat % (escape(script, True), '&nbsp;/')
         if not steps:
             return url
         last = steps.pop()
         for step in steps:
             script = '%s/%s' % (script, step)
-            out.append(linkpat % (escape(script, 1), escape(unquote(step))))
+            out.append(linkpat % (escape(script, True), escape(unquote(step))))
         script = '%s/%s' % (script, last)
         out.append(
             '<a class="strong-link" href="%s/manage_workspace">%s</a>' %
-            (escape(script, 1), escape(unquote(last))))
+            (escape(script, True), escape(unquote(last), False)))
         return '%s%s' % (url, '/'.join(out))
 
     def tabs_path_info(self, script, path):

--- a/src/App/tests/testImageFile.py
+++ b/src/App/tests/testImageFile.py
@@ -64,6 +64,6 @@ class TestImageFileFunctional(unittest.TestCase):
         image = App.ImageFile.ImageFile(path)
         result = image.index_html(request, response)
         self.assertEqual(stdout.getvalue(), b'')
-        self.assertTrue(isinstance(result, io.FileIO))
+        self.assertIsInstance(result, io.FileIO)
         self.assertTrue(b''.join(result).startswith(b'\x89PNG\r\n'))
         self.assertEqual(len(result), image.size)

--- a/src/App/tests/test_ApplicationManager.py
+++ b/src/App/tests/test_ApplicationManager.py
@@ -125,11 +125,11 @@ class DatabaseChooserTests(ConfigTestBase, unittest.TestCase):
         root = self._makeRoot()
         dc = self._makeOne().__of__(root)
         found = dc['foo']
-        self.assertTrue(isinstance(found, AltDatabaseManager))
+        self.assertIsInstance(found, AltDatabaseManager)
         self.assertEqual(found.id, 'foo')
         self.assertTrue(found.__parent__ is dc)
         conn = found._p_jar
-        self.assertTrue(isinstance(conn, FakeConnection))
+        self.assertIsInstance(conn, FakeConnection)
         self.assertTrue(conn.db() is foo)
 
     def test___bobo_traverse___miss(self):
@@ -148,11 +148,11 @@ class DatabaseChooserTests(ConfigTestBase, unittest.TestCase):
         root = self._makeRoot()
         dc = self._makeOne().__of__(root)
         found = dc.__bobo_traverse__(None, 'foo')
-        self.assertTrue(isinstance(found, AltDatabaseManager))
+        self.assertIsInstance(found, AltDatabaseManager)
         self.assertEqual(found.id, 'foo')
         self.assertTrue(found.__parent__ is dc)
         conn = found._p_jar
-        self.assertTrue(isinstance(conn, FakeConnection))
+        self.assertIsInstance(conn, FakeConnection)
         self.assertTrue(conn.db() is foo)
 
     def test___bobo_traverse___miss_db_hit_attr(self):

--- a/src/OFS/DTMLDocument.py
+++ b/src/OFS/DTMLDocument.py
@@ -115,7 +115,7 @@ class DTMLDocument(PropertyManager, DTMLMethod):
             if 'content_type' in self.__dict__:
                 c = self.content_type
             else:
-                c, e = guess_content_type(self.__name__, r)
+                c, e = guess_content_type(self.__name__, r.encode('utf-8'))
             RESPONSE.setHeader('Content-Type', c)
         result = decapitate(r, RESPONSE)
         if not self._cache_namespace_keys:

--- a/src/OFS/DTMLMethod.py
+++ b/src/OFS/DTMLMethod.py
@@ -142,7 +142,7 @@ class DTMLMethod(RestrictedDTML,
                 return result
 
             r = HTML.__call__(self, client, REQUEST, **kw)
-            if RESPONSE is None or not isinstance(r, binary_type):
+            if RESPONSE is None or not isinstance(r, str):
                 if not self._cache_namespace_keys:
                     self.ZCacheable_set(r)
                 return r
@@ -157,7 +157,7 @@ class DTMLMethod(RestrictedDTML,
             if 'content_type' in self.__dict__:
                 c = self.content_type
             else:
-                c, e = guess_content_type(self.getId(), r)
+                c, e = guess_content_type(self.getId(), r.encode('utf-8'))
             RESPONSE.setHeader('Content-Type', c)
         result = decapitate(r, RESPONSE)
         if not self._cache_namespace_keys:

--- a/src/OFS/Image.py
+++ b/src/OFS/Image.py
@@ -910,11 +910,11 @@ class Image(File):
 
         if alt is None:
             alt = getattr(self, 'alt', '')
-        result = '%s alt="%s"' % (result, escape(alt, 1))
+        result = '%s alt="%s"' % (result, escape(alt, True))
 
         if title is None:
             title = getattr(self, 'title', '')
-        result = '%s title="%s"' % (result, escape(title, 1))
+        result = '%s title="%s"' % (result, escape(title, True))
 
         if height:
             result = '%s height="%s"' % (result, height)

--- a/src/OFS/ObjectManager.py
+++ b/src/OFS/ObjectManager.py
@@ -94,11 +94,12 @@ def checkValidId(self, id, allow_dup=0):
     # set to false before the object is added.
     if not id or not isinstance(id, str):
         if isinstance(id, text_type):
-            id = escape(id)
+            id = escape(id, True)
         raise BadRequest('Empty or invalid id specified', id)
     if bad_id(id) is not None:
         raise BadRequest(
-            'The id "%s" contains characters illegal in URLs.' % escape(id))
+            ('The id "%s" contains characters '
+             'illegal in URLs.' % escape(id, True)))
     if id in ('.', '..'):
         raise BadRequest(
             'The id "%s" is invalid because it is not traversable.' % id)
@@ -541,7 +542,7 @@ class ObjectManager(CopyContainer,
                     'Object "%s" is locked.' % v.getId())
 
             if v is self:
-                raise BadRequest('%s does not exist' % escape(ids[-1]))
+                raise BadRequest('%s does not exist' % escape(ids[-1], True))
             self._delObject(id)
             del ids[-1]
         if REQUEST is not None:
@@ -615,14 +616,14 @@ class ObjectManager(CopyContainer,
         """Import an object from a file"""
         dirname, file = os.path.split(file)
         if dirname:
-            raise BadRequest('Invalid file name %s' % escape(file))
+            raise BadRequest('Invalid file name %s' % escape(file, True))
 
         for impath in self._getImportPaths():
             filepath = os.path.join(impath, 'import', file)
             if os.path.exists(filepath):
                 break
         else:
-            raise BadRequest('File does not exist: %s' % escape(file))
+            raise BadRequest('File does not exist: %s' % escape(file, True))
 
         imported = self._importObjectFromFile(
             filepath, verify=bool(REQUEST), set_owner=set_owner)

--- a/src/OFS/PropertyManager.py
+++ b/src/OFS/PropertyManager.py
@@ -124,8 +124,10 @@ class PropertyManager(Base):
 
     security.declareProtected(access_contents_information, 'valid_property_id')
     def valid_property_id(self, id):
-        if not id or id[:1] == '_' or (id[:3] == 'aq_') \
-           or (' ' in id) or hasattr(aq_base(self), id) or escape(id) != id:
+        if (not id or id[:1] == '_' or (id[:3] == 'aq_') or
+                (' ' in id) or
+                hasattr(aq_base(self), id) or
+                escape(id, True) != id):
             return 0
         return 1
 
@@ -202,7 +204,8 @@ class PropertyManager(Base):
         # the value to the type of the existing property.
         self._wrapperCheck(value)
         if not self.hasProperty(id):
-            raise BadRequest('The property %s does not exist' % escape(id))
+            raise BadRequest(
+                'The property %s does not exist' % escape(id, True))
         if isinstance(value, str):
             proptype = self.getPropertyType(id) or 'string'
             if proptype in type_converters:
@@ -211,7 +214,8 @@ class PropertyManager(Base):
 
     def _delProperty(self, id):
         if not self.hasProperty(id):
-            raise ValueError('The property %s does not exist' % escape(id))
+            raise ValueError(
+                'The property %s does not exist' % escape(id, True))
         self._delPropValue(id)
         self._properties = tuple(i for i in self._properties if i['id'] != id)
 
@@ -326,8 +330,10 @@ class PropertyManager(Base):
         for name, value in props.items():
             if self.hasProperty(name):
                 if 'w' not in propdict[name].get('mode', 'wd'):
-                    raise BadRequest('%s cannot be changed' % escape(name))
+                    raise BadRequest(
+                        '%s cannot be changed' % escape(name, True))
                 self._updateProperty(name, value)
+
         if REQUEST:
             message = "Saved changes."
             return self.manage_propertiesForm(self, REQUEST,
@@ -367,7 +373,8 @@ class PropertyManager(Base):
         for id in ids:
             if not hasattr(aq_base(self), id):
                 raise BadRequest(
-                    'The property <em>%s</em> does not exist' % escape(id))
+                    ('The property <em>%s</em> '
+                     'does not exist' % escape(id, True)))
             if ('d' not in propdict[id].get('mode', 'wd')) or (id in nd):
                 raise BadRequest('Cannot delete %s' % id)
             self._delProperty(id)

--- a/src/OFS/PropertySheets.py
+++ b/src/OFS/PropertySheets.py
@@ -163,7 +163,7 @@ class PropertySheet(Traversable, Persistent, Implicit, DAVPropertySheetMixin):
 
     def valid_property_id(self, id):
         if not id or id[:1] == '_' or (id[:3] == 'aq_') \
-           or (' ' in id) or escape(id) != id:
+           or (' ' in id) or escape(id, True) != id:
             return 0
         return 1
 
@@ -205,7 +205,7 @@ class PropertySheet(Traversable, Persistent, Implicit, DAVPropertySheetMixin):
         # systems.
         self._wrapperCheck(value)
         if not self.valid_property_id(id):
-            raise BadRequest('Invalid property id, %s.' % escape(id))
+            raise BadRequest('Invalid property id, %s.' % escape(id, True))
 
         if not self.property_extensible_schema__():
             raise BadRequest(
@@ -216,7 +216,7 @@ class PropertySheet(Traversable, Persistent, Implicit, DAVPropertySheetMixin):
             if not (id == 'title' and id not in self.__dict__):
                 raise BadRequest(
                     'Invalid property id, <em>%s</em>. It is in use.' %
-                    escape(id))
+                    escape(id, True))
         if meta is None:
             meta = {}
         prop = {'id': id, 'type': type, 'meta': meta}
@@ -243,10 +243,11 @@ class PropertySheet(Traversable, Persistent, Implicit, DAVPropertySheetMixin):
         # it will used to _replace_ the properties meta data.
         self._wrapperCheck(value)
         if not self.hasProperty(id):
-            raise BadRequest('The property %s does not exist.' % escape(id))
+            raise BadRequest('The property %s does not exist.' %
+                             escape(id, True))
         propinfo = self.propertyInfo(id)
         if 'w' not in propinfo.get('mode', 'wd'):
-            raise BadRequest('%s cannot be changed.' % escape(id))
+            raise BadRequest('%s cannot be changed.' % escape(id, True))
         if isinstance(value, str):
             proptype = propinfo.get('type', 'string')
             if proptype in type_converters:
@@ -268,14 +269,15 @@ class PropertySheet(Traversable, Persistent, Implicit, DAVPropertySheetMixin):
         # Delete the property with the given id. If a property with the
         # given id does not exist, a ValueError is raised.
         if not self.hasProperty(id):
-            raise BadRequest('The property %s does not exist.' % escape(id))
+            raise BadRequest('The property %s does not exist.' %
+                             escape(id, True))
         vself = self.v_self()
         if hasattr(vself, '_reserved_names'):
             nd = vself._reserved_names
         else:
             nd = ()
         if ('d' not in self.propertyInfo(id).get('mode', 'wd')) or (id in nd):
-            raise BadRequest('%s cannot be deleted.' % escape(id))
+            raise BadRequest('%s cannot be deleted.' % escape(id, True))
         delattr(vself, id)
         pself = self.p_self()
         pself._properties = tuple(
@@ -303,7 +305,7 @@ class PropertySheet(Traversable, Persistent, Implicit, DAVPropertySheetMixin):
         for p in self._propertyMap():
             if p['id'] == id:
                 return p
-        raise ValueError('The property %s does not exist.' % escape(id))
+        raise ValueError('The property %s does not exist.' % escape(id, True))
 
     def _propertyMap(self):
         # Return a tuple of mappings, giving meta-data for properties.
@@ -366,7 +368,8 @@ class PropertySheet(Traversable, Persistent, Implicit, DAVPropertySheetMixin):
         for name, value in props.items():
             if self.hasProperty(name):
                 if 'w' not in propdict[name].get('mode', 'wd'):
-                    raise BadRequest('%s cannot be changed' % escape(name))
+                    raise BadRequest('%s cannot be changed' %
+                                     escape(name, True))
                 self._updateProperty(name, value)
         message = 'Your changes have been saved.'
         return self.manage(self, REQUEST, manage_tabs_message=message)

--- a/src/OFS/Uninstalled.py
+++ b/src/OFS/Uninstalled.py
@@ -48,7 +48,7 @@ class BrokenClass(ZODB_Broken, Explicit, Item, Overridable):
     def __getattr__(self, name):
         if name[:3] == '_p_':
             return BrokenClass.inheritedAttribute('__getattr__')(self, name)
-        raise AttributeError(escape(name))
+        raise AttributeError(escape(name, True))
 
     manage = DTMLFile('dtml/brokenEdit', globals())
     manage_main = DTMLFile('dtml/brokenEdit', globals())

--- a/src/OFS/role.py
+++ b/src/OFS/role.py
@@ -126,7 +126,7 @@ class RoleManager(BaseRoleManager):
 
         if fails:
             raise BadRequest('Some permissions had errors: ' +
-                             escape(', '.join(fails)))
+                             escape(', '.join(fails), True))
         if REQUEST is not None:
             return self.manage_access(REQUEST)
 

--- a/src/OFS/tests/testApplication.py
+++ b/src/OFS/tests/testApplication.py
@@ -108,7 +108,7 @@ class ApplicationTests(unittest.TestCase):
 
         result = app.__bobo_traverse__(request, 'OTHER')
 
-        self.assertTrue(isinstance(result, NullResource))
+        self.assertIsInstance(result, NullResource)
         self.assertTrue(aq_parent(aq_inner(result)) is app)
 
 

--- a/src/OFS/tests/testFileAndImage.py
+++ b/src/OFS/tests/testFileAndImage.py
@@ -188,7 +188,7 @@ class FileTests(unittest.TestCase):
     def testReadData(self):
         s = b'a' * (2 << 16)
         data, size = self.file._read_data(BytesIO(s))
-        self.assertTrue(isinstance(data, Pdata))
+        self.assertIsInstance(data, Pdata)
         self.assertEqual(bytes(data), s)
         self.assertEqual(len(s), len(bytes(data)))
         self.assertEqual(len(s), size)

--- a/src/OFS/tests/testObjectManager.py
+++ b/src/OFS/tests/testObjectManager.py
@@ -495,7 +495,7 @@ class ObjectManagerTests(PlacelessSetup, unittest.TestCase):
         # This must work whether we've done "make instance" or not.
         # So list_imports() may return an empty list, or whatever's
         # in skel/import. Tolerate both cases.
-        self.assertTrue(isinstance(om.list_imports(), list))
+        self.assertIsInstance(om.list_imports(), list)
         for filename in om.list_imports():
             self.assertTrue(filename.endswith('.zexp') or
                             filename.endswith('.xml'))

--- a/src/OFS/tests/testProperties.py
+++ b/src/OFS/tests/testProperties.py
@@ -36,20 +36,20 @@ class TestPropertyManager(unittest.TestCase):
         inst = self._makeOne()
 
         inst._setProperty('prop', ['xxx', 'yyy'], 'lines')
-        self.assertTrue(isinstance(inst.getProperty('prop'), tuple))
-        self.assertTrue(isinstance(inst.prop, tuple))
+        self.assertIsInstance(inst.getProperty('prop'), tuple)
+        self.assertIsInstance(inst.prop, tuple)
 
         inst._setPropValue('prop', ['xxx', 'yyy'])
-        self.assertTrue(isinstance(inst.getProperty('prop'), tuple))
-        self.assertTrue(isinstance(inst.prop, tuple))
+        self.assertIsInstance(inst.getProperty('prop'), tuple)
+        self.assertIsInstance(inst.prop, tuple)
 
         inst._updateProperty('prop', ['xxx', 'yyy'])
-        self.assertTrue(isinstance(inst.getProperty('prop'), tuple))
-        self.assertTrue(isinstance(inst.prop, tuple))
+        self.assertIsInstance(inst.getProperty('prop'), tuple)
+        self.assertIsInstance(inst.prop, tuple)
 
         inst.manage_addProperty('prop2', ['xxx', 'yyy'], 'lines')
-        self.assertTrue(isinstance(inst.getProperty('prop2'), tuple))
-        self.assertTrue(isinstance(inst.prop2, tuple))
+        self.assertIsInstance(inst.getProperty('prop2'), tuple)
+        self.assertIsInstance(inst.prop2, tuple)
 
     def test_propertyLabel_no_label_falls_back_to_id(self):
         class NoLabel(self._getTargetClass()):
@@ -96,13 +96,13 @@ class TestPropertySheet(unittest.TestCase):
         inst = self._makeOne('foo')
 
         inst._setProperty('prop', ['xxx', 'yyy'], 'lines')
-        self.assertTrue(isinstance(inst.getProperty('prop'), tuple))
-        self.assertTrue(isinstance(inst.prop, tuple))
+        self.assertIsInstance(inst.getProperty('prop'), tuple)
+        self.assertIsInstance(inst.prop, tuple)
 
         inst._updateProperty('prop', ['xxx', 'yyy'])
-        self.assertTrue(isinstance(inst.getProperty('prop'), tuple))
-        self.assertTrue(isinstance(inst.prop, tuple))
+        self.assertIsInstance(inst.getProperty('prop'), tuple)
+        self.assertIsInstance(inst.prop, tuple)
 
         inst.manage_addProperty('prop2', ['xxx', 'yyy'], 'lines')
-        self.assertTrue(isinstance(inst.getProperty('prop2'), tuple))
-        self.assertTrue(isinstance(inst.prop2, tuple))
+        self.assertIsInstance(inst.getProperty('prop2'), tuple)
+        self.assertIsInstance(inst.prop2, tuple)

--- a/src/OFS/tests/testSimpleItem.py
+++ b/src/OFS/tests/testSimpleItem.py
@@ -34,7 +34,7 @@ class TestItem(unittest.TestCase):
         try:
             item.raise_standardErrorMessage(
                 error_type=OverflowError,
-                error_value='simple',
+                error_value=OverflowError('simple'),
                 REQUEST=REQUEST(),
             )
         except Exception:
@@ -58,7 +58,7 @@ class TestItem(unittest.TestCase):
         try:
             item.raise_standardErrorMessage(
                 error_type=OverflowError,
-                error_value=TaintedString('<simple>'),
+                error_value=OverflowError(TaintedString('<simple>')),
                 REQUEST=REQUEST(),
             )
         except Exception:

--- a/src/OFS/tests/test_DTMLDocument.py
+++ b/src/OFS/tests/test_DTMLDocument.py
@@ -26,8 +26,8 @@ class FactoryTests(unittest.TestCase):
         addDTMLDocument(dispatcher, 'id')
         method = dispatcher._set['id']
         self.assertTrue(isinstance(method, DTMLDocument))
-        self.assertFalse(b'standard_html_header' in method.read())
-        self.assertFalse(b'standard_html_footer' in method.read())
+        self.assertFalse('standard_html_header' in method.read())
+        self.assertFalse('standard_html_footer' in method.read())
 
 
 class DummyDispatcher:

--- a/src/OFS/tests/test_DTMLDocument.py
+++ b/src/OFS/tests/test_DTMLDocument.py
@@ -25,7 +25,7 @@ class FactoryTests(unittest.TestCase):
         dispatcher = DummyDispatcher()
         addDTMLDocument(dispatcher, 'id')
         method = dispatcher._set['id']
-        self.assertTrue(isinstance(method, DTMLDocument))
+        self.assertIsInstance(method, DTMLDocument)
         self.assertFalse('standard_html_header' in method.read())
         self.assertFalse('standard_html_footer' in method.read())
 

--- a/src/OFS/tests/test_DTMLMethod.py
+++ b/src/OFS/tests/test_DTMLMethod.py
@@ -18,7 +18,7 @@ class DTMLMethodTests(unittest.TestCase):
     def test_edit_taintedstring(self):
         from AccessControl.tainted import TaintedString
         doc = self._makeOne()
-        self.assertEqual(doc.read(), b'')
+        self.assertEqual(doc.read(), '')
         data = TaintedString('hello<br/>')
 
         doc.manage_edit(data, 'title')
@@ -35,8 +35,8 @@ class FactoryTests(unittest.TestCase):
         addDTMLMethod(dispatcher, 'id')
         method = dispatcher._set['id']
         self.assertTrue(isinstance(method, DTMLMethod))
-        self.assertFalse(b'standard_html_header' in method.read())
-        self.assertFalse(b'standard_html_footer' in method.read())
+        self.assertFalse('standard_html_header' in method.read())
+        self.assertFalse('standard_html_footer' in method.read())
 
 
 class DummyDispatcher:

--- a/src/OFS/tests/test_DTMLMethod.py
+++ b/src/OFS/tests/test_DTMLMethod.py
@@ -34,7 +34,7 @@ class FactoryTests(unittest.TestCase):
         dispatcher = DummyDispatcher()
         addDTMLMethod(dispatcher, 'id')
         method = dispatcher._set['id']
-        self.assertTrue(isinstance(method, DTMLMethod))
+        self.assertIsInstance(method, DTMLMethod)
         self.assertFalse('standard_html_header' in method.read())
         self.assertFalse('standard_html_footer' in method.read())
 

--- a/src/OFS/tests/test_Uninstalled.py
+++ b/src/OFS/tests/test_Uninstalled.py
@@ -74,7 +74,7 @@ class TestsOfBroken(unittest.TestCase):
 
         inst = Broken(self, OID, ('Products.MyProduct.MyClass', 'MyClass'))
 
-        self.assertTrue(isinstance(inst, BrokenClass))
+        self.assertIsInstance(inst, BrokenClass)
         self.assertTrue(inst._p_jar is self)
         self.assertEqual(inst._p_oid, OID)
 
@@ -127,7 +127,7 @@ class TestsIntegratedBroken(base.TestCase):
         # get new connection that will give access to broken object
         app = base.app()
         inst = aq_base(app.tr)
-        self.assertTrue(isinstance(inst, BrokenClass))
+        self.assertIsInstance(inst, BrokenClass)
         state = inst.__getstate__()
         self.assertEqual(state, {'id': 'tr'})
 

--- a/src/OFS/tests/test_subscribers.py
+++ b/src/OFS/tests/test_subscribers.py
@@ -13,9 +13,10 @@
 ##############################################################################
 
 
-import io
 import logging
 import unittest
+
+from six import StringIO
 
 
 class TestMaybeWarnDeprecated(unittest.TestCase):
@@ -31,7 +32,7 @@ class TestMaybeWarnDeprecated(unittest.TestCase):
         # deprecatedManageAddDeleteClasses list is special cased
         self.deprecatedManageAddDeleteClasses.append(int)
         # Pick up log messages
-        self.logfile = io.BytesIO()
+        self.logfile = StringIO()
         self.log_handler = logging.StreamHandler(self.logfile)
         logging.root.addHandler(self.log_handler)
         self.old_log_level = logging.root.level
@@ -53,14 +54,14 @@ class TestMaybeWarnDeprecated(unittest.TestCase):
             def manage_afterAdd(self):
                 pass
             manage_afterAdd.__five_method__ = True
-        self.assertLog(Deprecated, b'')
+        self.assertLog(Deprecated, '')
 
     def test_class_deprecated(self):
         class Deprecated(object):
             def manage_afterAdd(self):
                 pass
         self.deprecatedManageAddDeleteClasses.append(Deprecated)
-        self.assertLog(Deprecated, b'')
+        self.assertLog(Deprecated, '')
 
     def test_subclass_deprecated(self):
         class Deprecated(object):
@@ -71,7 +72,7 @@ class TestMaybeWarnDeprecated(unittest.TestCase):
             pass
 
         self.deprecatedManageAddDeleteClasses.append(Deprecated)
-        self.assertLog(ASubClass, b'')
+        self.assertLog(ASubClass, '')
 
     def test_not_deprecated(self):
         class Deprecated(object):
@@ -79,12 +80,12 @@ class TestMaybeWarnDeprecated(unittest.TestCase):
                 pass
         self.assertLog(
             Deprecated,
-            b'OFS.tests.test_subscribers.Deprecated.manage_afterAdd is '
-            b'discouraged. You should use event subscribers instead.\n')
+            'OFS.tests.test_subscribers.Deprecated.manage_afterAdd is '
+            'discouraged. You should use event subscribers instead.\n')
 
     def test_not_deprecated_when_there_are_no_classes(self):
         class Deprecated(object):
             def manage_afterAdd(self):
                 pass
         self.deprecatedManageAddDeleteClasses[:] = []
-        self.assertLog(Deprecated, b'')
+        self.assertLog(Deprecated, '')

--- a/src/Products/Five/browser/tests/resource.txt
+++ b/src/Products/Five/browser/tests/resource.txt
@@ -65,7 +65,7 @@ PageTemplateResource's __call__ renders the template
 
   >>> for r in dir_resource_names:
   ...     resource = self.folder.unrestrictedTraverse(base % r)
-  ...     self.assertTrue(isinstance(resource, Resource))
+  ...     self.assertIsInstance(resource, Resource)
   ...     if not isinstance(resource, PageTemplateResource):
   ...         self.assertEquals(resource(), base_url % r)
 

--- a/src/Products/Five/browser/tests/resource.txt
+++ b/src/Products/Five/browser/tests/resource.txt
@@ -65,7 +65,7 @@ PageTemplateResource's __call__ renders the template
 
   >>> for r in dir_resource_names:
   ...     resource = self.folder.unrestrictedTraverse(base % r)
-  ...     self.assert_(isinstance(resource, Resource))
+  ...     self.assertTrue(isinstance(resource, Resource))
   ...     if not isinstance(resource, PageTemplateResource):
   ...         self.assertEquals(resource(), base_url % r)
 

--- a/src/Products/Five/browser/tests/resource_ftest.txt
+++ b/src/Products/Five/browser/tests/resource_ftest.txt
@@ -90,7 +90,7 @@ Page templates aren't guaranteed to render, so exclude them from the test:
   ...     if r.endswith('.pt'):
   ...         continue
   ...     response = self.publish(base_url % r, basic='manager:r00t')
-  ...     self.assertEquals(200, response.getStatus())
+  ...     self.assertEqual(200, response.getStatus())
 
   >>> print(http(r'''
   ... GET /test_folder_1_/testoid/++resource++fivetest_resources/resource_subdir/resource.htm HTTP/1.1

--- a/src/Products/Five/browser/tests/test_menu.py
+++ b/src/Products/Five/browser/tests/test_menu.py
@@ -49,42 +49,45 @@ def test_menu():
 
       >>> from operator import itemgetter
       >>> menu.sort(key=itemgetter('title'))
-      >>> from pprint import pprint
-      >>> pprint(menu[0])
-      {'action': '@@cockatiel_menu_public.html',
-       'description': u'',
-       'extra': None,
-       'icon': None,
-       'selected': u'',
-       'submenu': None,
-       'title': u'Page in a menu (public)'}
+      >>> menu[0] == {
+      ...     'action': '@@cockatiel_menu_public.html',
+      ...     'description': u'',
+      ...     'extra': None,
+      ...     'icon': None,
+      ...     'selected': u'',
+      ...     'submenu': None,
+      ...     'title': u'Page in a menu (public)'}
+      True
 
-      >>> pprint(menu[1])
-      {'action': u'seagull.html',
-       'description': u'This is a test menu item',
-       'extra': None,
-       'icon': None,
-       'selected': u'',
-       'submenu': None,
-       'title': u'Test Menu Item'}
+      >>> menu[1] == {
+      ...     'action': u'seagull.html',
+      ...     'description': u'This is a test menu item',
+      ...     'extra': None,
+      ...     'icon': None,
+      ...     'selected': u'',
+      ...     'submenu': None,
+      ...     'title': u'Test Menu Item'}
+      True
 
-      >>> pprint(menu[2])
-      {'action': u'parakeet.html',
-       'description': u'This is a test menu item',
-       'extra': None,
-       'icon': None,
-       'selected': u'',
-       'submenu': None,
-       'title': u'Test Menu Item 2'}
+      >>> menu[2] == {
+      ...     'action': u'parakeet.html',
+      ...     'description': u'This is a test menu item',
+      ...     'extra': None,
+      ...     'icon': None,
+      ...     'selected': u'',
+      ...     'submenu': None,
+      ...     'title': u'Test Menu Item 2'}
+      True
 
-      >>> pprint(menu[3])
-      {'action': u'falcon.html',
-       'description': u'This is a test menu item',
-       'extra': None,
-       'icon': None,
-       'selected': u'',
-       'submenu': None,
-       'title': u'Test Menu Item 3'}
+      >>> menu[3] == {
+      ...     'action': u'falcon.html',
+      ...     'description': u'This is a test menu item',
+      ...     'extra': None,
+      ...     'icon': None,
+      ...     'selected': u'',
+      ...     'submenu': None,
+      ...     'title': u'Test Menu Item 3'}
+      True
 
     Let's create a manager user account and log in.
 
@@ -101,68 +104,75 @@ def test_menu():
       7
 
       >>> menu.sort(key=itemgetter('title'))
-      >>> pprint(menu[0])
-      {'action': '@@cockatiel_menu_protected.html',
-       'description': u'',
-       'extra': None,
-       'icon': None,
-       'selected': u'',
-       'submenu': None,
-       'title': u'Page in a menu (protected)'}
+      >>> menu[0] == {
+      ...     'action': '@@cockatiel_menu_protected.html',
+      ...     'description': u'',
+      ...     'extra': None,
+      ...     'icon': None,
+      ...     'selected': u'',
+      ...     'submenu': None,
+      ...     'title': u'Page in a menu (protected)'}
+      True
 
-      >>> pprint(menu[1])
-      {'action': '@@cockatiel_menu_public.html',
-       'description': u'',
-       'extra': None,
-       'icon': None,
-       'selected': u'',
-       'submenu': None,
-       'title': u'Page in a menu (public)'}
+      >>> menu[1] == {
+      ...     'action': '@@cockatiel_menu_public.html',
+      ...     'description': u'',
+      ...     'extra': None,
+      ...     'icon': None,
+      ...     'selected': u'',
+      ...     'submenu': None,
+      ...     'title': u'Page in a menu (public)'}
+      True
 
-      >>> pprint(menu[2])
-      {'action': u'seagull.html',
-       'description': u'This is a protected test menu item',
-       'extra': None,
-       'icon': None,
-       'selected': u'',
-       'submenu': None,
-       'title': u'Protected Test Menu Item'}
+      >>> menu[2] == {
+      ...     'action': u'seagull.html',
+      ...     'description': u'This is a protected test menu item',
+      ...     'extra': None,
+      ...     'icon': None,
+      ...     'selected': u'',
+      ...     'submenu': None,
+      ...     'title': u'Protected Test Menu Item'}
+      True
 
-      >>> pprint(menu[3])
-      {'action': u'falcon.html',
-       'description': u'This is a protected test menu item',
-       'extra': None,
-       'icon': None,
-       'selected': u'',
-       'submenu': None,
-       'title': u'Protected Test Menu Item 2'}
+      >>> menu[3] == {
+      ...     'action': u'falcon.html',
+      ...     'description': u'This is a protected test menu item',
+      ...     'extra': None,
+      ...     'icon': None,
+      ...     'selected': u'',
+      ...     'submenu': None,
+      ...     'title': u'Protected Test Menu Item 2'}
+      True
 
-      >>> pprint(menu[4])
-      {'action': u'seagull.html',
-       'description': u'This is a test menu item',
-       'extra': None,
-       'icon': None,
-       'selected': u'',
-       'submenu': None,
-       'title': u'Test Menu Item'}
+      >>> menu[4] == {
+      ...     'action': u'seagull.html',
+      ...     'description': u'This is a test menu item',
+      ...     'extra': None,
+      ...     'icon': None,
+      ...     'selected': u'',
+      ...     'submenu': None,
+      ...     'title': u'Test Menu Item'}
+      True
 
-      >>> pprint(menu[5])
-      {'action': u'parakeet.html',
-       'description': u'This is a test menu item',
-       'extra': None,
-       'icon': None,
-       'selected': u'',
-       'submenu': None,
-       'title': u'Test Menu Item 2'}
+      >>> menu[5] == {
+      ...     'action': u'parakeet.html',
+      ...     'description': u'This is a test menu item',
+      ...     'extra': None,
+      ...     'icon': None,
+      ...     'selected': u'',
+      ...     'submenu': None,
+      ...     'title': u'Test Menu Item 2'}
+      True
 
-      >>> pprint(menu[6])
-      {'action': u'falcon.html',
-       'description': u'This is a test menu item',
-       'extra': None,
-       'icon': None,
-       'selected': u'',
-       'submenu': None,
-       'title': u'Test Menu Item 3'}
+      >>> menu[6] == {
+      ...     'action': u'falcon.html',
+      ...     'description': u'This is a test menu item',
+      ...     'extra': None,
+      ...     'icon': None,
+      ...     'selected': u'',
+      ...     'submenu': None,
+      ...     'title': u'Test Menu Item 3'}
+      True
 
 
     Clean up:

--- a/src/Products/Five/browser/tests/test_pagetemplatefile.py
+++ b/src/Products/Five/browser/tests/test_pagetemplatefile.py
@@ -71,7 +71,7 @@ class ViewPageTemplateFileTests(unittest.TestCase):
         self.assertTrue(namespace['context'] is context)
         self.assertTrue(namespace['request'] is request)
         views = namespace['views']
-        self.assertTrue(isinstance(views, ViewMapper))
+        self.assertIsInstance(views, ViewMapper)
         self.assertEqual(views.ob, context)
         self.assertEqual(views.request, request)
         self.assertTrue(namespace['here'] is context)
@@ -159,7 +159,7 @@ class ViewPageTemplateFileTests(unittest.TestCase):
         request = DummyRequest()
         foo = Foo(context, request)
         bound = foo.bar
-        self.assertTrue(isinstance(bound, BoundPageTemplate))
+        self.assertIsInstance(bound, BoundPageTemplate)
         self.assertTrue(bound.__func__ is template)
         self.assertTrue(bound.__self__ is foo)
 

--- a/src/Products/Five/component/makesite.txt
+++ b/src/Products/Five/component/makesite.txt
@@ -96,10 +96,15 @@ Ensure that its local components are no longer available:
 
     >>> ISite.providedBy(app.folder)
     False
-    >>> browser.open('http://localhost/folder/@@testview.html')
-    Traceback (most recent call last):
-    ...
-    NotFound: ...
+
+    >>> from zExceptions import NotFound
+    >>> try:
+    ...     browser.open('http://localhost/folder/@@testview.html')
+    ... except NotFound as exc:
+    ...     print(exc.args)
+    ... else:
+    ...     print('NotFound not raised.')
+    ('http://localhost/folder/@@testview.html',)
 
 Clean up:
 ---------

--- a/src/Products/PageTemplates/tests/secure.pt
+++ b/src/Products/PageTemplates/tests/secure.pt
@@ -1,5 +1,5 @@
 <div xmlns="http://www.w3.org/1999/xhtml"
      xmlns:tal="http://xml.zope.org/namespaces/tal">
   <span tal:define="soup view/tagsoup | options/soup"
-        tal:replace="structure python: modules['cgi'].escape(soup)" />
+        tal:replace="structure python: modules['cgi'].escape(soup, True)" />
 </div>

--- a/src/Products/PageTemplates/tests/testExpressions.py
+++ b/src/Products/PageTemplates/tests/testExpressions.py
@@ -140,13 +140,13 @@ class EngineTestsBase(PlacelessSetup):
         from zope.tales.expressions import DeferWrapper
         ec = self._makeContext()
         defer = ec.evaluate('defer: b')
-        self.assertTrue(isinstance(defer, DeferWrapper))
+        self.assertIsInstance(defer, DeferWrapper)
 
     def test_lazy_expression_returns_wrapper(self):
         from zope.tales.expressions import LazyWrapper
         ec = self._makeContext()
         lazy = ec.evaluate('lazy: b')
-        self.assertTrue(isinstance(lazy, LazyWrapper))
+        self.assertIsInstance(lazy, LazyWrapper)
 
     def test_empty_path_expression_explicit(self):
         ec = self._makeContext()
@@ -172,7 +172,7 @@ class EngineTestsBase(PlacelessSetup):
         # only bothers compiling true strings, not unicode strings
         result = ec.evaluate(eng.compile(u'string:x'))
         self.assertEqual(result, u'x')
-        self.assertTrue(isinstance(result, text_type))
+        self.assertIsInstance(result, text_type)
 
     def test_mixed(self):
         # 8-bit strings in unicode string expressions cause UnicodeDecodeErrors

--- a/src/Products/PageTemplates/tests/test_persistenttemplate.py
+++ b/src/Products/PageTemplates/tests/test_persistenttemplate.py
@@ -1,9 +1,14 @@
-import cgi
 import re
 import unittest
 
 from Products.PageTemplates.ZopePageTemplate import manage_addPageTemplate
 from Testing.ZopeTestCase import ZopeTestCase
+
+try:
+    from html import escape
+except ImportError:  # PY2
+    from cgi import escape
+
 
 macro_outer = """
 <metal:defm define-macro="master">
@@ -118,7 +123,7 @@ class TestPersistent(ZopeTestCase):
         result = template().strip()
         self.assertEqual(result, u'Hello, World')
         editable_text = get_editable_content(template)
-        self.assertEqual(editable_text, cgi.escape(simple_i18n))
+        self.assertEqual(editable_text, escape(simple_i18n, False))
 
     def test_escape_on_edit(self):
         # check that escapable chars can round-trip intact.
@@ -126,7 +131,7 @@ class TestPersistent(ZopeTestCase):
         template = self._makeOne('foo', source)
         self.assertEqual(template(), source)  # nothing to render
         editable_text = get_editable_content(template)
-        self.assertEqual(editable_text, cgi.escape(source))
+        self.assertEqual(editable_text, escape(source, False))
 
     def test_macro_with_i18n(self):
         self._makeOne('macro_outer', macro_outer)
@@ -208,9 +213,9 @@ class TestPersistent(ZopeTestCase):
         editable_text = get_editable_content(template)
         # and the errors should be in an xml comment at the start of
         # the editable text
-        error_prefix = cgi.escape(
+        error_prefix = escape(
             '<!-- Page Template Diagnostics\n {0}\n-->\n'.format(
-                '\n '.join(template._v_errors)
+                '\n '.join(template._v_errors), False
             )
         )
         self.assertTrue(editable_text.startswith(error_prefix))

--- a/src/Testing/ZopeTestCase/testFunctional.py
+++ b/src/Testing/ZopeTestCase/testFunctional.py
@@ -62,12 +62,12 @@ class TestFunctional(ZopeTestCase.FunctionalTestCase):
     def testPublishFolder(self):
         response = self.publish(self.folder_path)
         self.assertEqual(response.getStatus(), 200)
-        self.assertEqual(response.getBody(), 'index')
+        self.assertEqual(response.getBody(), b'index')
 
     def testPublishDocument(self):
         response = self.publish(self.folder_path + '/index_html')
         self.assertEqual(response.getStatus(), 200)
-        self.assertEqual(response.getBody(), 'index')
+        self.assertEqual(response.getBody(), b'index')
 
     def testUnauthorized(self):
         response = self.publish(self.folder_path + '/secret_html')
@@ -77,7 +77,7 @@ class TestFunctional(ZopeTestCase.FunctionalTestCase):
         response = self.publish(self.folder_path + '/secret_html',
                                 self.basic_auth)
         self.assertEqual(response.getStatus(), 200)
-        self.assertEqual(response.getBody(), 'secret')
+        self.assertEqual(response.getBody(), b'secret')
 
     def testRedirect(self):
         response = self.publish(self.folder_path + '/redirect')
@@ -107,7 +107,7 @@ class TestFunctional(ZopeTestCase.FunctionalTestCase):
         self.setPermissions([manage_properties])
 
         form = {'title': 'Foo'}
-        post_data = BytesIO(urlencode(form))
+        post_data = BytesIO(urlencode(form).encode('utf-8'))
 
         response = self.publish(self.folder_path + '/index_html/change_title',
                                 request_method='POST', stdin=post_data,

--- a/src/Testing/ZopeTestCase/testPortalTestCase.py
+++ b/src/Testing/ZopeTestCase/testPortalTestCase.py
@@ -138,7 +138,7 @@ class TestPortalTestCase(ZopeTestCase.PortalTestCase):
         acl_user = self.portal.acl_users.getUserById(user_name)
         self.assertTrue(acl_user)
         self.assertEqual(acl_user.getRoles(), ('Member', 'Authenticated'))
-        self.assertTrue(isinstance(acl_user.roles, list))
+        self.assertIsInstance(acl_user.roles, list)
 
     def test_setupHomeFolder(self):
         # User's home folder should be set up
@@ -324,7 +324,7 @@ class TestPortalTestCase(ZopeTestCase.PortalTestCase):
         acl_user = self.portal.acl_users.getUserById(user_name)
         self.assertTrue(acl_user)
         self.assertEqual(acl_user.getRoles(), ('Member', 'Authenticated'))
-        self.assertTrue(isinstance(acl_user.roles, list))
+        self.assertIsInstance(acl_user.roles, list)
         auth_name = getSecurityManager().getUser().getId()
         self.assertEqual(auth_name, user_name)
         self.assertEqual(self._called, ['beforeSetUp', 'afterSetUp'])

--- a/src/Testing/ZopeTestCase/zopedoctest/FunctionalDocTest.txt
+++ b/src/Testing/ZopeTestCase/zopedoctest/FunctionalDocTest.txt
@@ -70,27 +70,31 @@ Examples
 
 Test Publish Document
 
-  >>> print(http(r"""
+  >>> response = http(r"""
   ... GET /test_folder_1_/index_html HTTP/1.1
-  ... """, handle_errors=False))
-  HTTP/1.1 200 OK
-  ...
-  Content-Length: 5
-  Content-Type: text/plain; charset=...
-  <BLANKLINE>
-  index
+  ... """, handle_errors=False)
+
+  >>> response.status
+  200
+  >>> response.headers == {
+  ...     'content-length': '5', 'content-type': 'text/plain; charset=utf-8'}
+  True
+  >>> response.getBody() == b'index'
+  True
 
 Test parameter containing an additional '?'
 
-  >>> print(http(r"""
+  >>> response = http(r"""
   ... GET /test_folder_1_?foo=bla%3Fbaz HTTP/1.1
-  ... """))
-  HTTP/1.1 200 OK
-  ...
-  Content-Length: 5
-  Content-Type: text/plain; charset=utf-8
-  <BLANKLINE>
-  index
+  ... """)
+
+  >>> response.status
+  200
+  >>> response.headers == {
+  ...     'content-length': '5', 'content-type': 'text/plain; charset=utf-8'}
+  True
+  >>> response.getBody() == b'index'
+  True
               
 Test Unauthorized
 
@@ -107,14 +111,13 @@ Test Basic Authentication
   >>> from AccessControl.Permissions import manage_properties
   >>> self.setPermissions([manage_properties])
 
-  >>> print(http(r"""
+  >>> response = http(r"""
   ... GET /test_folder_1_/index_html/change_title?title=Foo HTTP/1.1
   ... Authorization: Basic %s
-  ... """ % user_auth, handle_errors=False))
-  HTTP/1.1 200 OK
-  ...
-  Content-Length: 0
-  ...
+  ... """ % user_auth, handle_errors=False)
+
+  >>> response.status
+  200
 
   >>> self.folder.index_html.title_or_id()
   'Foo'
@@ -122,41 +125,41 @@ Test Basic Authentication
 Test passing in non-base64-encoded login/pass
 
   >>> from Testing.ZopeTestCase import user_name, user_password
-  >>> print(http(r"""
+  >>> response = http(r"""
   ... GET /test_folder_1_/index_html/change_title?title=Baz HTTP/1.1
   ... Authorization: Basic %s:%s
-  ... """ % (user_name, user_password), handle_errors=False))
-  HTTP/1.1 200 OK
-  ...
-  Content-Length: 0
-  ...
+  ... """ % (user_name, user_password), handle_errors=False)
+
+  >>> response.status
+  200
 
   >>> self.folder.index_html.title_or_id()
   'Baz'
 
 Test setting cookies
 
-  >>> print(http(r"""
+  >>> response = http(r"""
   ... GET /test_folder_1_/index_html/set_cookie HTTP/1.1
-  ... """, handle_errors=False))
-  HTTP/1.1 200 OK
-  ...
-  Content-Length: 0
-  ...
-  Set-Cookie: foo="Bar"; Path=/
-  <BLANKLINE>
+  ... """, handle_errors=False)
+
+  >>> response.status
+  200
+
+  >>> b'Set-Cookie: foo="Bar"; Path=/' in response.getOutput()
+  True
 
 Test reading cookies
 
-  >>> print(http(r"""
+  >>> response = http(r"""
   ... GET /test_folder_1_/index_html/show_cookies HTTP/1.1
   ... Cookie: foo=bar; baz="oki doki"
-  ... """, handle_errors=False))
-  HTTP/1.1 200 OK
-  ...
-  Content-Length: 23
-  Content-Type: text/plain; charset=...
-  <BLANKLINE>
-  foo: bar
-  baz: oki doki
-  <BLANKLINE>
+  ... """, handle_errors=False)
+
+  >>> response.status
+  200
+
+  >>> b'foo: bar' in response.getBody()
+  True
+
+  >>> b'baz: oki doki' in response.getBody()
+  True

--- a/src/Testing/ZopeTestCase/zopedoctest/testFunctionalDocTest.py
+++ b/src/Testing/ZopeTestCase/zopedoctest/testFunctionalDocTest.py
@@ -89,7 +89,7 @@ class HTTPHeaderOutputTests(unittest.TestCase):
 
 
 SHOW_COOKIES_DTML = '''\
-<dtml-in "REQUEST.cookies.keys()">
+<dtml-in "list(REQUEST.cookies.keys())">
 <dtml-var sequence-item>: <dtml-var "REQUEST.cookies[_['sequence-item']]">
 </dtml-in>'''
 
@@ -97,15 +97,16 @@ SHOW_COOKIES_DTML = '''\
 def setUp(self):
     '''This method will run after the test_class' setUp.
 
-    >>> print(http(r"""
+    >>> response = http(r"""
     ... GET /test_folder_1_/index_html HTTP/1.1
-    ... """))
-    HTTP/1.1 200 OK
-    ...
-    Content-Length: 5
-    Content-Type: text/plain; charset=...
-    <BLANKLINE>
-    index
+    ... """)
+    >>> response.status
+    200
+    >>> response.headers == {
+    ...     'content-length': '5', 'content-type': 'text/plain; charset=utf-8'}
+    True
+    >>> response.getBody() == b'index'
+    True
 
     >>> foo
     1

--- a/src/ZPublisher/Converters.py
+++ b/src/ZPublisher/Converters.py
@@ -76,7 +76,7 @@ def field2int(v):
             return int(v)
         except ValueError:
             raise ValueError(
-                "An integer was expected in the value %r" % escape(v)
+                "An integer was expected in the value %r" % escape(v, True)
             )
     raise ValueError('Empty entry when <strong>integer</strong> expected')
 
@@ -91,7 +91,7 @@ def field2float(v):
         except ValueError:
             raise ValueError(
                 "A floating-point number was expected in the value %r" %
-                escape(v)
+                escape(v, True)
             )
     raise ValueError(
         'Empty entry when <strong>floating-point number</strong> expected')
@@ -109,7 +109,7 @@ def field2long(v):
             return int(v)
         except ValueError:
             raise ValueError(
-                "A long integer was expected in the value %r" % escape(v)
+                "A long integer was expected in the value %r" % escape(v, True)
             )
     raise ValueError('Empty entry when <strong>integer</strong> expected')
 
@@ -133,7 +133,7 @@ def field2date(v):
     try:
         v = DateTime(v)
     except SyntaxError:
-        raise SyntaxError("Invalid DateTime " + escape(repr(v)))
+        raise SyntaxError("Invalid DateTime " + escape(repr(v), True))
     return v
 
 

--- a/src/ZPublisher/HTTPRequest.py
+++ b/src/ZPublisher/HTTPRequest.py
@@ -650,7 +650,7 @@ class HTTPRequest(BaseRequest):
                         if '<' in attr:
                             raise ValueError(
                                 "%s is not a valid record attribute name" %
-                                escape(attr))
+                                escape(attr, True))
 
                     # defer conversion
                     if flags & CONVERTED:
@@ -1469,36 +1469,37 @@ class HTTPRequest(BaseRequest):
         result = "<h3>form</h3><table>"
         row = '<tr valign="top" align="left"><th>%s</th><td>%s</td></tr>'
         for k, v in _filterPasswordFields(self.form.items()):
-            result = result + row % (escape(k), escape(repr(v)))
+            result = result + row % (escape(k, False), escape(repr(v), False))
         result = result + "</table><h3>cookies</h3><table>"
         for k, v in _filterPasswordFields(self.cookies.items()):
-            result = result + row % (escape(k), escape(repr(v)))
+            result = result + row % (escape(k, False), escape(repr(v, False)))
         result = result + "</table><h3>lazy items</h3><table>"
         for k, v in _filterPasswordFields(self._lazies.items()):
-            result = result + row % (escape(k), escape(repr(v)))
+            result = result + row % (escape(k, False), escape(repr(v), False))
         result = result + "</table><h3>other</h3><table>"
         for k, v in _filterPasswordFields(self.other.items()):
             if k in ('PARENTS', 'RESPONSE'):
                 continue
-            result = result + row % (escape(k), escape(repr(v)))
+            result = result + row % (escape(k, False), escape(repr(v), False))
 
         for n in "0123456789":
             key = "URL%s" % n
             try:
-                result = result + row % (key, escape(self[key]))
+                result = result + row % (key, escape(self[key], False))
             except KeyError:
                 pass
         for n in "0123456789":
             key = "BASE%s" % n
             try:
-                result = result + row % (key, escape(self[key]))
+                result = result + row % (key, escape(self[key], False))
             except KeyError:
                 pass
 
         result = result + "</table><h3>environ</h3><table>"
         for k, v in self.environ.items():
             if k not in hide_key:
-                result = result + row % (escape(k), escape(repr(v)))
+                result = result + row % (
+                    escape(k, False), escape(repr(v), False))
         return result + "</table>"
 
     def __repr__(self):

--- a/src/ZPublisher/HTTPResponse.py
+++ b/src/ZPublisher/HTTPResponse.py
@@ -393,7 +393,7 @@ class HTTPBaseResponse(BaseResponse):
                         self.body = (
                             body[:index] +
                             b'\n<base href="' +
-                            escape(self.base, 1).encode('utf-8') +
+                            escape(self.base, True).encode('utf-8') +
                             b'" />\n' +
                             body[index:]
                         )
@@ -985,7 +985,7 @@ class WSGIResponse(HTTPBaseResponse):
         exc.detail = (
             'Sorry, the requested resource does not exist.'
             '<p>Check the URL and try again.</p>'
-            '<p><b>Resource:</b> %s</p>' % escape(entry))
+            '<p><b>Resource:</b> %s</p>' % escape(entry, True))
         raise exc
 
     # If a resource is forbidden, why reveal that it exists?

--- a/src/ZPublisher/tests/testHTTPRequest.py
+++ b/src/ZPublisher/tests/testHTTPRequest.py
@@ -714,22 +714,22 @@ class HTTPRequestTests(unittest.TestCase, HTTPRequestFactoryMixin):
                     'foo_tuple': (_NON_ASCII.encode(default_encoding), 'HAM'),
                     'foo_dict': {'foo': _NON_ASCII, 'bar': 'EGGS'}}
         req.postProcessInputs()
-        self.assertTrue(isinstance(req.form['foo'], unicode))
+        self.assertIsInstance(req.form['foo'], unicode)
         self.assertEqual(req.form['foo'], _NON_ASCII)
-        self.assertTrue(isinstance(req.form['foo_list'], list))
-        self.assertTrue(isinstance(req.form['foo_list'][0], unicode))
+        self.assertIsInstance(req.form['foo_list'], list)
+        self.assertIsInstance(req.form['foo_list'][0], unicode)
         self.assertEqual(req.form['foo_list'][0], _NON_ASCII)
-        self.assertTrue(isinstance(req.form['foo_list'][1], unicode))
+        self.assertIsInstance(req.form['foo_list'][1], unicode)
         self.assertEqual(req.form['foo_list'][1], u'SPAM')
-        self.assertTrue(isinstance(req.form['foo_tuple'], tuple))
-        self.assertTrue(isinstance(req.form['foo_tuple'][0], unicode))
+        self.assertIsInstance(req.form['foo_tuple'], tuple)
+        self.assertIsInstance(req.form['foo_tuple'][0], unicode)
         self.assertEqual(req.form['foo_tuple'][0], _NON_ASCII)
-        self.assertTrue(isinstance(req.form['foo_tuple'][1], unicode))
+        self.assertIsInstance(req.form['foo_tuple'][1], unicode)
         self.assertEqual(req.form['foo_tuple'][1], u'HAM')
-        self.assertTrue(isinstance(req.form['foo_dict'], dict))
-        self.assertTrue(isinstance(req.form['foo_dict']['foo'], unicode))
+        self.assertIsInstance(req.form['foo_dict'], dict)
+        self.assertIsInstance(req.form['foo_dict']['foo'], unicode)
         self.assertEqual(req.form['foo_dict']['foo'], _NON_ASCII)
-        self.assertTrue(isinstance(req.form['foo_dict']['bar'], unicode))
+        self.assertIsInstance(req.form['foo_dict']['bar'], unicode)
         self.assertEqual(req.form['foo_dict']['bar'], u'EGGS')
 
     def test_close_removes_stdin_references(self):
@@ -796,7 +796,7 @@ class HTTPRequestTests(unittest.TestCase, HTTPRequestFactoryMixin):
         from zope.publisher.base import DebugFlags
         # when accessing request.debug we will see the DebugFlags instance
         request = self._makeOne()
-        self.assertTrue(isinstance(request.debug, DebugFlags))
+        self.assertIsInstance(request.debug, DebugFlags)
         # It won't be available through dictonary lookup, though
         self.assertTrue(request.get('debug') is None)
 
@@ -1027,7 +1027,7 @@ class HTTPRequestTests(unittest.TestCase, HTTPRequestFactoryMixin):
         request = self._makeOne(None, TEST_ENVIRON.copy(), DummyResponse())
         request['PARENTS'] = [object()]
         clone = request.clone()
-        self.assertTrue(isinstance(clone.response, DummyResponse))
+        self.assertIsInstance(clone.response, DummyResponse)
 
     def test_clone_preserves_request_subclass(self):
         class SubRequest(self._getTargetClass()):
@@ -1035,7 +1035,7 @@ class HTTPRequestTests(unittest.TestCase, HTTPRequestFactoryMixin):
         request = SubRequest(None, TEST_ENVIRON.copy(), None)
         request['PARENTS'] = [object()]
         clone = request.clone()
-        self.assertTrue(isinstance(clone, SubRequest))
+        self.assertIsInstance(clone, SubRequest)
 
     def test_clone_preserves_direct_interfaces(self):
         from zope.interface import directlyProvides

--- a/src/ZPublisher/tests/testHTTPResponse.py
+++ b/src/ZPublisher/tests/testHTTPResponse.py
@@ -1303,8 +1303,8 @@ class HTTPResponseTests(unittest.TestCase):
             t, v, tb = sys.exc_info()
             response._setBCIHeaders(t, tb)
             # required by Bobo Call Interface (BCI)
-            self.assertEqual(response.headers['bobo-exception-type'],
-                             "<type 'exceptions.AttributeError'>")
+            self.assertIn('AttributeError',
+                          response.headers['bobo-exception-type'])
             self.assertEqual(response.headers['bobo-exception-value'],
                              'See the server error log for details')
             self.assertTrue('bobo-exception-file' in response.headers)
@@ -1322,8 +1322,8 @@ class HTTPResponseTests(unittest.TestCase):
             self.assertEqual(response.status, 500)
             self.assertEqual(response.errmsg, 'Internal Server Error')
             # required by Bobo Call Interface (BCI)
-            self.assertEqual(response.headers['bobo-exception-type'],
-                             "<type 'exceptions.AttributeError'>")
+            self.assertIn('AttributeError',
+                          response.headers['bobo-exception-type'])
             self.assertEqual(response.headers['bobo-exception-value'],
                              'See the server error log for details')
             self.assertTrue('bobo-exception-file' in response.headers)

--- a/src/ZPublisher/tests/testHTTPResponse.py
+++ b/src/ZPublisher/tests/testHTTPResponse.py
@@ -134,7 +134,7 @@ class HTTPResponseTests(unittest.TestCase):
         STDOUT, STDERR = object(), object()
         response = self._makeOne(stdout=STDOUT, stderr=STDERR)
         cloned = response.retry()
-        self.assertTrue(isinstance(cloned, self._getTargetClass()))
+        self.assertIsInstance(cloned, self._getTargetClass())
         self.assertTrue(cloned.stdout is STDOUT)
         self.assertTrue(cloned.stderr is STDERR)
 

--- a/src/ZPublisher/tests/test_WSGIPublisher.py
+++ b/src/ZPublisher/tests/test_WSGIPublisher.py
@@ -279,7 +279,7 @@ class TestPublishModule(unittest.TestCase, PlacelessSetup):
 
         environ = self._makeEnviron(PATH_INFO='/@@testing')
         self.assertEqual(self._callFUT(environ, noopStartResponse),
-                         ('', 'foobar'))
+                         (b'', b'foobar'))
 
     def test_publish_can_return_new_response(self):
         from ZPublisher.HTTPRequest import HTTPRequest

--- a/src/ZPublisher/tests/test_WSGIPublisher.py
+++ b/src/ZPublisher/tests/test_WSGIPublisher.py
@@ -299,7 +299,7 @@ class TestPublishModule(unittest.TestCase, PlacelessSetup):
         self.assertEqual(headers, [('Content-Length', '0')])
         self.assertEqual(kw, {})
         (request, module_info), kw = _publish._called_with
-        self.assertTrue(isinstance(request, HTTPRequest))
+        self.assertIsInstance(request, HTTPRequest)
         self.assertEqual(kw, {})
         self.assertTrue(_response._finalized)
         self.assertEqual(_after1._called_with, ((), {}))

--- a/src/ZPublisher/tests/test_pubevents.py
+++ b/src/ZPublisher/tests/test_pubevents.py
@@ -88,13 +88,13 @@ class TestPubEvents(TestCase):
         r.action = 'succeed'
         self._publish(r, PUBMODULE)
         events = self.reporter.events
-        self.assertTrue(isinstance(events[0], PubStart))
+        self.assertIsInstance(events[0], PubStart)
         self.assertEqual(events[0].request, r)
-        self.assertTrue(isinstance(events[1], PubAfterTraversal))
+        self.assertIsInstance(events[1], PubAfterTraversal)
         self.assertEqual(events[1].request, r)
-        self.assertTrue(isinstance(events[2], PubBeforeCommit))
+        self.assertIsInstance(events[2], PubBeforeCommit)
         self.assertEqual(events[2].request, r)
-        self.assertTrue(isinstance(events[3], PubSuccess))
+        self.assertIsInstance(events[3], PubSuccess)
         self.assertEqual(events[3].request, r)
 
     def testFailureReturn(self):
@@ -102,11 +102,11 @@ class TestPubEvents(TestCase):
         r.action = 'fail_return'
         self.assertRaises(Exception, self._publish, r, PUBMODULE)
         events = self.reporter.events
-        self.assertTrue(isinstance(events[0], PubStart))
+        self.assertIsInstance(events[0], PubStart)
         self.assertEqual(events[0].request, r)
-        self.assertTrue(isinstance(events[1], PubBeforeAbort))
+        self.assertIsInstance(events[1], PubBeforeAbort)
         self.assertEqual(events[1].request, r)
-        self.assertTrue(isinstance(events[2], PubFailure))
+        self.assertIsInstance(events[2], PubFailure)
         self.assertEqual(events[2].request, r)
         self.assertEqual(len(events[2].exc_info), 3)
 
@@ -115,12 +115,12 @@ class TestPubEvents(TestCase):
         r.action = 'fail_exception'
         self.assertRaises(Exception, self._publish, r, PUBMODULE)
         events = self.reporter.events
-        self.assertTrue(isinstance(events[0], PubStart))
+        self.assertIsInstance(events[0], PubStart)
         self.assertEqual(events[0].request, r)
-        self.assertTrue(isinstance(events[1], PubBeforeAbort))
+        self.assertIsInstance(events[1], PubBeforeAbort)
         self.assertEqual(events[1].request, r)
         self.assertEqual(len(events[1].exc_info), 3)
-        self.assertTrue(isinstance(events[2], PubFailure))
+        self.assertIsInstance(events[2], PubFailure)
         self.assertEqual(events[2].request, r)
         self.assertEqual(len(events[2].exc_info), 3)
 
@@ -129,16 +129,16 @@ class TestPubEvents(TestCase):
         r.action = 'conflict'
         self.assertRaises(ConflictError, self._publish, r, PUBMODULE)
         events = self.reporter.events
-        self.assertTrue(isinstance(events[0], PubStart))
+        self.assertIsInstance(events[0], PubStart)
         self.assertEqual(events[0].request, r)
-        self.assertTrue(isinstance(events[1], PubBeforeAbort))
+        self.assertIsInstance(events[1], PubBeforeAbort)
         self.assertEqual(events[1].request, r)
         self.assertEqual(len(events[1].exc_info), 3)
-        self.assertTrue(isinstance(events[1].exc_info[1], ConflictError))
-        self.assertTrue(isinstance(events[2], PubFailure))
+        self.assertIsInstance(events[1].exc_info[1], ConflictError)
+        self.assertIsInstance(events[2], PubFailure)
         self.assertEqual(events[2].request, r)
         self.assertEqual(len(events[2].exc_info), 3)
-        self.assertTrue(isinstance(events[2].exc_info[1], ConflictError))
+        self.assertIsInstance(events[2].exc_info[1], ConflictError)
 
     def testStreaming(self):
         out = BytesIO()
@@ -148,7 +148,7 @@ class TestPubEvents(TestCase):
 
         events = self.reporter.events
         self.assertEqual(len(events), 1)
-        self.assertTrue(isinstance(events[0], PubBeforeStreaming))
+        self.assertIsInstance(events[0], PubBeforeStreaming)
         self.assertEqual(events[0].response, response)
 
         self.assertTrue(b'datachunk1datachunk2' in out.getvalue())

--- a/src/ZTUtils/Zope.py
+++ b/src/ZTUtils/Zope.py
@@ -13,8 +13,6 @@
 """Zope-specific versions of ZTUTils classes
 """
 
-import cgi
-
 from AccessControl import getSecurityManager
 from AccessControl.unauthorized import Unauthorized
 from AccessControl.ZopeGuards import guarded_getitem
@@ -28,6 +26,11 @@ from ZTUtils.SimpleTree import SimpleTreeMaker
 from ZTUtils.Tree import decodeExpansion
 from ZTUtils.Tree import encodeExpansion
 from ZTUtils.Tree import TreeMaker
+
+try:
+    from html import escape
+except ImportError:  # PY2
+    from cgi import escape
 
 
 class LazyFilter(Lazy):
@@ -231,7 +234,7 @@ def make_hidden_input(*args, **kwargs):
     d.update(kwargs)
 
     def hq(x):
-        return cgi.escape(x, quote=True)
+        return escape(x, quote=True)
 
     qlist = complex_marshal(list(d.items()))
     for i in range(len(qlist)):

--- a/src/ZTUtils/tests/testZope.py
+++ b/src/ZTUtils/tests/testZope.py
@@ -12,25 +12,25 @@ from ZTUtils.Zope import (
 
 
 class QueryTests(unittest.TestCase):
-    
+
     def testMarshalString(self):
         self.assertEqual(simple_marshal('string'), '')
-        
+
     def testMarshalBool(self):
         self.assertEqual(simple_marshal(True), ':boolean')
-        
+
     def testMarshalInt(self):
         self.assertEqual(simple_marshal(42), ":int")
-        
+
     def testMarshalFloat(self):
         self.assertEqual(simple_marshal(3.1415), ":float")
-    
+
     def testMarshalDate(self):
         self.assertEqual(simple_marshal(DateTime()), ":date")
-        
+
     def testMarshalUnicode(self):
         self.assertEqual(simple_marshal(u'unic\xF3de'), ":utf8:ustring")
-    
+
     def testMarshallLists(self):
         '''Test marshalling lists'''
         test_date = DateTime()

--- a/tox.ini
+++ b/tox.ini
@@ -9,9 +9,3 @@ commands =
 skip_install = true
 deps =
     zc.buildout
-
-[testenv:py27]
-basepython =
-    python2.7
-setenv =
-    PYTHONHASHSEED = 0


### PR DESCRIPTION
All Python 3 versions now see the same number of test failures:

Total: 1118 tests, 28 failures, 33 errors and 1 skipped in 7.121 seconds.