### PR TITLE
revert to callable() check

### DIFF
--- a/src/App/Common.py
+++ b/src/App/Common.py
@@ -20,7 +20,6 @@ from Acquisition import aq_base, aq_parent
 
 # BBB
 from os.path import realpath  # NOQA
-import collections
 attrget = getattr
 
 # These are needed because the various date formats below must
@@ -72,7 +71,7 @@ def rfc1123_date(ts=None):
 def absattr(attr, callable=callable):
     # Return the absolute value of an attribute,
     # calling the attr if it is callable.
-    if isinstance(attr, collections.Callable):
+    if callable(attr):
         return attr()
     return attr
 

--- a/src/OFS/CopySupport.py
+++ b/src/OFS/CopySupport.py
@@ -13,7 +13,6 @@
 """Copy interface
 """
 
-import collections
 from json import dumps
 from json import loads
 import logging
@@ -625,7 +624,7 @@ def sanity_check(c, ob):
 
 
 def absattr(attr):
-    if isinstance(attr, collections.Callable):
+    if callable(attr):
         return attr()
     return attr
 

--- a/src/OFS/FindSupport.py
+++ b/src/OFS/FindSupport.py
@@ -27,7 +27,6 @@ from ExtensionClass import Base
 from zope.interface import implementer
 
 from OFS.interfaces import IFindSupport
-import collections
 
 
 @implementer(IFindSupport)
@@ -212,6 +211,6 @@ def role_match(ob, permission, roles, lt=type([]), tt=type(())):
 
 
 def absattr(attr):
-    if isinstance(attr, collections.Callable):
+    if callable(attr):
         return attr()
     return attr

--- a/src/OFS/Moniker.py
+++ b/src/OFS/Moniker.py
@@ -52,6 +52,6 @@ def loadMoniker(data):
 
 
 def absattr(attr):
-    if isinstance(attr, collections.Callable):
+    if callable(attr):
         return attr()
     return attr

--- a/src/OFS/ObjectManager.py
+++ b/src/OFS/ObjectManager.py
@@ -15,7 +15,6 @@
 
 from io import BytesIO
 from logging import getLogger
-import collections
 import copy
 import fnmatch
 import marshal
@@ -270,7 +269,7 @@ class ObjectManager(CopyContainer,
         # adequate permission to add that type of object.
         sm = getSecurityManager()
         meta_types = []
-        if isinstance(self.all_meta_types, collections.Callable):
+        if callable(self.all_meta_types):
             all = self.all_meta_types()
         else:
             all = self.all_meta_types

--- a/src/OFS/SimpleItem.py
+++ b/src/OFS/SimpleItem.py
@@ -61,7 +61,6 @@ from OFS.CopySupport import CopySource
 from OFS.Lockable import LockableItem
 from OFS.role import RoleManager
 from OFS.Traversable import Traversable
-import collections
 
 if bbb.HAS_ZSERVER:
     from webdav.Resource import Resource
@@ -135,7 +134,7 @@ class Item(Base,
         """Return the title if it is not blank and the id otherwise.
         """
         title = self.title
-        if isinstance(title, collections.Callable):
+        if callable(title):
             title = title()
         if title:
             return title
@@ -147,7 +146,7 @@ class Item(Base,
         If the title is not blank, then the id is included in parens.
         """
         title = self.title
-        if isinstance(title, collections.Callable):
+        if callable(title):
             title = title()
         id = self.getId()
         return title and ("%s (%s)" % (title, id)) or id
@@ -232,7 +231,7 @@ class Item(Base,
 
                 if getattr(aq_base(s), 'isDocTemp', 0):
                     v = s(client, REQUEST, **kwargs)
-                elif isinstance(s, collections.Callable):
+                elif callable(s):
                     v = s(**kwargs)
                 else:
                     v = HTML.__call__(s, client, REQUEST, **kwargs)

--- a/src/Products/PageTemplates/Expressions.py
+++ b/src/Products/PageTemplates/Expressions.py
@@ -17,7 +17,6 @@ for Python expressions, string literals, and paths.
 """
 
 import logging
-import sys
 from six import text_type, binary_type
 
 from zope.component import queryUtility
@@ -47,7 +46,6 @@ from zExceptions import Unauthorized
 from zope.contentprovider.tales import TALESProviderExpression
 from Products.PageTemplates import ZRPythonExpr
 from Products.PageTemplates.interfaces import IUnicodeEncodingConflictResolver
-import collections
 
 
 SecureModuleImporter = ZRPythonExpr._SecureModuleImporter()
@@ -116,7 +114,7 @@ def render(ob, ns):
         # item might be proxied (e.g. modules might have a deprecation
         # proxy)
         base = removeAllProxies(base)
-        if isinstance(base, collections.Callable):
+        if callable(base):
             if getattr(base, 'isDocTemp', 0):
                 ob = ZRPythonExpr.call_with_ns(ob, ns, 2)
             else:

--- a/src/Products/PageTemplates/expression.py
+++ b/src/Products/PageTemplates/expression.py
@@ -25,7 +25,6 @@ from chameleon.astutil import Static
 from chameleon.codegen import template
 
 from z3c.pt import expressions
-import collections
 
 _marker = object()
 
@@ -82,7 +81,7 @@ class BoboAwareZopeTraverse(object):
             return base
 
         if (getattr(base, '__call__', _marker) is not _marker or
-                isinstance(base, collections.Callable)):
+                callable(base)):
             base = render(base, econtext)
 
         return base

--- a/src/Testing/ZopeTestCase/placeless.py
+++ b/src/Testing/ZopeTestCase/placeless.py
@@ -22,7 +22,6 @@ from AccessControl.security import newInteraction
 
 # For convenience
 from Zope2.App import zcml  # NOQA
-import collections
 
 
 class PlacelessSetup(CAPlacelessSetup,
@@ -58,7 +57,7 @@ del ps
 
 
 def callZCML(zcml_callback):
-    if isinstance(zcml_callback, collections.Callable):
+    if callable(zcml_callback):
         zcml_callback()
     else:
         for func in zcml_callback:

--- a/src/ZPublisher/HTTPRequest.py
+++ b/src/ZPublisher/HTTPRequest.py
@@ -1220,7 +1220,7 @@ class HTTPRequest(BaseRequest):
         # to ensure we are getting the actual object named by
         # the given url, and not some kind of default object.
         if hasattr(object, 'id'):
-            if isinstance(object.id, collections.Callable):
+            if callable(object.id):
                 name = object.id()
             else:
                 name = object.id
@@ -1359,7 +1359,7 @@ class HTTPRequest(BaseRequest):
         if self._lazies:
             v = self._lazies.get(key, _marker)
             if v is not _marker:
-                if isinstance(v, collections.Callable):
+                if callable(v):
                     v = v()
                 self[key] = v  # Promote lazy value
                 del self._lazies[key]


### PR DESCRIPTION
Go back to using the `callable` builtin to see if an object is callable. We saw problems with some views that were instances of collections.Callable but did not actually have a `__call__` method. And while `callable` was removed for Python 3.0-3.1, it has returned.