### PR TITLE
Set x-wsgiorg.throw_errors earlier because request copies its environ

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,7 +20,7 @@ Bugfixes
 
 - Install a default page for the root view in new installations again.
 
-- Re-raise app exceptions if wsgi.handleErrors is False in the request environ.
+- Re-raise app exceptions if x-wsgiorg.throw_errors is True in the request environ.
 
 - Fix path expressions trying to call views that do not implement `__call__`.
 

--- a/src/Testing/ZopeTestCase/functional.py
+++ b/src/Testing/ZopeTestCase/functional.py
@@ -92,6 +92,10 @@ class Functional(sandbox.Sandboxed):
         if basic:
             env['HTTP_AUTHORIZATION'] = basic_auth_encode(basic)
 
+        if not handle_errors:
+            # Tell the publisher to skip exception views
+            env['x-wsgiorg.throw_errors'] = True
+
         if stdin is None:
             stdin = BytesIO()
 
@@ -120,9 +124,6 @@ class Functional(sandbox.Sandboxed):
         publish = partial(publish_module, _request=request, _response=response)
         if handle_errors:
             publish = HTTPExceptionHandler(publish)
-        else:
-            # Tell the publisher to skip exception views
-            env['x-wsgiorg.throw_errors'] = True
 
         wsgi_result = publish(env, start_response)
 

--- a/src/Testing/ZopeTestCase/zopedoctest/functional.py
+++ b/src/Testing/ZopeTestCase/zopedoctest/functional.py
@@ -188,6 +188,10 @@ def http(request_string, handle_errors=True):
     if 'HTTP_AUTHORIZATION' in env:
         env['HTTP_AUTHORIZATION'] = auth_header(env['HTTP_AUTHORIZATION'])
 
+    if not handle_errors:
+        # Tell the publisher to skip exception views
+        env['x-wsgiorg.throw_errors'] = True
+
     outstream = BytesIO()
     response = WSGIResponse(stdout=outstream, stderr=sys.stderr)
     request = Request(instream, env, response)


### PR DESCRIPTION
The request makes a sanitized copy of its environ, so the functional test wrappers need to set x-wsgiorg.throw_errors earlier. Also this was missing from zopedoctest/functional.py