### PR TITLE
Py3 once more

### DIFF
--- a/src/Products/Five/browser/metaconfigure.py
+++ b/src/Products/Five/browser/metaconfigure.py
@@ -75,7 +75,6 @@ def _configure_z2security(_context, new_class, required):
             args=(new_class, attr, permission)
         )
     # Make everything else private
-    # if not _context:
     private_attrs = [name for name in dir(new_class)
                      if ((not name.startswith('_')) and
                          (name not in required) and

--- a/src/Products/Five/browser/metaconfigure.py
+++ b/src/Products/Five/browser/metaconfigure.py
@@ -19,6 +19,7 @@ namespace in ZCML known from zope.app.
 
 import os
 import sys
+from inspect import isfunction
 from inspect import ismethod
 
 from zope.component import queryMultiAdapter
@@ -56,6 +57,11 @@ from Products.Five.browser.resource import DirectoryResourceFactory
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 
 
+def is_method(func):
+    # Under Python 3, there are no unbound methods
+    return isfunction(func) or ismethod(func)
+
+
 def _configure_z2security(_context, new_class, required):
     _context.action(
         discriminator=('five:protectClass', new_class),
@@ -69,10 +75,11 @@ def _configure_z2security(_context, new_class, required):
             args=(new_class, attr, permission)
         )
     # Make everything else private
+    # if not _context:
     private_attrs = [name for name in dir(new_class)
                      if ((not name.startswith('_')) and
                          (name not in required) and
-                         ismethod(getattr(new_class, name)))]
+                         is_method(getattr(new_class, name)))]
     for attr in private_attrs:
         _context.action(
             discriminator=('five:protectName', new_class, attr),

--- a/src/ZPublisher/Converters.py
+++ b/src/ZPublisher/Converters.py
@@ -38,6 +38,16 @@ def field2string(v):
         return str(v)
 
 
+def field2bytes(v):
+    # Converts value to bytes.
+    if hasattr(v, 'read'):
+        return v.read()
+    elif isinstance(v, text_type):
+        return v.encode(default_encoding)
+    else:
+        return bytes(v)
+
+
 def field2text(value, nl=re.compile('\r\n|\n\r').search):
     value = field2string(value)
     match_object = nl(value)
@@ -212,11 +222,13 @@ class field2ulines:
 
 field2ulines = field2ulines()
 
+
 type_converters = {
     'float': field2float,
     'int': field2int,
     'long': field2long,
     'string': field2string,  # to native str
+    'bytes': field2bytes,
     'date': field2date,
     'date_international': field2date_international,
     'required': field2required,

--- a/src/ZPublisher/HTTPRequest.py
+++ b/src/ZPublisher/HTTPRequest.py
@@ -1206,9 +1206,8 @@ class HTTPRequest(BaseRequest):
             object = req.traverse(path)
         except Exception as exc:
             rsp.exception()
-            if object is None:
-                req.clear()
-                raise exc.__class__(rsp.errmsg)
+            req.clear()
+            raise exc.__class__(rsp.errmsg)
 
         # The traversal machinery may return a "default object"
         # like an index_html document. This is not appropriate

--- a/src/ZPublisher/HTTPRequest.py
+++ b/src/ZPublisher/HTTPRequest.py
@@ -23,7 +23,6 @@ from os import unlink
 from os.path import isfile
 import random
 import re
-import sys
 from tempfile import (
     mkstemp,
     _TemporaryFileWrapper,
@@ -34,6 +33,7 @@ from AccessControl.tainted import TaintedString
 import pkg_resources
 from six import binary_type
 from six import PY3
+from six import string_types
 from six import text_type
 from six.moves.urllib.parse import unquote
 from zope.i18n.interfaces import IUserPreferredLanguages
@@ -107,6 +107,8 @@ default_port = {'http': '80', 'https': '443'}
 
 tainting_env = str(os.environ.get('ZOPE_DTML_REQUEST_AUTOQUOTE', '')).lower()
 TAINTING_ENABLED = tainting_env not in ('disabled', '0', 'no')
+
+search_type = re.compile(r'(:[a-zA-Z][-a-zA-Z0-9_]+|\\.[xy])$').search
 
 _marker = []
 
@@ -239,7 +241,7 @@ class HTTPRequest(BaseRequest):
     def setVirtualRoot(self, path, hard=0):
         """ Treat the current publishing object as a VirtualRoot """
         other = self.other
-        if isinstance(path, str) or isinstance(path, text_type):
+        if isinstance(path, string_types):
             path = path.split('/')
         self._script[:] = list(map(quote, [_p for _p in path if _p]))
         del self._steps[:]
@@ -258,7 +260,7 @@ class HTTPRequest(BaseRequest):
 
     def physicalPathToVirtualPath(self, path):
         """ Remove the path to the VirtualRoot from a physical path """
-        if isinstance(path, str):
+        if isinstance(path, string_types):
             path = path.split('/')
         rpp = self.other.get('VirtualRootPhysicalPath', ('',))
         i = 0
@@ -482,9 +484,7 @@ class HTTPRequest(BaseRequest):
             CONVERTED=32,
             hasattr=hasattr,
             getattr=getattr,
-            setattr=setattr,
-            search_type=re.compile(
-                '(:[a-zA-Z][-a-zA-Z0-9_]+|\\.[xy])$').search):
+            setattr=setattr):
         """Process request inputs
 
         We need to delay input parsing so that it is done under
@@ -1204,11 +1204,11 @@ class HTTPRequest(BaseRequest):
         # method is called on the response).
         try:
             object = req.traverse(path)
-        except Exception:
+        except Exception as exc:
             rsp.exception()
-        if object is None:
-            req.clear()
-            raise sys.exc_info()[0](rsp.errmsg)
+            if object is None:
+                req.clear()
+                raise exc.__class__(rsp.errmsg)
 
         # The traversal machinery may return a "default object"
         # like an index_html document. This is not appropriate
@@ -1836,6 +1836,6 @@ def _decode(value, charset):
         return tuple(_decode(v, charset) for v in value)
     elif isinstance(value, dict):
         return dict((k, _decode(v, charset)) for k, v in value.items())
-    elif isinstance(value, str):
+    elif isinstance(value, binary_type):
         return text_type(value, charset, 'replace')
     return value

--- a/src/ZPublisher/httpexceptions.py
+++ b/src/ZPublisher/httpexceptions.py
@@ -20,8 +20,12 @@ from zExceptions import (
 
 class HTTPExceptionHandler(object):
 
-    def __init__(self, application):
+    def __init__(self, application, global_conf=None):
         self.application = application
+        debug_mode = False
+        if global_conf is not None:
+            debug_mode = global_conf.get('debug_mode', 'false') == 'true'
+        self.debug_mode = debug_mode
 
     def __call__(self, environ, start_response):
         environ['Zope2.httpexceptions'] = self
@@ -30,6 +34,10 @@ class HTTPExceptionHandler(object):
         except HTTPException as exc:
             return exc(environ, start_response)
         except Exception as exc:
+            if self.debug_mode:
+                # In debug mode, let the web server log a real
+                # traceback
+                raise
             return self.catch_all_response(exc)(environ, start_response)
 
     def catch_all_response(self, exc):
@@ -39,4 +47,4 @@ class HTTPExceptionHandler(object):
 
 
 def main(app, global_conf=None):
-    return HTTPExceptionHandler(app)
+    return HTTPExceptionHandler(app, global_conf=global_conf)

--- a/src/ZPublisher/tests/test_Converters.py
+++ b/src/ZPublisher/tests/test_Converters.py
@@ -11,11 +11,9 @@
 #
 ##############################################################################
 
-import sys
 import unittest
 
-if sys.version_info >= (3, ):
-    unicode = str
+from six import text_type
 
 
 class ConvertersTests(unittest.TestCase):
@@ -28,8 +26,8 @@ class ConvertersTests(unittest.TestCase):
     def test_field2string_with_unicode_default_encoding(self):
         from ZPublisher.Converters import field2string
         to_convert = u'to_convert'
-        self.assertEqual(field2string(to_convert),
-                         to_convert.encode('utf-8'))
+        expected = 'to_convert'
+        self.assertEqual(field2string(to_convert), expected)
 
     def test_field2string_with_filelike_object(self):
         from ZPublisher.Converters import field2string
@@ -39,6 +37,17 @@ class ConvertersTests(unittest.TestCase):
             def read(self):
                 return to_convert
         self.assertEqual(field2string(Filelike()), to_convert)
+
+    def test_field2bytes_with_bytes(self):
+        from ZPublisher.Converters import field2bytes
+        to_convert = b'to_convert'
+        self.assertEqual(field2bytes(to_convert), to_convert)
+
+    def test_field2bytes_with_text(self):
+        from ZPublisher.Converters import field2bytes
+        to_convert = u'to_convert'
+        expected = b'to_convert'
+        self.assertEqual(field2bytes(to_convert), expected)
 
     def test_field2lines_with_list(self):
         from ZPublisher.Converters import field2lines
@@ -69,13 +78,13 @@ class ConvertersTests(unittest.TestCase):
         from ZPublisher.Converters import field2ulines
         to_convert = [u'one', 'two']
         self.assertEqual(field2ulines(to_convert),
-                         [unicode(x) for x in to_convert])
+                         [text_type(x) for x in to_convert])
 
     def test_field2ulines_with_tuple(self):
         from ZPublisher.Converters import field2ulines
         to_convert = (u'one', 'two')
         self.assertEqual(field2ulines(to_convert),
-                         [unicode(x) for x in to_convert])
+                         [text_type(x) for x in to_convert])
 
     def test_field2ulines_with_empty_string(self):
         from ZPublisher.Converters import field2ulines

--- a/src/ZTUtils/tests/testZope.py
+++ b/src/ZTUtils/tests/testZope.py
@@ -1,6 +1,7 @@
 import unittest
 
 from DateTime import DateTime
+from six import PY2
 from six.moves.urllib.parse import quote
 
 from ZTUtils.Zope import (
@@ -29,17 +30,26 @@ class QueryTests(unittest.TestCase):
         self.assertEqual(simple_marshal(DateTime()), ":date")
 
     def testMarshalUnicode(self):
-        self.assertEqual(simple_marshal(u'unic\xF3de'), ":utf8:ustring")
+        if PY2:
+            arg_type = ':utf8:ustring'
+        else:
+            arg_type = ''
+        self.assertEqual(simple_marshal(u'unic\xF3de'), arg_type)
 
     def testMarshallLists(self):
         '''Test marshalling lists'''
         test_date = DateTime()
         list_ = [1, test_date, 'str', u'unic\xF3de']
         result = complex_marshal([('list', list_), ])
-        assert result == [('list', ':int:list', 1),
+        if PY2:
+            arg4_type = ':utf8:ustring:list'
+        else:
+            arg4_type = ':list'
+        self.assertEqual(result,
+                         [('list', ':int:list', 1),
                           ('list', ':date:list', test_date),
                           ('list', ':list', 'str'),
-                          ('list', ':utf8:ustring:list', u'unic\xF3de')]
+                          ('list', arg4_type, u'unic\xF3de')])
 
     def testMarshallRecords(self):
         '''Test marshalling records'''
@@ -49,24 +59,32 @@ class QueryTests(unittest.TestCase):
             'arg3': 'str', 'arg4': u'unic\xF3de',
         }
         result = complex_marshal([('record', record), ])
+        if PY2:
+            arg4_type = ':utf8:ustring:record'
+        else:
+            arg4_type = ':record'
         self.assertEqual(
             set(result),
             set([('record.arg1', ':int:record', 1),
                  ('record.arg2', ':date:record', test_date),
                  ('record.arg3', ':record', 'str'),
-                 ('record.arg4', ':utf8:ustring:record', u'unic\xF3de')]))
+                 ('record.arg4', arg4_type, u'unic\xF3de')]))
 
     def testMarshallListsInRecords(self):
         '''Test marshalling lists inside of records'''
         test_date = DateTime()
         record = {'arg1': [1, test_date, 'str', u'unic\xF3de'], 'arg2': 1}
         result = complex_marshal([('record', record), ])
+        if PY2:
+            arg1_type = ':utf8:ustring:list:record'
+        else:
+            arg1_type = ':list:record'
         self.assertEqual(
             set(result),
             set([('record.arg1', ':int:list:record', 1),
                  ('record.arg1', ':date:list:record', test_date),
                  ('record.arg1', ':list:record', 'str'),
-                 ('record.arg1', ':utf8:ustring:list:record', u'unic\xF3de'),
+                 ('record.arg1', arg1_type, u'unic\xF3de'),
                  ('record.arg2', ':int:record', 1)]))
 
     def testMakeComplexQuery(self):
@@ -100,7 +118,11 @@ class QueryTests(unittest.TestCase):
            https://github.com/zopefoundation/Zope/issues/15
         '''
         query = make_query(search_text=u'unic\xF3de')
-        self.assertEqual('search_text:utf8:ustring=unic%C3%B3de', query)
+        if PY2:
+            arg_type = 'search_text:utf8:ustring='
+        else:
+            arg_type = 'search_text='
+        self.assertEqual(arg_type + 'unic%C3%B3de', query)
 
     def testMakeHiddenInput(self):
         tag = make_hidden_input(foo='bar')


### PR DESCRIPTION
Some of these fixes feel icky to me. They are a result of treating the field2string (str) type converter / property to always mean native str. I think that makes sense, but results in those version dependent test expectations.

Tests: Total: 1120 tests, 2 failures, 6 errors and 2 skipped in 9.273 seconds.

P.S. Special thanks goes to that metaconfigure.py ismethod fix. Took me ages to find it :(