### PR TITLE
Make ApplicationManger persistent again.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ Bugs Fixed
 
 - Fix Content-Length header for non-ascii responses incl. a base tag.
 
+- Fix issue with ``Control_Panel`` on first startup of ZODB from Zope 2.13.
+
 
 Features Added
 ++++++++++++++

--- a/src/App/ApplicationManager.py
+++ b/src/App/ApplicationManager.py
@@ -25,6 +25,7 @@ from App.special_dtml import DTMLFile
 from App.Undo import UndoSupport
 from App.version_txt import version_txt
 from OFS.Traversable import Traversable
+from Persistence import Persistent
 from Products.PageTemplates.PageTemplateFile import PageTemplateFile
 
 
@@ -80,7 +81,7 @@ class DatabaseChooser(Tabs, Traversable, Implicit):
 InitializeClass(DatabaseChooser)
 
 
-class ApplicationManager(Tabs, Traversable, Implicit):
+class ApplicationManager(Persistent, Tabs, Traversable, Implicit):
     """System management
     """
     __allow_access_to_unprotected_subobjects__ = 1


### PR DESCRIPTION
This fixes #159.  A startup with an old ZODB from Zope 2.13 is now possible.