### PR TITLE
Fix 'lines' property to always use 'bytes'

### DIFF
--- a/src/ZPublisher/Converters.py
+++ b/src/ZPublisher/Converters.py
@@ -135,7 +135,7 @@ def field2lines(v):
     if isinstance(v, (list, tuple)):
         result = []
         for item in v:
-            result.append(str(item))
+            result.append(field2bytes(item))
         return result
     return field2text(v).splitlines()
 

--- a/src/ZPublisher/tests/test_Converters.py
+++ b/src/ZPublisher/tests/test_Converters.py
@@ -52,12 +52,14 @@ class ConvertersTests(unittest.TestCase):
     def test_field2lines_with_list(self):
         from ZPublisher.Converters import field2lines
         to_convert = ['one', 'two']
-        self.assertEqual(field2lines(to_convert), to_convert)
+        expected = [b'one', b'two']
+        self.assertEqual(field2lines(to_convert), expected)
 
     def test_field2lines_with_tuple(self):
         from ZPublisher.Converters import field2lines
         to_convert = ('one', 'two')
-        self.assertEqual(field2lines(to_convert), list(to_convert))
+        expected = [b'one', b'two']
+        self.assertEqual(field2lines(to_convert), expected)
 
     def test_field2lines_with_empty_string(self):
         from ZPublisher.Converters import field2lines

--- a/src/ZPublisher/tests/test_Converters.py
+++ b/src/ZPublisher/tests/test_Converters.py
@@ -51,13 +51,13 @@ class ConvertersTests(unittest.TestCase):
 
     def test_field2lines_with_list(self):
         from ZPublisher.Converters import field2lines
-        to_convert = ['one', 'two']
+        to_convert = ['one', b'two']
         expected = [b'one', b'two']
         self.assertEqual(field2lines(to_convert), expected)
 
     def test_field2lines_with_tuple(self):
         from ZPublisher.Converters import field2lines
-        to_convert = ('one', 'two')
+        to_convert = ('one', b'two')
         expected = [b'one', b'two']
         self.assertEqual(field2lines(to_convert), expected)
 


### PR DESCRIPTION
The 'lines' property type could not be used with bytes so far, as `str` will include the prefix and quotes:
```
$ python3.6
Python 3.6.3 (default, Oct 21 2017, 11:47:54) 
[GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> str(b'foo')
"b'foo'"
>>> 
```

This fixes the type to always store bytes as was already the case with Python 2.