### PR TITLE
Add support for IPv6 addresses for the trusted-proxy zope.conf setting.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,11 @@ https://github.com/zopefoundation/Zope/blob/4.0a6/CHANGES.rst
 4.0b2 (unreleased)
 ------------------
 
+New features
+++++++++++++
+
+- Add support for IPv6 addresses for the trusted-proxy zope.conf setting.
+
 Bugfixes
 ++++++++
 

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -27,6 +27,7 @@ Zope2==4.0a6
 five.globalrequest==99.1
 five.localsitemanager==3.0.1
 funcsigs==1.0.2
+ipaddress==1.0.18
 mock==2.0.0
 pbr==3.1.1
 persistent==4.2.2

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ setup(
         'RestrictedPython',
         'ZConfig >= 2.9.2',
         'ZODB',
+        'ipaddress',
         'setuptools',
         'six',
         'transaction',

--- a/src/Zope2/Startup/starter.py
+++ b/src/Zope2/Startup/starter.py
@@ -14,13 +14,13 @@
 
 import logging
 import sys
-import re
-from socket import gethostbyaddr
 
 from six import PY2
 from ZConfig import ConfigurationError
 from zope.event import notify
 from zope.processlifetime import ProcessStarting
+
+from Zope2.Startup.handlers import _name_to_ips
 
 logger = logging.getLogger("Zope")
 
@@ -103,14 +103,3 @@ class WSGIStarter(object):
         # Import Zope
         import Zope2
         Zope2.startup_wsgi()
-
-
-def _name_to_ips(host, _is_ip=re.compile(r'(\d+\.){3}').match):
-    '''map a name *host* to the sequence of its ip addresses;
-    use *host* itself (as sequence) if it already is an ip address.
-    Thus, if only a specific interface on a host is trusted,
-    identify it by its ip (and not the host name).
-    '''
-    if _is_ip(host):
-        return [host]
-    return gethostbyaddr(host)[2]

--- a/src/Zope2/Startup/tests/test_handlers.py
+++ b/src/Zope2/Startup/tests/test_handlers.py
@@ -1,0 +1,41 @@
+##############################################################################
+#
+# Copyright (c) 2017 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+
+import unittest
+
+
+class TestNameToIPs(unittest.TestCase):
+
+    def _callFUT(self, host):
+        from Zope2.Startup.handlers import _name_to_ips
+        return _name_to_ips(host)
+
+    def test_ip4(self):
+        self.assertEqual(self._callFUT('127.0.0.1'), ['127.0.0.1'])
+        self.assertEqual(self._callFUT('8.8.8.8'), ['8.8.8.8'])
+
+    def test_ip6(self):
+        self.assertEqual(self._callFUT('::1'), ['::1'])
+        self.assertEqual(self._callFUT(
+            '0000:0000:0000:0000:0000:0abc:0007:0def'), ['::abc:7:def'])
+
+    def test_hostname(self):
+        hosts = self._callFUT('localhost')
+        self.assertTrue(hosts == ['127.0.0.1'] or hosts == ['::1'], hosts)
+
+    def test_encoding(self):
+        self.assertEqual(self._callFUT(
+            b'0000:0000:0000:0000:0000:0abc:0007:0def'), ['::abc:7:def'])
+        self.assertEqual(self._callFUT(
+            u'0000:0000:0000:0000:0000:0abc:0007:0def'), ['::abc:7:def'])

--- a/versions-prod.cfg
+++ b/versions-prod.cfg
@@ -14,6 +14,7 @@ ExtensionClass = 4.3.0
 five.globalrequest = 99.1
 five.localsitemanager = 3.0.1
 funcsigs = 1.0.2
+ipaddress = 1.0.18
 mock = 2.0.0
 Missing = 4.0.1
 MultiMapping = 4.0


### PR DESCRIPTION
This uses the ipaddress library (part of the stdlib in Python 3) instead of a regular expression.

The alternative would have been to use the regex from ZConfig (https://github.com/zopefoundation/ZConfig/blob/master/ZConfig/datatypes.py#L285), but that looked incomprehensible to me ;)