### PR TITLE
Fix final Py3 test failure.

### DIFF
--- a/src/ZPublisher/HTTPRequest.py
+++ b/src/ZPublisher/HTTPRequest.py
@@ -1668,8 +1668,7 @@ class ZopeFieldStorage(FieldStorage):
     def __del__(self):
         # Only call close on file object, cStringIO/BytesIO objects
         # would be closed too early.
-        if (self.file is not None and
-                isinstance(self.file, TemporaryFileWrapper)):
+        if isinstance(self.file, TemporaryFileWrapper):
             self.file.close()
 
 

--- a/src/ZPublisher/tests/testHTTPRequest.py
+++ b/src/ZPublisher/tests/testHTTPRequest.py
@@ -749,7 +749,9 @@ class HTTPRequestTests(unittest.TestCase, HTTPRequestFactoryMixin):
         s = BytesIO(TEST_FILE_DATA)
         start_count = sys.getrefcount(s)
 
-        req = self._makeOne(stdin=s, environ=TEST_ENVIRON.copy())
+        environ = TEST_ENVIRON.copy()
+        environ['CONTENT_LENGTH'] = str(len(TEST_FILE_DATA))
+        req = self._makeOne(stdin=s, environ=environ)
         req.processInputs()
         self.assertNotEqual(start_count, sys.getrefcount(s))  # Precondition
         req.close()
@@ -759,7 +761,9 @@ class HTTPRequestTests(unittest.TestCase, HTTPRequestFactoryMixin):
         # checks fileupload object supports the filename
         s = BytesIO(TEST_LARGEFILE_DATA)
 
-        req = self._makeOne(stdin=s, environ=TEST_ENVIRON.copy())
+        environ = TEST_ENVIRON.copy()
+        environ['CONTENT_LENGTH'] = str(len(TEST_LARGEFILE_DATA))
+        req = self._makeOne(stdin=s, environ=environ)
         req.processInputs()
         f = req.form.get('largefile')
         self.assertTrue(f.name)
@@ -769,12 +773,14 @@ class HTTPRequestTests(unittest.TestCase, HTTPRequestFactoryMixin):
         # collector entry 1837
         s = BytesIO(TEST_FILE_DATA)
 
-        req = self._makeOne(stdin=s, environ=TEST_ENVIRON.copy())
+        environ = TEST_ENVIRON.copy()
+        environ['CONTENT_LENGTH'] = str(len(TEST_FILE_DATA))
+        req = self._makeOne(stdin=s, environ=environ)
         req.processInputs()
-        f = req.form.get('file')
-        self.assertEqual(list(f), ['test\n'])
+        f = req.form.get('smallfile')
+        self.assertEqual(list(f), [b'test\n'])
         f.seek(0)
-        self.assertEqual(next(f), 'test\n')
+        self.assertEqual(next(f), b'test\n')
 
     def test__authUserPW_simple(self):
         user_id = 'user'
@@ -1144,7 +1150,7 @@ TEST_ENVIRON = {
 
 TEST_FILE_DATA = b'''
 --12345
-Content-Disposition: form-data; name="file"; filename="file"
+Content-Disposition: form-data; name="smallfile"; filename="smallfile"
 Content-Type: application/octet-stream
 
 test


### PR DESCRIPTION
This is a combination of three fixes. The tests had to be adjusted, as the cgi module in Python 3 won't work without a content-length header anymore. This is a side-effect of python/cpython@5c23b8e6ea7cdb0002842d16dbce4b4d716dd35a. Without the content length, the limit / read_bytes calculation is off, and we end up with three fieldstorage instances each with an empty byte, rather than one instance with a content of `test\n`.

The second part is a heavy handed workaround for closing the BytesIO instance underlying the FieldStorage too early. In Python 2.7, there wasn't a `__del__` defined yet. There's a good chance, a proper fix could also be related to http://bugs.python.org/issue23700 and http://bugs.python.org/issue18879, but I couldn't work out if something similar was indeed the issue here.

Finally the TemporaryFileWrapper no longer needs special closing/del logic under Python 3, as the implementation changed. There is no `close_called` attribute anymore, but rather a more complex `_closer` indirection.

I'm not particularly happy with the `__del__` part of this fix, but I couldn't come up with a better way. Any better ideas are more than welcome. I'm at my wits' end :(