### PR TITLE
Abort the transaction before closing the connection.

### DIFF
--- a/src/ZPublisher/WSGIPublisher.py
+++ b/src/ZPublisher/WSGIPublisher.py
@@ -222,6 +222,7 @@ def load_app(module_info):
     try:
         yield (app, realm, debug_mode)
     finally:
+        transaction.abort()
         app._p_jar.close()
 
 


### PR DESCRIPTION
Before the rework to use a context manager the transaction was aborted directly
on the transaction manager. We still need to do this as an Unauthorized would
not be raised but lead to a `Cannot close a connection joined to a
transaction`.

This fixes a regression introduced by #155.