### PR TITLE
Raise app exceptions without rendering response if wsgi.handleErrors is False

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,10 @@ https://github.com/zopefoundation/Zope/blob/4.0a6/CHANGES.rst
 4.0b3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+Bugfixes
+++++++++
+
+- Re-raise app exceptions if wsgi.handleErrors is False in the request environ.
 
 
 4.0b2 (2017-10-13)

--- a/src/ZPublisher/WSGIPublisher.py
+++ b/src/ZPublisher/WSGIPublisher.py
@@ -142,6 +142,11 @@ def transaction_pubevents(request, response, tm=transaction.manager):
         # Create new exc_info with the upgraded exception.
         exc_info = (exc_type, exc, sys.exc_info()[2])
 
+        # Raise exception from app if handle-errors is False
+        # (set by zope.testbrowser in some cases)
+        if not request.environ.get('wsgi.handleErrors', True):
+            reraise(*exc_info)
+
         if isinstance(exc, Unauthorized):
             # _unauthorized modifies the response in-place. If this hook
             # is used, an exception view for Unauthorized has to merge

--- a/src/ZPublisher/WSGIPublisher.py
+++ b/src/ZPublisher/WSGIPublisher.py
@@ -142,20 +142,20 @@ def transaction_pubevents(request, response, tm=transaction.manager):
         # Create new exc_info with the upgraded exception.
         exc_info = (exc_type, exc, sys.exc_info()[2])
 
-        # Raise exception from app if handle-errors is False
-        # (set by zope.testbrowser in some cases)
-        if not request.environ.get('wsgi.handleErrors', True):
-            reraise(*exc_info)
-
-        if isinstance(exc, Unauthorized):
-            # _unauthorized modifies the response in-place. If this hook
-            # is used, an exception view for Unauthorized has to merge
-            # the state of the response and the exception instance.
-            exc.setRealm(response.realm)
-            response._unauthorized()
-            response.setStatus(exc.getStatus())
-
         try:
+            # Raise exception from app if handle-errors is False
+            # (set by zope.testbrowser in some cases)
+            if not request.environ.get('wsgi.handleErrors', True):
+                reraise(*exc_info)
+
+            if isinstance(exc, Unauthorized):
+                # _unauthorized modifies the response in-place. If this hook
+                # is used, an exception view for Unauthorized has to merge
+                # the state of the response and the exception instance.
+                exc.setRealm(response.realm)
+                response._unauthorized()
+                response.setStatus(exc.getStatus())
+
             # Handle exception view
             exc_view_created = _exc_view_created_response(
                 exc, request, response)

--- a/src/ZPublisher/tests/test_WSGIPublisher.py
+++ b/src/ZPublisher/tests/test_WSGIPublisher.py
@@ -517,6 +517,17 @@ class TestPublishModule(ZopeTestCase):
         headers = dict(headers)
         self.assertEqual(headers['Location'], 'http://localhost:9/')
 
+    def testHandleErrorsFalseBypassesExceptionResponse(self):
+        from AccessControl import Unauthorized
+        environ = self._makeEnviron(**{
+            'wsgi.handleErrors': False,
+        })
+        start_response = DummyCallable()
+        _publish = DummyCallable()
+        _publish._raise = Unauthorized('argg')
+        with self.assertRaises(Unauthorized):
+            self._callFUT(environ, start_response, _publish)
+
 
 class TestLoadApp(unittest.TestCase):
 

--- a/src/ZPublisher/tests/test_pubevents.py
+++ b/src/ZPublisher/tests/test_pubevents.py
@@ -325,6 +325,7 @@ class _Request(BaseRequest):
     response = WSGIResponse()
     _hacked_path = False
     args = ()
+    environ = {}
 
     def __init__(self, *args, **kw):
         BaseRequest.__init__(self, *args, **kw)


### PR DESCRIPTION
Raise the publish exception immediately rather than trying to return an exception response if the client requested this by setting the `wsgi.handleErrors` environ key to False. This is set by zope.testbrowser when the browser's `handleErrors` attribute is set to False. This restores behavior from Zope 2 that a number of Plone tests depend on in order to be able to inspect the actual exception raised by the app rather than a rendered response.