### PR TITLE
Move _html to HTTPBaseResponse 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,7 @@ Bugfixes
 
 - Fix path expressions trying to call views that do not implement `__call__`.
 
+- Move _html to HTTPBaseResponse since it is shared by HTTPResponse and WSGIResponse.
 
 Changes
 +++++++

--- a/src/ZPublisher/HTTPResponse.py
+++ b/src/ZPublisher/HTTPResponse.py
@@ -696,6 +696,12 @@ class HTTPBaseResponse(BaseResponse):
         if realm:
             self.setHeader('WWW-Authenticate', 'basic realm="%s"' % realm, 1)
 
+    def _html(self, title, body):
+        return ("<html>\n"
+                "<head>\n<title>%s</title>\n</head>\n"
+                "<body>\n%s\n</body>\n"
+                "</html>\n" % (title, body))
+
 
 class HTTPResponse(HTTPBaseResponse):
 
@@ -745,12 +751,6 @@ class HTTPResponse(HTTPBaseResponse):
     def _traceback(self, t, v, tb, as_html=1):
         tb = format_exception(t, v, tb, as_html=as_html)
         return '\n'.join(tb)
-
-    def _html(self, title, body):
-        return ("<html>\n"
-                "<head>\n<title>%s</title>\n</head>\n"
-                "<body>\n%s\n</body>\n"
-                "</html>\n" % (title, body))
 
     def _error_html(self, title, body):
         return ("""<!DOCTYPE html><html>


### PR DESCRIPTION
it is shared by HTTPResponse and WSGIResponse.

Found in `./bin/test -s Products.CMFPlone -t test_PloneTool_deleteObjectsByPaths`

```
[0]   /Users/pbauer/workspace/coredev/parts/test/bin/test(441)<module>()
[1]   /Users/pbauer/.cache/buildout/eggs/collective.xmltestreport-1.3.4-py2.7.egg/collective/xmltestreport/runner.py(60)run()
-> failed = run_internal(defaults, args, script_parts=script_parts)
[2]   /Users/pbauer/.cache/buildout/eggs/collective.xmltestreport-1.3.4-py2.7.egg/collective/xmltestreport/runner.py(73)run_internal()
-> runner.run()
[3]   /Users/pbauer/.cache/buildout/eggs/zope.testrunner-4.4.4-py2.7.egg/zope/testrunner/runner.py(160)run()
-> self.run_tests()
[4]   /Users/pbauer/.cache/buildout/eggs/zope.testrunner-4.4.4-py2.7.egg/zope/testrunner/runner.py(242)run_tests()
-> self.skipped, self.import_errors)
[5]   /Users/pbauer/.cache/buildout/eggs/zope.testrunner-4.4.4-py2.7.egg/zope/testrunner/runner.py(411)run_layer()
-> import_errors)
[6]   /Users/pbauer/.cache/buildout/eggs/zope.testrunner-4.4.4-py2.7.egg/zope/testrunner/runner.py(331)run_tests()
-> test(result)
[7]   /Users/pbauer/workspace/coredev/src/Products.CMFPlone/Products/CMFPlone/tests/testCSRFProtection.py(40)test_PloneTool_deleteObjectsByPaths()
-> 'paths:list=news')
[8]   /Users/pbauer/workspace/coredev/src/Products.CMFPlone/Products/CMFPlone/tests/testCSRFProtection.py(33)checkAuthenticator()
-> request_method='POST', stdin=data)
[9]   /Users/pbauer/workspace/coredev/src/Zope/src/Testing/ZopeTestCase/functional.py(43)wrapped_func()
-> return func(*args, **kw)
[10]   /Users/pbauer/workspace/coredev/src/Zope/src/Testing/ZopeTestCase/functional.py(127)publish()
-> wsgi_result = publish(env, start_response)
[11]   /Users/pbauer/workspace/coredev/src/Zope/src/ZPublisher/httpexceptions.py(33)__call__()
-> return self.application(environ, start_response)
[12]   /Users/pbauer/workspace/coredev/src/Zope/src/ZPublisher/WSGIPublisher.py(256)publish_module()
-> response = _publish(request, new_mod_info)
[13]   /Users/pbauer/workspace/coredev/src/Zope/src/ZPublisher/WSGIPublisher.py(211)publish()
-> response.setBody(result)
[14]   /Users/pbauer/workspace/coredev/src/Zope/src/ZPublisher/HTTPResponse.py(1094)setBody()
-> super(WSGIResponse, self).setBody(body, title, is_error)
[15] > /Users/pbauer/workspace/coredev/src/Zope/src/ZPublisher/HTTPResponse.py(507)setBody()
-> self.body = body = self._html(
(Pdb++) self._html(title, body.decode(self.charset)).encode(self.charset)
*** AttributeError: 'WSGIResponse' object has no attribute '_html'
```