### PR TITLE
Fix unpickling of instances those base class changed to a new-style class.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,9 @@ Bugfixes
 
 - Move _html to HTTPBaseResponse since it is shared by HTTPResponse and WSGIResponse.
 
+- Fix unpickling of instances created before 4.0b2 those classes changed from
+  old-style classes to new-style classes.
+
 Changes
 +++++++
 

--- a/src/Shared/DC/Scripts/Bindings.py
+++ b/src/Shared/DC/Scripts/Bindings.py
@@ -50,9 +50,14 @@ class NameAssignments(object):
 
     __allow_access_to_unprotected_subobjects__ = 1
 
-    def __init__(self, mapping):
+    def __init__(self, mapping=None):
         # mapping is presumably the REQUEST or compatible equivalent.
         # Note that we take care not to store expression texts in the ZODB.
+
+        # The default value is needed for unpickling instances of this class
+        # which where created before 4.0b2 where this class was still an old
+        # style class. For details see
+        # https://github.com/zopefoundation/Zope/issues/205
         asgns = {}
         _isLegalName = self._isLegalName
         for name, expr in self._exprs:

--- a/src/Shared/DC/Scripts/Bindings.py
+++ b/src/Shared/DC/Scripts/Bindings.py
@@ -59,6 +59,8 @@ class NameAssignments(object):
         # style class. For details see
         # https://github.com/zopefoundation/Zope/issues/205
         asgns = {}
+        if mapping is None:
+            mapping = {}
         _isLegalName = self._isLegalName
         for name, expr in self._exprs:
             if name in mapping:

--- a/src/Shared/DC/Scripts/Signature.py
+++ b/src/Shared/DC/Scripts/Signature.py
@@ -21,7 +21,11 @@ from functools import total_ordering
 @total_ordering
 class FuncCode(object):
 
-    def __init__(self, varnames, argcount):
+    def __init__(self, varnames=None, argcount=None):
+        # The default values are needed for unpickling instances of this class
+        # which where created before 4.0b2 where this class was still an old
+        # style class. For details see
+        # https://github.com/zopefoundation/Zope/issues/205
         self.co_varnames = varnames
         self.co_argcount = argcount
 

--- a/src/Shared/DC/Scripts/Signature.py
+++ b/src/Shared/DC/Scripts/Signature.py
@@ -21,7 +21,7 @@ from functools import total_ordering
 @total_ordering
 class FuncCode(object):
 
-    def __init__(self, varnames=None, argcount=None):
+    def __init__(self, varnames=(), argcount=-1):
         # The default values are needed for unpickling instances of this class
         # which where created before 4.0b2 where this class was still an old
         # style class. For details see

--- a/src/ZPublisher/BeforeTraverse.py
+++ b/src/ZPublisher/BeforeTraverse.py
@@ -86,7 +86,8 @@ class MultiHook(object):
     MultiHook calls the named hook from the class of the container, then
     the prior hook, then all the hooks in its list.
     """
-    def __init__(self, hookname=None, prior=None, defined_in_class=None):
+    def __init__(self, hookname='<undefined hookname>', prior=None,
+                 defined_in_class=False):
         # The default values are needed for unpickling instances of this class
         # which where created before 4.0b2 where this class was still an old
         # style class. For details see
@@ -124,7 +125,7 @@ class NameCaller(object):
     >>> registerBeforeTraverse(folder, NameCaller('preop'), 'XApp')
     """
 
-    def __init__(self, name=None):
+    def __init__(self, name='<undefined name>'):
         # The default value is needed for unpickling instances of this class
         # which where created before 4.0b2 where this class was still an old
         # style class. For details see

--- a/src/ZPublisher/BeforeTraverse.py
+++ b/src/ZPublisher/BeforeTraverse.py
@@ -86,7 +86,11 @@ class MultiHook(object):
     MultiHook calls the named hook from the class of the container, then
     the prior hook, then all the hooks in its list.
     """
-    def __init__(self, hookname, prior, defined_in_class):
+    def __init__(self, hookname=None, prior=None, defined_in_class=None):
+        # The default values are needed for unpickling instances of this class
+        # which where created before 4.0b2 where this class was still an old
+        # style class. For details see
+        # https://github.com/zopefoundation/Zope/issues/205
         self._hookname = hookname
         self._prior = prior
         self._defined_in_class = defined_in_class
@@ -120,7 +124,11 @@ class NameCaller(object):
     >>> registerBeforeTraverse(folder, NameCaller('preop'), 'XApp')
     """
 
-    def __init__(self, name):
+    def __init__(self, name=None):
+        # The default value is needed for unpickling instances of this class
+        # which where created before 4.0b2 where this class was still an old
+        # style class. For details see
+        # https://github.com/zopefoundation/Zope/issues/205
         self.name = name
 
     def __call__(self, container, request):


### PR DESCRIPTION
If the instance was created before Zope 4.0b2 unpickling broke because in 4.0b2 all classes became new-style classes.

Fixes #205.

The proposes solution seems to work as shown in #205.
Could anyone think of a cleaner solution?