### PR TITLE
Keep buildout artifacts in tox env dir.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ install:
     - pip install -U setuptools==`grep setuptools versions.cfg | awk '{print $3}'`
     - pip install zc.buildout
     - buildout bootstrap
-    - buildout tox:env=travis install test alltests
+    - buildout install test alltests
 script:
-    - bin/alltests-travis -v
+    - bin/alltests -v
 notifications:
     email: false
 cache:

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -6,7 +6,7 @@ develop = .
 extends =
     sources.cfg
     versions.cfg
-installed = .installed-${tox:env}.cfg
+installed = .installed.cfg
 parts =
     test
     zopescripts
@@ -25,13 +25,9 @@ auto-checkout =
     Products.ZCatalog
 
 
-[tox]
-env = py27
-
-
 [test]
 recipe = zc.recipe.testrunner
-script = test-${tox:env}
+script = test
 initialization =
     import sys
     import warnings
@@ -59,7 +55,7 @@ eggs = Zope2
 
 [alltests]
 recipe = zc.recipe.testrunner
-script = alltests-${tox:env}
+script = alltests
 eggs =
     AccessControl
     Acquisition
@@ -81,7 +77,7 @@ eggs =
 
 [ztktests]
 recipe = zc.recipe.testrunner
-script = ztktests-${tox:env}
+script = ztktests
 eggs =
     zope.annotation
     zope.browser

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,10 @@ envlist = py27,py34,py35,py36
 
 [testenv]
 commands =
-    {envbindir}/buildout -c {toxinidir}/buildout.cfg tox:env={envname} bootstrap
-    {envbindir}/buildout -c {toxinidir}/buildout.cfg tox:env={envname} install test alltests
-    {toxinidir}/bin/alltests-{envname}
+    {envbindir}/buildout -c {toxinidir}/buildout.cfg buildout:directory={envdir} buildout:develop={toxinidir} bootstrap
+    {envbindir}/buildout -c {toxinidir}/buildout.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test alltests
+    {envbindir}/alltests
 skip_install = true
 deps =
+    setuptools==33.1.1
     zc.buildout


### PR DESCRIPTION
@hannosch This is the solution I was actually hoping to find in Halle:  I added the `buildout:develop={toxinidir}` line which keeps all the buildouts in the tox environment directories.