### PR TITLE
Bring back some tabs on the ZMI

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -236,8 +236,6 @@ Restructuring
 
 - Move `Products.SiteAccess` into ZServer distribution.
 
-- Simplify Page Template and Scripts ZMI screens.
-
 - Change VHM id to `virtual_hosting` to match AppInitializer.
 
 - Raise BadRequest instead of returning MessageDialog.

--- a/src/OFS/DTMLMethod.py
+++ b/src/OFS/DTMLMethod.py
@@ -76,6 +76,7 @@ class DTMLMethod(RestrictedDTML,
 
     manage_options = ((
         {'label': 'Edit', 'action': 'manage_main'},
+        {'label': 'View', 'action': ''},
         {'label': 'Proxy', 'action': 'manage_proxyForm'},
     ) +
         RoleManager.manage_options +

--- a/src/OFS/Image.py
+++ b/src/OFS/Image.py
@@ -114,7 +114,10 @@ class File(Persistent, Implicit, PropertyManager,
     manage_uploadForm = manage_editForm
 
     manage_options = (
-        ({'label': 'Edit', 'action': 'manage_main'}, ) +
+        (
+            {'label': 'Edit', 'action': 'manage_main'},
+            {'label': 'View', 'action': ''},
+        ) +
         PropertyManager.manage_options +
         RoleManager.manage_options +
         Item_w__name__.manage_options +
@@ -824,7 +827,8 @@ class Image(File):
     )
 
     manage_options = (
-        ({'label': 'Edit', 'action': 'manage_main'}, ) +
+        ({'label': 'Edit', 'action': 'manage_main'},
+         {'label': 'View', 'action': 'view_image_or_file'}) +
         RoleManager.manage_options +
         Item_w__name__.manage_options +
         Cacheable.manage_options

--- a/src/Products/PageTemplates/ZopePageTemplate.py
+++ b/src/Products/PageTemplates/ZopePageTemplate.py
@@ -86,6 +86,7 @@ class ZopePageTemplate(Script, PageTemplate, Cacheable,
 
     manage_options = (
         {'label': 'Edit', 'action': 'pt_editForm'},
+        {'label': 'Test', 'action': 'ZScriptHTML_tryForm'},
     ) + PropertyManager.manage_options + \
         SimpleItem.manage_options + \
         Cacheable.manage_options
@@ -102,6 +103,8 @@ class ZopePageTemplate(Script, PageTemplate, Cacheable,
 
     # protect methods from base class(es)
     security.declareProtected(view, '__call__')
+    security.declareProtected(view_management_screens,
+                              'read', 'ZScriptHTML_tryForm')
 
     def __init__(self, id, text=None, content_type='text/html', strict=True,
                  output_encoding='utf-8'):
@@ -203,6 +206,10 @@ class ZopePageTemplate(Script, PageTemplate, Cacheable,
 
         self.pt_edit(text, content_type)
         return self.pt_editForm(manage_tabs_message='Saved changes')
+
+    def ZScriptHTML_tryParams(self):
+        """Parameters to test the script with."""
+        return []
 
     def pt_getContext(self, *args, **kw):
         root = None

--- a/src/Products/PageTemplates/www/ptEdit.zpt
+++ b/src/Products/PageTemplates/www/ptEdit.zpt
@@ -23,6 +23,19 @@
              tal:attributes="value request/content_type | context/content_type" />
     </td>
   </tr>
+  <tr>
+    <td align="left" valign="middle"></td>
+    <td align="left" valign="middle"></td>
+    <td align="left" valign="top" colspan="2">
+      <a href="source.html" tal:condition="context/html">Browse HTML source</a>
+      <a href="source.xml" tal:condition="not:context/html">Browse XML source</a>
+      <br />
+      <input type="hidden" name="expand:int:default" value="0" />
+      <input type="checkbox" value="1" name="expand:int"
+             tal:attributes="checked request/expand | context/expand" />
+      Expand macros when editing
+    </td>
+  </tr>
 
   <tr tal:define="errors context/pt_errors" tal:condition="errors">
     <td align="left" valign="middle" class="form-label">Errors</td>

--- a/src/Shared/DC/Scripts/BindingsUI.py
+++ b/src/Shared/DC/Scripts/BindingsUI.py
@@ -12,7 +12,9 @@
 ##############################################################################
 
 from AccessControl.class_init import InitializeClass
+from AccessControl.Permissions import view_management_screens
 from AccessControl.SecurityInfo import ClassSecurityInfo
+from App.special_dtml import DTMLFile
 from Shared.DC.Scripts.Bindings import Bindings
 
 
@@ -20,7 +22,13 @@ class BindingsUI(Bindings):
 
     security = ClassSecurityInfo()
 
-    manage_options = tuple()
+    manage_options = (
+        {'label': 'Bindings', 'action': 'ZBindingsHTML_editForm'},
+    )
+
+    security.declareProtected(view_management_screens,
+                              'ZBindingsHTML_editForm')
+    ZBindingsHTML_editForm = DTMLFile('dtml/scriptBindings', globals())
 
     security.declareProtected('Change bindings', 'ZBindingsHTML_editAction')
     def ZBindingsHTML_editAction(self, REQUEST):

--- a/src/Shared/DC/Scripts/Script.py
+++ b/src/Shared/DC/Scripts/Script.py
@@ -15,10 +15,15 @@
 This provides generic script support
 """
 
+from six.moves.urllib.parse import quote
+
 from AccessControl.class_init import InitializeClass
+from AccessControl.Permissions import view_management_screens
 from AccessControl.SecurityInfo import ClassSecurityInfo
+from App.special_dtml import DTMLFile
 from DocumentTemplate.DT_Util import TemplateDict
 from OFS.SimpleItem import SimpleItem
+from zExceptions import Redirect
 
 from Shared.DC.Scripts.BindingsUI import BindingsUI
 
@@ -37,6 +42,19 @@ class Script(SimpleItem, BindingsUI):
     __defaults__ = ()
 
     _Bindings_ns_class = TemplateDict
+
+    security.declareProtected(view_management_screens, 'ZScriptHTML_tryForm')
+    ZScriptHTML_tryForm = DTMLFile('dtml/scriptTry', globals())
+
+    def ZScriptHTML_tryAction(self, REQUEST, argvars):
+        """Apply the test parameters.
+        """
+        vv = []
+        for argvar in argvars:
+            if argvar.value:
+                vv.append("%s=%s" % (quote(argvar.name), quote(argvar.value)))
+        raise Redirect("%s?%s" % (REQUEST['URL1'], '&'.join(vv)))
+
     from .Signature import _setFuncSignature
 
 InitializeClass(Script)

--- a/src/Shared/DC/Scripts/dtml/scriptBindings.dtml
+++ b/src/Shared/DC/Scripts/dtml/scriptBindings.dtml
@@ -1,0 +1,136 @@
+<dtml-var manage_page_header>
+<dtml-var manage_tabs>
+
+<p class="form-help">
+Each of the following items describes a piece of information about 
+this script's calling environment.  If you supply a variable name for 
+an item, or accept the recommended name, the information will 
+automatically be provided under that name when the script is called.
+</p>
+
+<form action="ZBindingsHTML_editAction" method="POST">
+
+<dtml-with getBindingAssignments>
+<table cellpadding="2" cellspacing="0" border="0">
+<tr class="section-bar">
+  <td align="left" valign="top" colspan="2">
+  <div class="form-label">
+  Context
+  </div>
+  </td>
+</tr>
+<tr>
+  <td align="left" valign="top">
+  <div class="form-text">
+  This is the object on which the script is being called, also known as the
+  &quot;acquisition parent&quot; of the script.  This <em>may</em> be the 
+  container, but varies according to the path through which the script is 
+  accessed.
+  <br /><br />
+  Recommended value: <code>context</code>
+  </div>
+  </td>
+  <td align="left" valign="top">
+  <input type="text" name="name_context" value="<dtml-var expr="getAssignedName('name_context', '')" html_quote>">
+  </td>
+</tr>
+
+<tr class="section-bar">
+  <td align="left" valign="top" colspan="2">
+  <div class="form-label">
+  Container
+  </div>
+  </td>
+</tr>
+<tr>
+  <td align="left" valign="top">
+  <div class="form-text">
+  This is the <dtml-with expr="aq_inner.aq_parent">&dtml-meta_type;
+  "&dtml.missing.html_quote-title_or_id;"</dtml-with>, in which this
+  script is located.  This doesn't change unless you move the script.
+  <br /><br />
+  Recommended value: <code>container</code>
+  </div>
+  </td>
+  <td align="left" valign="top">
+  <input type="text" name="name_container" value="<dtml-var expr="getAssignedName('name_container', '')" html_quote>">
+  </td>
+</tr>
+
+<tr class="section-bar">
+  <td align="left" valign="top" colspan="2">
+  <div class="form-label">
+  Script
+  </div>
+  </td>
+</tr>
+<tr>
+  <td align="left" valign="top">
+  <div class="form-text">
+  This is the script object &quot;&dtml-title_or_id;&quot; itself.
+  <br /><br />
+  Recommended value: <code>script</code>
+  </div>
+  </td>
+  <td align="left" valign="top">
+  <input type="text" name="name_m_self" value="<dtml-var expr="getAssignedName('name_m_self', '')" html_quote>">
+  </td>
+</tr>
+
+<tr class="section-bar">
+  <td align="left" valign="top" colspan="2">
+  <div class="form-label">
+  Namespace
+  </div>
+  </td>
+</tr>
+<tr>
+  <td align="left" valign="top">
+  <div class="form-text">
+  When the script is called from DTML, this is the caller's DTML namespace,
+  otherwise it is an empty namespace.
+  <br /><br />
+  Recommended value: <code>_</code> (underscore character)
+  </div>
+  </td>
+  <td align="left" valign="top">
+  <input type="text" name="name_ns" value="<dtml-var expr="getAssignedName('name_ns', '')" html_quote>">
+  </td>
+</tr>
+
+<tr class="section-bar">
+  <td align="left" valign="top" colspan="2">
+  <div class="form-label">
+  Subpath
+  </div>
+  </td>
+</tr>
+<tr>
+  <td align="left" valign="top">
+  <div class="form-text">
+  When the script is published directly from a URL, this is the
+  portion of the URL path after the script's name, split at slash separators
+  into a list of strings. Otherwise, it is an empty list.
+  <br /><br />
+  Recommended value: <code>traverse_subpath</code>
+  </div>
+  </td>
+  <td align="left" valign="top">
+  <input type="text" name="name_subpath" value="<dtml-var expr="getAssignedName('name_subpath', '')" html_quote>">
+  </td>
+</tr>
+
+<tr>
+  <td align="left" valign="top" colspan="2">
+  <div class="form-element">
+  <br />
+  <input class="form-element" type="submit" name="submit" 
+   value="Save Changes" /> 
+  </div>
+  </td>
+</tr>
+</table>
+</form>
+</dtml-with>
+
+<dtml-var manage_page_footer>

--- a/src/Shared/DC/Scripts/dtml/scriptTry.dtml
+++ b/src/Shared/DC/Scripts/dtml/scriptTry.dtml
@@ -1,0 +1,49 @@
+<dtml-var manage_page_header>
+<dtml-var manage_tabs>
+
+<p class="form-help">
+Enter variable values to pass to the script in the form below and 
+click <em>run script</em> to view the result of the call.
+</p>
+
+<form action="&dtml-URL1;/ZScriptHTML_tryAction" method="post">
+<table cellpadding="2" cellspacing="0" border="0">
+<tr class="list-header">
+  <td align="left" valign="top">
+  <div class="form-label">
+  Parameter
+  </div>
+  </td>
+  <td align="left" valign="top">
+  <div class="form-label">
+  Value
+  </div>
+  </td>
+</tr>
+
+<dtml-in ZScriptHTML_tryParams>
+<tr>
+  <td align="left" valign="top">
+  <input name="argvars.name:records" type="text" 
+     value="&dtml-sequence-item;">
+  </td>
+  <td align="left" valign="top">
+  <input name="argvars.value:records" type="text" value="">
+  </td>
+</tr>
+<dtml-else>
+  <dtml-raise type="Redirect"><dtml-var URL1></dtml-raise>
+</dtml-in>
+
+<tr>
+  <td align="left" valign="top" colspan="2">
+  <div class="form-element">
+  <input class="form-element" type="submit" name="submit" 
+   value="Run Script" /> 
+  </div>
+  </td>
+</tr>
+</table>
+</form>
+
+<dtml-var manage_page_footer>


### PR DESCRIPTION
This pull request brings back the following tabs on the ZMI

* Image - View
* File - View
* DTML Method - View
* DTML Document - View
* PageTemplate - Test
* PageTemplate - Bindings
* PythonScript - Test
* PythonScript - Bindings

It basically reverts these commits @hannosch  did a while ago.

https://github.com/zopefoundation/Zope/commit/735105dab061aec1d2405c99155670ff2951a468
https://github.com/zopefoundation/Zope/commit/18ef29ca220c8f3e920eef58c0594ab09e03801f

Plus a few adjustments to make it working under python3.

As noted in issue #147, there should be a way to test/view these objects via the ZMI.
I'm not quite sure why these tabs have been removed in the first place.
I don't see a big problem with the code itself and they also very useful in the way I
use the Zope.

However I'm pretty sure @hannosch  had good reasons to remove them.
So it would be nice to hear is opinion as well.
