### PR TITLE
Fix path expressions with uncallable views

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ Bugfixes
 
 - Re-raise app exceptions if wsgi.handleErrors is False in the request environ.
 
+- Fix path expressions trying to call views that do not implement `__call__`.
+
 
 4.0b2 (2017-10-13)
 ------------------

--- a/src/Products/Five/browser/metaconfigure.py
+++ b/src/Products/Five/browser/metaconfigure.py
@@ -447,7 +447,7 @@ class simple(zope.browserpage.metaconfigure.simple):
 
         attr = self.__page_attribute__
         if attr == '__call__':
-            raise AttributeError("__call__")
+            raise NotImplementedError
 
         return getattr(self, attr)
 

--- a/src/Products/Five/browser/metaconfigure.py
+++ b/src/Products/Five/browser/metaconfigure.py
@@ -437,6 +437,10 @@ def resourceDirectory(_context, name, directory, layer=IDefaultBrowserLayer,
         )
 
 
+class ViewNotCallableError(AttributeError, NotImplementedError):
+    pass
+
+
 class simple(zope.browserpage.metaconfigure.simple):
 
     # __call__ should have the same signature as the original method
@@ -447,7 +451,7 @@ class simple(zope.browserpage.metaconfigure.simple):
 
         attr = self.__page_attribute__
         if attr == '__call__':
-            raise NotImplementedError
+            raise ViewNotCallableError('__call__')
 
         return getattr(self, attr)
 

--- a/src/Products/PageTemplates/Expressions.py
+++ b/src/Products/PageTemplates/Expressions.py
@@ -115,10 +115,13 @@ def render(ob, ns):
         # proxy)
         base = removeAllProxies(base)
         if callable(base):
-            if getattr(base, 'isDocTemp', 0):
-                ob = ZRPythonExpr.call_with_ns(ob, ns, 2)
-            else:
-                ob = ob()
+            try:
+                if getattr(base, 'isDocTemp', 0):
+                    ob = ZRPythonExpr.call_with_ns(ob, ns, 2)
+                else:
+                    ob = ob()
+            except NotImplementedError:
+                pass
     return ob
 
 

--- a/src/Products/PageTemplates/tests/testExpressions.py
+++ b/src/Products/PageTemplates/tests/testExpressions.py
@@ -1,8 +1,7 @@
 # *-* coding: iso-8859-1 -*-
 
-import sys
 import unittest
-from six import text_type, binary_type
+from six import text_type
 
 from zope.component.testing import PlacelessSetup
 
@@ -89,6 +88,15 @@ class EngineTestsBase(PlacelessSetup):
     def test_evaluate_with_render_simple_callable(self):
         ec = self._makeContext()
         self.assertEqual(ec.evaluate('dummy'), 'dummy')
+
+    def test_evaluate_with_unimplemented_call(self):
+        class Dummy(object):
+            def __call__(self):
+                raise NotImplementedError
+
+        dummy = Dummy()
+        ec = self._makeContext(bindings={'dummy': dummy})
+        self.assertIs(ec.evaluate('dummy'), dummy)
 
     def test_evaluate_with_render_DTML_template(self):
         # http://www.zope.org/Collectors/Zope/2232

--- a/src/Products/PageTemplates/tests/testExpressions.py
+++ b/src/Products/PageTemplates/tests/testExpressions.py
@@ -92,7 +92,7 @@ class EngineTestsBase(PlacelessSetup):
     def test_evaluate_with_unimplemented_call(self):
         class Dummy(object):
             def __call__(self):
-                raise NotImplementedError
+                raise NotImplementedError()
 
         dummy = Dummy()
         ec = self._makeContext(bindings={'dummy': dummy})


### PR DESCRIPTION
This fixes a regression from Zope 2: if a browser view does not implement `__call__`, traversing to it in a path expression should return the view instance itself rather than raising an AttributeError. `callable()` was returning a false positive in this case, probably tricked by the `__call__` property on the view superclass.

(Zope 2 caught the AttributeError and checked to see if its parameter was `__call__`, but I figure catching NotImplementedError matches the intent better.)