### PR TITLE
Prevent UnicodeDecodeError

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,8 @@ Bugfixes
 - Fix unpickling of instances created before 4.0b2 those classes changed from
   old-style classes to new-style classes.
 
+- Prevent UnicodeDecodeError when publishing image (bytes) responses without content-type
+
 Changes
 +++++++
 

--- a/src/ZPublisher/HTTPResponse.py
+++ b/src/ZPublisher/HTTPResponse.py
@@ -437,7 +437,6 @@ class HTTPBaseResponse(BaseResponse):
             try:
                 text = text.decode(self.charset)
             except UnicodeDecodeError:
-                import pdb; pdb.set_trace()
                 pass
         text = text.lstrip()
         # Note that the string can be big, so text.lower().startswith()

--- a/src/ZPublisher/HTTPResponse.py
+++ b/src/ZPublisher/HTTPResponse.py
@@ -433,10 +433,12 @@ class HTTPBaseResponse(BaseResponse):
                     self.setHeader('content-length', len(self.body))
 
     def isHTML(self, text):
-        try:
-            text = text.decode(self.charset)
-        except UnicodeDecodeError:
-            pass
+        if isinstance(text, bytes):
+            try:
+                text = text.decode(self.charset)
+            except UnicodeDecodeError:
+                import pdb; pdb.set_trace()
+                pass
         text = text.lstrip()
         # Note that the string can be big, so text.lower().startswith()
         # is more expensive than s[:n].lower().

--- a/src/ZPublisher/HTTPResponse.py
+++ b/src/ZPublisher/HTTPResponse.py
@@ -433,6 +433,10 @@ class HTTPBaseResponse(BaseResponse):
                     self.setHeader('content-length', len(self.body))
 
     def isHTML(self, text):
+        try:
+            text = text.decode(self.charset)
+        except UnicodeDecodeError:
+            pass
         text = text.lstrip()
         # Note that the string can be big, so text.lower().startswith()
         # is more expensive than s[:n].lower().
@@ -514,7 +518,7 @@ class HTTPBaseResponse(BaseResponse):
         content_type = self.headers.get('content-type')
 
         if content_type is None:
-            if self.isHTML(body.decode(self.charset)):
+            if self.isHTML(body):
                 content_type = 'text/html; charset=%s' % self.charset
             else:
                 content_type = 'text/plain; charset=%s' % self.charset


### PR DESCRIPTION
When publishing image (bytes) responses without content-type a UnicodeDecodeError is raised.

Found when debuggung the failing test in Plone `testPublishFTPScaleViaUID`. 

Here is a session with a pdb just before `if self.isHTML(body.decode(self.charset)):`

```
$ ./bin/test -t testPublishFTPScaleViaUID
Running plone.app.imaging.testing.ImagingTestCase:Functional tests:
  Set up plone.testing.zca.LayerCleanup in 0.000 seconds.
  Set up plone.testing.z2.Startup in 0.114 seconds.
  Set up plone.app.testing.layers.PloneFixture in 8.322 seconds.
  Set up plone.app.imaging.testing.ImagingFixture in 2.049 seconds.
  Set up plone.app.imaging.testing.ImagingTestCase:Functional in 0.000 seconds.
  Running:
    1/1 (100.0%) testPublishFTPScaleViaUID (plone.app.imaging.tests.test_new_scaling.ImagePublisherTests)[14] > /Users/pbauer/workspace/coredev/src/Zope/src/ZPublisher/HTTPResponse.py(518)setBody()
-> if self.isHTML(body.decode(self.charset)):
   2 frames hidden (try 'help hidden_frames')
(Pdb++) body.decode(self.charset)
*** UnicodeDecodeError: 'utf8' codec can't decode byte 0x89 in position 0: invalid start byte
(Pdb++) u
[13] > /Users/pbauer/workspace/coredev/src/Zope/src/ZPublisher/HTTPResponse.py(1094)setBody()
-> super(WSGIResponse, self).setBody(body, title, is_error)
(Pdb++) u
[12] > /Users/pbauer/workspace/coredev/src/Zope/src/ZPublisher/WSGIPublisher.py(211)publish()
-> response.setBody(result)
(Pdb++) result
'\x89PNG\r\n\x1a\n\x00\x00\ [...] \x00\x00IEND\xaeB`\x82'
(Pdb++) u
[11] > /Users/pbauer/workspace/coredev/src/Zope/src/ZPublisher/WSGIPublisher.py(256)publish_module()
-> response = _publish(request, new_mod_info)
(Pdb++) u
[10] > /Users/pbauer/workspace/coredev/src/Zope/src/ZPublisher/httpexceptions.py(33)__call__()
-> return self.application(environ, start_response)
(Pdb++) u
[9] > /Users/pbauer/workspace/coredev/src/Zope/src/Testing/ZopeTestCase/functional.py(127)publish()
-> wsgi_result = publish(env, start_response)
(Pdb++) u
[8] > /Users/pbauer/workspace/coredev/src/Zope/src/Testing/ZopeTestCase/functional.py(43)wrapped_func()
-> return func(*args, **kw)
(Pdb++) u
[7] > /Users/pbauer/workspace/coredev/src/plone.app.imaging/src/plone/app/imaging/tests/test_new_scaling.py(173)testPublishFTPScaleViaUID()
-> response = self.publish(url, basic=self.getCredentials())
(Pdb++) url
'/plone/Members/test_user_1_/foo/@@images/fd197b93-df4f-4824-abb7-9b576d61a502.png/manage_FTPget'
```