### PR TITLE
Fix install_product for products with a non-empty `misc_` attribute.

### DIFF
--- a/src/OFS/Application.py
+++ b/src/OFS/Application.py
@@ -393,7 +393,7 @@ def install_product(app, product_dir, product_name, meta_types,
     if misc_:
         if isinstance(misc_, dict):
             misc_ = Misc_(product_name, misc_)
-        Application.misc_.__dict__[product_name] = misc_
+        setattr(Application.misc_, product_name, misc_)
 
     productObject = FactoryDispatcher.Product(product_name)
     context = ProductContext(productObject, None, product)

--- a/src/OFS/tests/testAppInitializer.py
+++ b/src/OFS/tests/testAppInitializer.py
@@ -106,4 +106,4 @@ class TestInitialization(unittest.TestCase):
         self.configure(good_cfg)
         i = self.getOne()
         i.install_products()
-        self.assertTrue('__roles__' in Application.misc_.__dict__)
+        self.assertTrue(hasattr(Application.misc_, '__roles__'))


### PR DESCRIPTION
This should fix #187.

It only broke for Products, whose `__init__` module contained a non-empty `misc_` variable. I'm not sure anymore what was once stored in that module global variable, but none of the core Products contain one anymore.

`Application.misc_` is a class (and not an instance), so assigning to the class dict fails now. Only the `setattr` change of this commit is strictly required, the test works either way (the dict/mappingproxy support `__contains__`).