### PR TITLE
Removed reference to old action.html

### DIFF
--- a/src/Products/Five/browser/configure.zcml
+++ b/src/Products/Five/browser/configure.zcml
@@ -16,7 +16,6 @@
       >
 
     <browser:page name="index.html"  template="adding.pt" />
-    <browser:page name="action.html" attribute="action" />
 
   </browser:view>
 


### PR DESCRIPTION
Fixes #211

This is more of a blind stab at the problem. I couldn't find any other plausible references, so I tentatively removed this line (which doesn't make a lot of sense to me anyway). The warning is now gone. I've seen no obvious problems.

But I am completely ignorant as to potential side effects, so I'm posting this in the hope that someone more knowlegeable will confirm this is OK.