### PR TITLE
Fix handling of multipart requests in functional doctests.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ https://zope.readthedocs.io/en/2.13/CHANGES.html
 Bugs Fixed
 ++++++++++
 
+- Allow handling of multipart requests in functional doctests using ``http``.
+
 
 Features Added
 ++++++++++++++

--- a/src/Testing/ZopeTestCase/zopedoctest/FunctionalDocTest.txt
+++ b/src/Testing/ZopeTestCase/zopedoctest/FunctionalDocTest.txt
@@ -163,3 +163,38 @@ Test reading cookies
 
   >>> b'baz: oki doki' in response.getBody()
   True
+
+Test parsing of multipart body with unicode
+
+  >>> ni_hao = '\xe4\xbd\xa0\xe5\xa5\xbd'  # utf-8 encoded
+  >>> response = http(r"""
+  ... GET /test_folder_1_/index_html/set_cookie HTTP/1.1
+  ... Authorization: %s:%s
+  ... Content-Type: multipart/form-data; boundary=---------------------------968064918930967154199105236
+  ... Content-Length: 418
+  ...
+  ... -----------------------------968064918930967154199105236
+  ... Content-Disposition: form-data; name="field.title"
+  ...
+  ... %s
+  ... -----------------------------968064918930967154199105236
+  ... Content-Disposition: form-data; name="field.description"
+  ...
+  ... Details
+  ... -----------------------------968064918930967154199105236
+  ... Content-Disposition: form-data; name="field.somenumber"
+  ...
+  ... 0
+  ... -----------------------------968064918930967154199105236
+  ... Content-Disposition: form-data; name="UPDATE_SUBMIT"
+  ...
+  ... Add
+  ... -----------------------------968064918930967154199105236
+  ... Content-Disposition: form-data; name="add_input_name"
+  ...
+  ... unicodetest
+  ... -----------------------------968064918930967154199105236--
+  ... """ % (user_name, user_password, ni_hao))
+
+  >>> response.status
+  200

--- a/src/Testing/ZopeTestCase/zopedoctest/functional.py
+++ b/src/Testing/ZopeTestCase/zopedoctest/functional.py
@@ -14,7 +14,7 @@
 """
 
 import doctest
-import email
+import email.parser
 from functools import partial
 from io import BytesIO
 import re
@@ -165,9 +165,15 @@ def http(request_string, handle_errors=True):
                    'bobo-exception-type', 'bobo-exception-file',
                    'bobo-exception-value', 'bobo-exception-line'))
 
-    msg = email.message_from_string(request_string)
+    # With a HeaderParser the payload is always a string, Parser would create a
+    # list of messages for multipart messages.
+    parser = email.parser.HeaderParser()
+    msg = parser.parsestr(request_string)
     headers = msg.items()
     body = msg.get_payload()
+
+    if isinstance(body, bytes):
+        body = body.decode('utf-8')
 
     # Store request body without headers
     instream = BytesIO(body.encode('utf-8'))


### PR DESCRIPTION
[Some tests](https://github.com/zopefoundation/five.formlib/blob/master/src/five/formlib/tests/forms.txt) in `five.formlib` pass a multipart message to the http helper function. When using the default parser in the `email` module, the payload of multipart messages are a list of messages instead of a string for non_multipart messages.   

This PR fixes that and ensures that the encoding is not failing with utf-8 encoded in the request body.  