### PR TITLE
Py3 again

### DIFF
--- a/src/OFS/CopySupport.py
+++ b/src/OFS/CopySupport.py
@@ -528,11 +528,11 @@ class CopySource(Base):
                 'Container "%r" needs to be in the database' % container)
 
         # Ask an object for a new copy of itself.
-        f = tempfile.TemporaryFile()
-        self._p_jar.exportFile(self._p_oid, f)
-        f.seek(0)
-        ob = container._p_jar.importFile(f)
-        f.close()
+        with tempfile.TemporaryFile() as f:
+            self._p_jar.exportFile(self._p_oid, f)
+            f.seek(0)
+            ob = container._p_jar.importFile(f)
+
         # Cleanup the copy.  It may contain private objects that the current
         # user is not allowed to see.
         sm = getSecurityManager()

--- a/src/OFS/ObjectManager.py
+++ b/src/OFS/ObjectManager.py
@@ -589,17 +589,20 @@ class ObjectManager(CopyContainer,
         suffix = 'zexp'
 
         if download:
-            f = BytesIO()
-            ob._p_jar.exportFile(ob._p_oid, f)
+            with BytesIO() as f:
+                ob._p_jar.exportFile(ob._p_oid, f)
+                result = f.getvalue()
+
             if RESPONSE is not None:
                 RESPONSE.setHeader('Content-type', 'application/data')
                 RESPONSE.setHeader('Content-Disposition',
                                    'inline;filename=%s.%s' % (id, suffix))
-            return f.getvalue()
+            return result
 
         cfg = getConfiguration()
         f = os.path.join(cfg.clienthome, '%s.%s' % (id, suffix))
-        ob._p_jar.exportFile(ob._p_oid, f)
+        with open(f, 'w+b') as fd:
+            ob._p_jar.exportFile(ob._p_oid, fd)
 
         if REQUEST is not None:
             return self.manage_main(

--- a/src/OFS/tests/testRanges.py
+++ b/src/OFS/tests/testRanges.py
@@ -169,7 +169,7 @@ class TestRequestRange(unittest.TestCase):
         import io
         import re
         import email
-        rangeParse = re.compile('bytes\s*(\d+)-(\d+)/(\d+)')
+        rangeParse = re.compile(r'bytes\s*(\d+)-(\d+)/(\d+)')
         req = self.app.REQUEST
         rsp = req.RESPONSE
 

--- a/src/OFS/tests/test_userfolder.py
+++ b/src/OFS/tests/test_userfolder.py
@@ -62,7 +62,7 @@ class UserFolderTests(unittest.TestCase):
         app._addRole('role1')
         app.manage_role('role1', ['View'])
         # Set up a published object accessible to user
-        app.addDTMLMethod('doc', file=b'')
+        app.addDTMLMethod('doc', file='')
         app.doc.manage_permission('View', ['role1'], acquire=0)
         # Rig the REQUEST so it looks like we traversed to doc
         app.REQUEST.set('PUBLISHED', app.doc)

--- a/src/Products/Five/browser/tests/resource.txt
+++ b/src/Products/Five/browser/tests/resource.txt
@@ -67,7 +67,7 @@ PageTemplateResource's __call__ renders the template
   ...     resource = self.folder.unrestrictedTraverse(base % r)
   ...     self.assertIsInstance(resource, Resource)
   ...     if not isinstance(resource, PageTemplateResource):
-  ...         self.assertEquals(resource(), base_url % r)
+  ...         self.assertEqual(resource(), base_url % r)
 
 Clean up
 --------

--- a/src/Products/PageTemplates/tests/input/CheckPathAlt.html
+++ b/src/Products/PageTemplates/tests/input/CheckPathAlt.html
@@ -15,7 +15,7 @@
    <p tal:attributes="name y/z | python:'||'[:0]">Z</p>
    <p tal:attributes="name y/z | nothing">Z</p>
 
-   <p tal:on-error="python:str(error.value[0])" tal:content="a/b | c/d">Z</p>
+   <p tal:on-error="python:str(error.value)" tal:content="a/b | c/d">Z</p>
    </div>
 </body>
 </html>

--- a/src/Products/PageTemplates/tests/locals.pt
+++ b/src/Products/PageTemplates/tests/locals.pt
@@ -5,8 +5,8 @@
     <div tal:replace="python:'here==container:'+str(here==container)" />
     <div tal:replace="string:root:${root/getPhysicalPath}" />
     <div tal:replace="string:nothing:${nothing}" />
-    <div tal:define="cgi python:modules['cgi']"
-         tal:replace="python: dir(cgi)"
+    <div tal:define="mod modules/html | modules/cgi"
+         tal:replace="python: dir(mod)"
          tal:on-error="nothing" />
     <tal:error on-error="nothing">
       <div tal:define="test python: test" tal:replace="python: test" />

--- a/src/Products/PageTemplates/tests/output/CheckPathAlt.html
+++ b/src/Products/PageTemplates/tests/output/CheckPathAlt.html
@@ -15,7 +15,7 @@
    <p name="">Z</p>
    <p>Z</p>
 
-   <p>c</p>
+   <p>'c'</p>
    </div>
 </body>
 </html>

--- a/src/Products/PageTemplates/tests/secure.pt
+++ b/src/Products/PageTemplates/tests/secure.pt
@@ -1,5 +1,6 @@
 <div xmlns="http://www.w3.org/1999/xhtml"
      xmlns:tal="http://xml.zope.org/namespaces/tal">
-  <span tal:define="soup view/tagsoup | options/soup"
-        tal:replace="structure python: modules['cgi'].escape(soup, True)" />
+  <span tal:define="soup view/tagsoup | options/soup;
+                    mod modules/html | modules/cgi"
+        tal:replace="structure python: mod.escape(soup, True)" />
 </div>

--- a/src/Products/PageTemplates/tests/testHTMLTests.py
+++ b/src/Products/PageTemplates/tests/testHTMLTests.py
@@ -11,12 +11,12 @@
 #
 ##############################################################################
 
-import sys
 import unittest
 
 from AccessControl import SecurityManager
 from AccessControl.SecurityManagement import noSecurityManager
 from Acquisition import Implicit
+from six import text_type
 import zope.component.testing
 from zope.component import provideUtility
 from zope.traversing.adapters import DefaultTraversable
@@ -26,9 +26,6 @@ from Products.PageTemplates.PageTemplate import PageTemplate
 from Products.PageTemplates.interfaces import IUnicodeEncodingConflictResolver
 from Products.PageTemplates.unicodeconflictresolver import \
     DefaultUnicodeEncodingConflictResolver
-
-if sys.version_info >= (3, ):
-    unicode = str
 
 
 class AqPageTemplate(Implicit, PageTemplate):
@@ -90,7 +87,8 @@ class HTMLTests(zope.component.testing.PlacelessSetup, unittest.TestCase):
         t.write(util.read_input(fname))
         assert not t._v_errors, 'Template errors: %s' % t._v_errors
         expect = util.read_output(fname)
-        expect = unicode(expect, 'utf8')
+        if not isinstance(expect, text_type):
+            expect = text_type(expect, 'utf-8')
         out = t(*args, **kwargs)
         util.check_html(expect, out)
 

--- a/src/Products/PageTemplates/tests/test_pagetemplate.py
+++ b/src/Products/PageTemplates/tests/test_pagetemplate.py
@@ -1,6 +1,8 @@
 import os
 import unittest
 
+from six import PY3
+
 from Products.PageTemplates.PageTemplateFile import PageTemplateFile
 from Testing.ZopeTestCase import ZopeTestCase
 
@@ -75,7 +77,10 @@ class TestPageTemplateFile(ZopeTestCase):
             self.fail("Expected unauthorized.")
 
         from AccessControl.SecurityInfo import allow_module
-        allow_module("cgi")
+        if PY3:
+            allow_module('html')
+        else:
+            allow_module('cgi')
         result = template(soup=soup)
         self.assertTrue('&lt;foo&gt;&lt;/bar&gt;' in result)
 

--- a/src/Products/PageTemplates/tests/test_persistenttemplate.py
+++ b/src/Products/PageTemplates/tests/test_persistenttemplate.py
@@ -215,8 +215,9 @@ class TestPersistent(ZopeTestCase):
         # the editable text
         error_prefix = escape(
             '<!-- Page Template Diagnostics\n {0}\n-->\n'.format(
-                '\n '.join(template._v_errors), False
-            )
+                '\n '.join(template._v_errors)
+            ),
+            False,
         )
         self.assertTrue(editable_text.startswith(error_prefix))
 

--- a/src/Testing/ZopeTestCase/testZODBCompat.py
+++ b/src/Testing/ZopeTestCase/testZODBCompat.py
@@ -63,7 +63,7 @@ class TestCopyPaste(ZopeTestCase.ZopeTestCase):
 
     def afterSetUp(self):
         self.setPermissions(cutpaste_permissions)
-        self.folder.addDTMLMethod('doc', file=b'foo')
+        self.folder.addDTMLMethod('doc', file='foo')
         # _p_oids are None until we create a savepoint
         self.assertEqual(self.folder._p_oid, None)
         transaction.savepoint(optimistic=True)
@@ -96,7 +96,7 @@ class TestImportExport(ZopeTestCase.ZopeTestCase):
 
     def afterSetUp(self):
         self.setupLocalEnvironment()
-        self.folder.addDTMLMethod('doc', file=b'foo')
+        self.folder.addDTMLMethod('doc', file='foo')
         # _p_oids are None until we create a savepoint
         self.assertEqual(self.folder._p_oid, None)
         transaction.savepoint(optimistic=True)

--- a/src/Testing/ZopeTestCase/zopedoctest/functional.py
+++ b/src/Testing/ZopeTestCase/zopedoctest/functional.py
@@ -93,8 +93,8 @@ class DocResponseWrapper(ResponseWrapper):
         self.header_output = header_output
 
 
-basicre = re.compile('Basic (.+)?:(.+)?$')
-headerre = re.compile('(\S+): (.+)$')
+basicre = re.compile(r'Basic (.+)?:(.+)?$')
+headerre = re.compile(r'(\S+): (.+)$')
 
 
 def split_header(header):

--- a/src/Testing/ZopeTestCase/zopedoctest/testFunctionalDocTest.py
+++ b/src/Testing/ZopeTestCase/zopedoctest/testFunctionalDocTest.py
@@ -89,7 +89,7 @@ class HTTPHeaderOutputTests(unittest.TestCase):
 
 
 SHOW_COOKIES_DTML = '''\
-<dtml-in "list(REQUEST.cookies.keys())">
+<dtml-in "REQUEST.cookies.keys()">
 <dtml-var sequence-item>: <dtml-var "REQUEST.cookies[_['sequence-item']]">
 </dtml-in>'''
 

--- a/src/Testing/tests/test_testbrowser.py
+++ b/src/Testing/tests/test_testbrowser.py
@@ -54,7 +54,7 @@ class TestTestbrowser(FunctionalTestCase):
     def test_auth(self):
         # Based on Testing.ZopeTestCase.testFunctional
         basic_auth = '%s:%s' % (user_name, user_password)
-        self.folder.addDTMLDocument('secret_html', file=b'secret')
+        self.folder.addDTMLDocument('secret_html', file='secret')
         self.folder.secret_html.manage_permission(view, ['Owner'])
         path = '/' + self.folder.absolute_url(1) + '/secret_html'
 
@@ -63,7 +63,7 @@ class TestTestbrowser(FunctionalTestCase):
         self.assertEqual(response.getStatus(), 401)
         response = self.publish(path + '/secret_html', basic_auth)
         self.assertEqual(response.getStatus(), 200)
-        self.assertEqual(response.getBody(), 'secret')
+        self.assertEqual(response.getBody(), b'secret')
 
         # Test browser
         url = 'http://localhost' + path

--- a/src/ZPublisher/BaseResponse.py
+++ b/src/ZPublisher/BaseResponse.py
@@ -21,6 +21,7 @@ from zExceptions import Unauthorized, Forbidden, NotFound, BadRequest
 class BaseResponse(object):
     """Base Response Class
     """
+    body = b''
     debug_mode = None
     _auth = None
     _error_format = 'text/plain'
@@ -98,7 +99,7 @@ class BaseResponse(object):
         return self.headers[name]
 
     def getBody(self):
-        'Returns a string representing the currently set body. '
+        'Returns bytes representing the currently set body. '
         return self.body
 
     def __bytes__(self):
@@ -128,6 +129,8 @@ class BaseResponse(object):
         Note that published objects must not generate any errors
         after beginning stream-oriented output.
         """
+        if isinstance(data, text_type):
+            raise ValueError('Data must be binary.')
         self.body = self.body + data
 
     def exception(self, fatal=0, info=None):

--- a/src/ZPublisher/HTTPRangeSupport.py
+++ b/src/ZPublisher/HTTPRangeSupport.py
@@ -23,7 +23,7 @@ import re
 import sys
 from zope.interface import Interface
 
-WHITESPACE = re.compile('\s*', re.MULTILINE)
+WHITESPACE = re.compile(r'\s*', re.MULTILINE)
 
 
 def parseRange(header):

--- a/src/ZPublisher/HTTPRequest.py
+++ b/src/ZPublisher/HTTPRequest.py
@@ -184,6 +184,7 @@ class HTTPRequest(BaseRequest):
     _file = None
     _urls = ()
 
+    charset = default_encoding
     retry_max_count = 0
 
     def supports_retry(self):

--- a/src/ZPublisher/HTTPResponse.py
+++ b/src/ZPublisher/HTTPResponse.py
@@ -501,7 +501,7 @@ class HTTPBaseResponse(BaseResponse):
             self.notFoundError(body[1:-1].decode(self.charset))
         else:
             if title:
-                title = str(title)
+                title = text_type(title)
                 if not is_error:
                     self.body = body = self._html(
                         title, body.decode(self.charset)).encode(self.charset)
@@ -893,15 +893,15 @@ class HTTPResponse(HTTPBaseResponse):
         if isinstance(b, Exception):
             try:
                 try:
-                    b = str(b)
-                except UnicodeEncodeError:
-                    b = self._encode_unicode(text_type(b))
+                    b = text_type(b)
+                except UnicodeDecodeError:
+                    b = self._encode_unicode(text_type(b)).decode(self.charset)
             except Exception:
                 b = '<unprintable %s object>' % type(b).__name__
 
         if fatal and t is SystemExit and v.code == 0:
             body = self.setBody(
-                (str(t),
+                (text_type(t),
                  'Zope has exited normally.<p>' +
                  self._traceback(t, v, tb) + '</p>'),
                 is_error=True)
@@ -910,9 +910,10 @@ class HTTPResponse(HTTPBaseResponse):
                 match = tag_search(b)
             except TypeError:
                 match = None
+
             if match is None:
                 body = self.setBody(
-                    (str(t),
+                    (text_type(t),
                      'Sorry, a site error occurred.<p>' +
                      self._traceback(t, v, tb) + '</p>'),
                     is_error=True)
@@ -925,7 +926,8 @@ class HTTPResponse(HTTPBaseResponse):
                     body = self.setBody(b, is_error=True)
             else:
                 body = self.setBody(
-                    (str(t), b + self._traceback(t, '(see above)', tb, 0)),
+                    (text_type(t),
+                     b + self._traceback(t, '(see above)', tb, 0)),
                     is_error=True)
         del tb
         return body

--- a/src/ZPublisher/tests/test_hooks.py
+++ b/src/ZPublisher/tests/test_hooks.py
@@ -30,7 +30,7 @@ class TestHooks(unittest.TestCase):
         set_(event)
 
         from zope.globalrequest import getRequest
-        self.assertEquals(getRequest(), event.request)
+        self.assertEqual(getRequest(), event.request)
 
     def test_clear(self):
 
@@ -49,4 +49,4 @@ class TestHooks(unittest.TestCase):
         clear(event)
 
         from zope.globalrequest import getRequest
-        self.assertEquals(getRequest(), None)
+        self.assertEqual(getRequest(), None)

--- a/src/ZPublisher/tests/test_mapply.py
+++ b/src/ZPublisher/tests/test_mapply.py
@@ -54,15 +54,28 @@ class MapplyTests(unittest.TestCase):
         v = mapply(cc.compute, (), values)
         self.assertEqual(v, '334')
 
-        if PY2:
-            # Testing old-style class behavior.
-            class c2:
-                """Must be a classic class."""
+    @unittest.skipUnless(PY2, 'Testing old-style class.')
+    def testOldStyleClass(self):
+        # Testing old-style class behavior.
+        values = {'a': 2, 'b': 3, 'c': 5}
 
-            c2inst = c2()
-            c2inst.__call__ = cc
-            v = mapply(c2inst, (), values)
-            self.assertEqual(v, '334')
+        class c(object):
+            a = 3
+
+            def __call__(self, b, c=4):
+                return '%d%d%d' % (self.a, b, c)
+
+            compute = __call__
+
+        cc = c()
+
+        class c2:
+            """Must be a classic class."""
+
+        c2inst = c2()
+        c2inst.__call__ = cc
+        v = mapply(c2inst, (), values)
+        self.assertEqual(v, '335')
 
     def testObjectWithCall(self):
         # Make sure that the __call__ of an object can also be another

--- a/src/ZPublisher/tests/test_mapply.py
+++ b/src/ZPublisher/tests/test_mapply.py
@@ -13,8 +13,11 @@
 ##############################################################################
 
 import unittest
-import ExtensionClass
+
 import Acquisition
+import ExtensionClass
+from six import PY2
+
 from ZPublisher.mapply import mapply
 
 
@@ -51,13 +54,15 @@ class MapplyTests(unittest.TestCase):
         v = mapply(cc.compute, (), values)
         self.assertEqual(v, '334')
 
-        class c2:
-            """Must be a classic class."""
+        if PY2:
+            # Testing old-style class behavior.
+            class c2:
+                """Must be a classic class."""
 
-        c2inst = c2()
-        c2inst.__call__ = cc
-        v = mapply(c2inst, (), values)
-        self.assertEqual(v, '334')
+            c2inst = c2()
+            c2inst.__call__ = cc
+            v = mapply(c2inst, (), values)
+            self.assertEqual(v, '334')
 
     def testObjectWithCall(self):
         # Make sure that the __call__ of an object can also be another

--- a/src/ZPublisher/tests/test_utils.py
+++ b/src/ZPublisher/tests/test_utils.py
@@ -15,6 +15,8 @@
 
 import unittest
 
+from six import PY2
+
 
 class SafeUnicodeTests(unittest.TestCase):
 
@@ -33,5 +35,8 @@ class SafeUnicodeTests(unittest.TestCase):
         self.assertEqual(self._makeOne(u'foö'), u'foö')
 
     def test_utf_8(self):
-        self.assertEqual(self._makeOne('test\xc2\xae'), u'test\xae')
+        if PY2:
+            self.assertEqual(self._makeOne('test\xc2\xae'), u'test\xae')
+        else:
+            self.assertEqual(self._makeOne('test\xc2\xae'), u'test\xc2\xae')
         self.assertEqual(self._makeOne(b'test\xc2\xae'), u'test\xae')

--- a/src/ZPublisher/utils.py
+++ b/src/ZPublisher/utils.py
@@ -13,15 +13,12 @@
 
 import base64
 import logging
-import sys
 
 from Acquisition import aq_inner, aq_parent
 from six import PY3
+from six import binary_type
+from six import text_type
 import transaction
-
-if sys.version_info >= (3, ):
-    basestring = (bytes, str)
-    unicode = str
 
 AC_LOGGER = logging.getLogger('event.AccessControl')
 
@@ -74,11 +71,11 @@ def recordMetaData(object, request):
 
 
 def safe_unicode(value):
-    if isinstance(value, unicode):
+    if isinstance(value, text_type):
         return value
-    elif isinstance(value, basestring):
+    elif isinstance(value, binary_type):
         try:
-            value = unicode(value, 'utf-8')
+            value = text_type(value, 'utf-8')
         except UnicodeDecodeError:
             value = value.decode('utf-8', 'replace')
     return value

--- a/src/Zope2/Startup/datatypes.py
+++ b/src/Zope2/Startup/datatypes.py
@@ -206,7 +206,9 @@ def default_zpublisher_encoding(value):
     from ZPublisher import Converters, HTTPRequest, HTTPResponse
     Converters.default_encoding = value
     HTTPRequest.default_encoding = value
+    HTTPRequest.HTTPRequest.charset = value
     HTTPResponse.default_encoding = value
+    HTTPResponse.HTTPBaseResponse.charset = value
     return value
 
 


### PR DESCRIPTION
This includes a larger refactoring of the HTTP response to get a semblance of order into it. It constantly moves its body back and forth between bytes and text and needs one or the other to guess the content type, modify the body in place or do compression.

The tests currently all pass, and I introduced a new `charset` attribute, which gets set to the zpublisher default encoding and gets modified when someone calls setHeader content-type with a charset value, incl. specifying a charset in the initial header set. A new `text` get/set property allows one to read or write the body according to this charset.

I hope those additions help when fixing other issues. I did delete a workaround for special casing certain characters in latin-1, as that looked like a Netscape 2 / IE 4 type of workaround and was hard to keep without another set of text/bytes roundtripping and charset guessing.

Tests: Total: 1116 tests, 12 failures, 8 errors and 1 skipped in 9.615 seconds.

I'm holding off on a release, as we are sooo close to have all tests passing, and currently I still have to do fixes in AccessControl, DocumentTemplate or zExceptions all the time.

The largest chunk of the test failures are now related to request parsing and processInputs.