### PR TITLE
Avoid additional transaction abort, if the transaction is already closed

### DIFF
--- a/src/App/ZApplication.py
+++ b/src/App/ZApplication.py
@@ -42,6 +42,9 @@ class ZApplicationWrapper(object):
         return getattr(self._klass, name)
 
     def __bobo_traverse__(self, REQUEST=None, name=None):
+        # This is only called by ZServer.ZPublisher.Publish,
+        # as the app in the module_info is used directly.
+
         conn = self._db.open()
 
         # arrange for the connection to be closed when the request goes away
@@ -63,6 +66,9 @@ class ZApplicationWrapper(object):
         return v
 
     def __call__(self, connection=None):
+        # This is only called by ZPublisher.WSGIPublisher,
+        # as load_app calls the app object present in the module_info.
+
         db = self._db
         if connection is None:
             connection = db.open()

--- a/src/ZPublisher/WSGIPublisher.py
+++ b/src/ZPublisher/WSGIPublisher.py
@@ -217,7 +217,10 @@ def load_app(module_info):
     try:
         yield (app, realm, debug_mode)
     finally:
-        transaction.abort()
+        if transaction.manager._txn is not None:
+            # Only abort a transaction, if one exists. Otherwise the
+            # abort creates a new transaction just to abort it.
+            transaction.abort()
         app._p_jar.close()
 
 


### PR DESCRIPTION
This can happen if exceptions happen inside exception views or publication event handlers (e.g. PubFailure).

Refs #103, #168.