### PR TITLE
Fix HTTPExceptionHandler to be usable in WSGI pipeline of testbrowser tests.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,9 @@ Bugfixes
 
 - Add missing version pin for `Zope2` in `versions-prod.cfg`.
 
+- Fix ``HTTPExceptionHandler`` to be usable as part of the WSGI pipeline in
+  testbrowser tests.
+
 Other changes
 +++++++++++++
 

--- a/src/ZPublisher/httpexceptions.py
+++ b/src/ZPublisher/httpexceptions.py
@@ -34,7 +34,7 @@ class HTTPExceptionHandler(object):
         except HTTPException as exc:
             return exc(environ, start_response)
         except Exception as exc:
-            if self.debug_mode:
+            if self.debug_mode or environ.get('x-wsgiorg.throw_errors', False):
                 # In debug mode, let the web server log a real
                 # traceback
                 raise


### PR DESCRIPTION
When using a programmatically defined WSGI pipeline which contains `HTTPExceptionHandler` as one of its steps setting `browser.handleErrors = False` was ignored.