### PR TITLE
fix regression in traversal of plone.app.folder.base.ReplaceableWrapper

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,10 @@ Bugfixes
 
 - Prevent UnicodeDecodeError when publishing image (bytes) responses without content-type
 
+- Fix regression in traversing to WebDAV NullResources if the final object
+  in the path is a proxy that provides access to aq_inner but is not itself
+  an acquisition wrapper.
+
 Changes
 +++++++
 

--- a/src/ZPublisher/BaseRequest.py
+++ b/src/ZPublisher/BaseRequest.py
@@ -475,8 +475,7 @@ class BaseRequest(object):
                             hasattr(object, 'aq_base') and
                             not hasattr(object, '__bobo_traverse__')):
 
-                        if (object.__parent__ is not
-                                aq_inner(object).__parent__):
+                        if object.__parent__ is not object.aq_inner.__parent__:
                             object = NullResource(parents[-2], object.getId(),
                                                   self).__of__(parents[-2])
 


### PR DESCRIPTION
This restores a webdav-related check to how it was done in Zope 2 to fix an edge case causing a Plone test to fail.