### PR TITLE
Use the requirements as the index is broken

### DIFF
--- a/doc/INSTALL-virtualenv.rst
+++ b/doc/INSTALL-virtualenv.rst
@@ -20,23 +20,11 @@ Create a Virtual Environment
 Install the Zope2 2.13.26 Software Packages
 -------------------------------------------
 
-First make sure to have a compatible pip version. pip 8.0 and later
-are not supported.
-
-.. code-block:: sh
-
-   $ bin/pip install -U 'pip<8.0'
-   Installing collected packages: pip
-     Found existing installation: pip 9.0.1
-       Uninstalling pip-9.0.1:
-         Successfully uninstalled pip-9.0.1
-   Successfully installed pip-7.1.2
-
 .. code-block:: sh
 
    $ bin/pip install \
-    --trusted-host download.zope.org \
-    --index http://download.zope.org/Zope2/index/2.13.26/ Zope2
+    --no-binary zc.recipe.egg \
+    -r https://zopefoundation.github.io/Zope/releases/2.13.26/requirements.txt
    Collecting Zope2
    ...
    Successfully installed ...


### PR DESCRIPTION
Using the previously described variant using the index led to a broken installation because `pip` installs `Products.ZCatalog` 4.x. It expects to find `products.zcatalog` in the index. (Even downgrading to pip 1.5 does not help.)
