### PR TITLE
Small speed-ups, avoid raising two exceptions during traversal.

### DIFF
--- a/src/OFS/Application.py
+++ b/src/OFS/Application.py
@@ -108,6 +108,11 @@ class Application(ApplicationDefaultPermissions, Folder.Folder, FindSupport):
     ZopeRedirect = Redirect
 
     def __bobo_traverse__(self, REQUEST, name=None):
+        if name is None:
+            # Make this more explicit, otherwise getattr(self, name)
+            # would raise a TypeErorr getattr(): attribute name must be string
+            return None
+
         if name == 'Control_Panel':
             return APP_MANAGER.__of__(self)
         try:

--- a/src/OFS/ObjectManager.py
+++ b/src/OFS/ObjectManager.py
@@ -790,11 +790,8 @@ class ObjectManager(CopyContainer,
             method = request.get('REQUEST_METHOD', 'GET')
             if (request.maybe_webdav_client and
                     method not in ('GET', 'POST')):
-                try:
+                if bbb.HAS_ZSERVER:
                     from webdav.NullResource import NullResource
-                except ImportError:
-                    pass
-                else:
                     return NullResource(self, key, request).__of__(self)
         raise KeyError(key)
 


### PR DESCRIPTION
This removes two exceptions and one import-lock from the normal traversal logic used in the WSGI publisher.

I did some unscientific benchmarks using `ab` with a database with just one page template called `index_html` with the default page template example content. Requests where done against ``http://127.0.0.1:8080/`` using a couple different concurrency settings.

Under Python 2.7 performance went up from ~500 requests/sec to ~800 requests/sec. Under Python 3.5 it went up from ~300 request/sec to ~700 requests/sec. Under Python 3.6 it went up from ~500 requests/sec to ~1000 requests/sec. That matches the general assumption that Python 3.6 is the first release with overall on-par or sometimes better performance compared to Python 2.7.

I think the main source here is avoiding the import lock and ImportError. The actual speedup is likely just a constant reduction of ~1ms per request. With the rest of the logic also taking ~1ms it just looks like a lot.