### PR TITLE
Skip IPv6 tests on Travis, as it is not supported.

### DIFF
--- a/doc/CHANGES.rst
+++ b/doc/CHANGES.rst
@@ -8,6 +8,8 @@ http://docs.zope.org/zope2/
 2.13.27 (unreleased)
 --------------------
 
+- Skip IPv6 tests on Travis, as it is not supported.
+
 - add ``tox`` test configuration
 
 - set explicit PyPI index, the old ``zc.buildout`` defaults no longer work

--- a/src/ZServer/tests/test_config.py
+++ b/src/ZServer/tests/test_config.py
@@ -145,11 +145,17 @@ class ZServerConfigurationTestCase(BaseTest, WarningInterceptor):
         self.assertEqual(factory.host, "::1")
         self.assertEqual(factory.port, 81)
         self.check_prepare(factory)
+        # Until here the test works on Travis, but ipv6 is not available
+        # there anymore, so we skip the rest of the test.
+        # See https://github.com/zopefoundation/Zope/issues/46
+        if os.environ.get('TRAVIS'):
+            print('Skipping ipv6 test on Travis.')
+            return
         server = factory.create()
         self.assertEqual(server.ip, '::1')
         self.assertEqual(server.port, 9381)
         server.close()
-    
+
     def test_http_factory_defaulthost(self):
         factory = self.load_factory("""\
             <http-server>


### PR DESCRIPTION
See the failures in https://github.com/zopefoundation/Zope/pull/226.
On the master branch we already did basically the same in [February 2016](https://github.com/zopefoundation/Zope/pull/47)

For 2.13 we still support Python 2.6, so I did not use `unittest.skipIf`.