### PR TITLE
Add universal wheel marker.

### DIFF
--- a/docs/maintenance.rst
+++ b/docs/maintenance.rst
@@ -52,7 +52,7 @@ Steps for creating a new Zope release
 
 - Upload the tagged release to PyPI::
 
-    python2.7 setup.py egg_info -RDb '' sdist bdist_wheel register upload
+    python2.7 setup.py egg_info -RDb '' sdist bdist_wheel upload
 
 - Update version information:
 

--- a/docs/maintenance.rst
+++ b/docs/maintenance.rst
@@ -52,7 +52,7 @@ Steps for creating a new Zope release
 
 - Upload the tagged release to PyPI::
 
-    python2.7 setup.py egg_info -RDb '' sdist register upload
+    python2.7 setup.py egg_info -RDb '' sdist bdist_wheel register upload
 
 - Update version information:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
 [flake8]
 ignore = C901,N801,N802,N803,N805,N806,N812,E301
 exclude = bootstrap.py
+
+[bdist_wheel]
+universal = 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,6 @@ exclude = bootstrap.py
 
 [bdist_wheel]
 universal = 1
+
+[zest.releaser]
+create-wheel = yes


### PR DESCRIPTION
I'd like to start releasing wheels, at least for pure Python projects with universal code (Python 2 / 3 compatibility in one code base).

While buildout can only pick these up via an extension, I think it would be nice to start releasing them, so either those extension users or pip users can get their benefits.

Objections, thoughts?