### PR TITLE
Avoid error when calling setBody with lock on a wsgi response.

### DIFF
--- a/src/ZPublisher/HTTPResponse.py
+++ b/src/ZPublisher/HTTPResponse.py
@@ -1075,7 +1075,7 @@ class WSGIResponse(HTTPBaseResponse):
 
         self.stdout.write(data)
 
-    def setBody(self, body, title='', is_error=False):
+    def setBody(self, body, title='', is_error=False, lock=None):
         if isinstance(body, IOBase):
             body.seek(0, 2)
             length = body.tell()


### PR DESCRIPTION
Same as the unmerged commit https://github.com/zopefoundation/Zope/pull/174/commits/727612db36456ea389a7b612acc1046bb975664b by @mauritsvanrees from https://github.com/zopefoundation/Zope/pull/174