### PR TITLE
Start testing five.localsitemanager.

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -67,6 +67,7 @@ eggs =
     zExceptions
     Zope2
 # Test optional dependencies.
+    five.localsitemanager
     Missing
     Products.BTreeFolder2
 # Exclude not yet ported MailHost

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -25,6 +25,7 @@ ZEO==5.1
 ZODB==5.2.3
 ZServer==4.0a2
 five.globalrequest==1.0
+five.localsitemanager==3.0.1
 funcsigs==1.0.2
 mock==2.0.0
 pbr==3.0.0

--- a/sources.cfg
+++ b/sources.cfg
@@ -17,6 +17,7 @@ zExceptions = git ${remotes:github}/zExceptions pushurl=${remotes:github_push}/z
 zope.globalrequest = git ${remotes:github}/zope.globalrequest pushurl=${remotes:github_push}/zope.globalrequest
 
 # Optional dependencies
+five.localsitemanager = git ${remotes:github}/five.localsitemanager pushurl=${remotes:github_push}/five.localsitemanager
 Missing = git ${remotes:github}/Missing pushurl=${remotes:github_push}/Missing
 Products.BTreeFolder2 = git ${remotes:github}/Products.BTreeFolder2 pushurl=${remotes:github_push}/Products.BTreeFolder2
 Products.MailHost = git ${remotes:github}/Products.MailHost pushurl=${remotes:github_push}/Products.MailHost

--- a/versions-prod.cfg
+++ b/versions-prod.cfg
@@ -11,6 +11,7 @@ DateTime = 4.2
 DocumentTemplate = 3.0a3
 ExtensionClass = 4.3.0
 five.globalrequest = 1.0
+five.localsitemanager = 3.0.1
 funcsigs = 1.0.2
 mock = 2.0.0
 Missing = 4.0


### PR DESCRIPTION
This adds five.localsitemanager to the list of optional dependencies, which get tested with Zope2 and get a version pin.

I'd be open to adding more projects to the optional dependency list again, but don't have good criteria for what should and what shouldn't be tested by default. I'm thinking PAS might be another good candidate to include, as it is a wildly used low-level library. All of CMF is maybe a bit too big, but maybe all of CMFs dependencies might be a good idea.

My main goal is to make sure we don't break these additional libraries, when we make changes to Zope or update zope.* dependencies to new versions.