### PR TITLE
Use a context manager to explicitly open/close the ZODB connection.

### DIFF
--- a/src/ZPublisher/tests/test_pubevents.py
+++ b/src/ZPublisher/tests/test_pubevents.py
@@ -159,8 +159,13 @@ def _succeed():
     return 'success'
 
 
+# Poor man's mock.
 class _Application(object):
-    pass
+    def __getattr__(self, name):
+        return self
+
+    def __call__(self, *args, **kwargs):
+        return self
 
 
 class _Reporter(object):


### PR DESCRIPTION
Hi,

this could be a fix for #103 to explicitly open/close the connection to ZODB/Zeo.

In theory the `__getattr__` and `__bobo_traverse__` methods could be removed from
the `ZApplicationWrapper`, because `WSGIPublisher` does not use them any more.

However there is the (deprecated ?) ZServer, which still relies on them. So I did not dare to remove these two methods.

The more tricky bit was to adjust the unittests to work with the changed behaviour of the publisher. I found no way around the monkey patch in `sandboxy.py`