### PR TITLE
Follow-up to #199, don't use `wsgi.handleErrors`.

### DIFF
--- a/src/Testing/ZopeTestCase/functional.py
+++ b/src/Testing/ZopeTestCase/functional.py
@@ -120,6 +120,9 @@ class Functional(sandbox.Sandboxed):
         publish = partial(publish_module, _request=request, _response=response)
         if handle_errors:
             publish = HTTPExceptionHandler(publish)
+        else:
+            # Tell the publisher to skip exception views
+            env['x-wsgiorg.throw_errors'] = True
 
         wsgi_result = publish(env, start_response)
 

--- a/src/Testing/ZopeTestCase/zopedoctest/functional.py
+++ b/src/Testing/ZopeTestCase/zopedoctest/functional.py
@@ -21,6 +21,7 @@ import re
 import sys
 import warnings
 
+from six import text_type
 import transaction
 
 from Testing.ZopeTestCase import ZopeTestCase
@@ -172,11 +173,11 @@ def http(request_string, handle_errors=True):
     headers = msg.items()
     body = msg.get_payload()
 
-    if isinstance(body, bytes):
-        body = body.decode('utf-8')
+    if isinstance(body, text_type):
+        body = body.encode('utf-8')
 
     # Store request body without headers
-    instream = BytesIO(body.encode('utf-8'))
+    instream = BytesIO(body)
 
     for name, value in headers:
         name = ('_'.join(name.upper().split('-')))

--- a/src/ZPublisher/WSGIPublisher.py
+++ b/src/ZPublisher/WSGIPublisher.py
@@ -145,7 +145,7 @@ def transaction_pubevents(request, response, tm=transaction.manager):
         try:
             # Raise exception from app if handle-errors is False
             # (set by zope.testbrowser in some cases)
-            if not request.environ.get('wsgi.handleErrors', True):
+            if request.environ.get('x-wsgiorg.throw_errors', False):
                 reraise(*exc_info)
 
             if isinstance(exc, Unauthorized):

--- a/src/ZPublisher/tests/test_WSGIPublisher.py
+++ b/src/ZPublisher/tests/test_WSGIPublisher.py
@@ -520,7 +520,7 @@ class TestPublishModule(ZopeTestCase):
     def testHandleErrorsFalseBypassesExceptionResponse(self):
         from AccessControl import Unauthorized
         environ = self._makeEnviron(**{
-            'wsgi.handleErrors': False,
+            'x-wsgiorg.throw_errors': True,
         })
         start_response = DummyCallable()
         _publish = DummyCallable()


### PR DESCRIPTION
Also fix `zopedoctest.functional.http` to support binary bodies.