### PR TITLE
Set the Python hash seed to random during tests.

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -21,9 +21,15 @@ parts =
 sources-dir = develop
 auto-checkout =
 
+
+[testenv]
+PYTHONHASHSEED = random
+
+
 [test]
 recipe = zc.recipe.testrunner
 script = test
+environment = testenv
 initialization =
     import sys
     import warnings
@@ -52,6 +58,7 @@ eggs = Zope
 [alltests]
 recipe = zc.recipe.testrunner
 script = alltests
+environment = testenv
 eggs =
     AccessControl
     Acquisition


### PR DESCRIPTION
This only applies to Python 2.7, but it doesn't hurt to specify it for Python 3 (where it is enabled by default).

Testing with randomized hashes ensures we don't introduce hash ordering dependent code into Python 2.7 only code paths.