### PR TITLE
Use correct stdout stream in publish_module.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,8 @@ https://github.com/zopefoundation/Zope/blob/4.0a6/CHANGES.rst
 4.0b4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix an edge case where the data which was set using ``response.write()`` was
+  not returned by ``publish_module``.
 
 
 4.0b3 (2018-01-27)

--- a/src/ZPublisher/WSGIPublisher.py
+++ b/src/ZPublisher/WSGIPublisher.py
@@ -276,7 +276,7 @@ def publish_module(environ, start_response,
             result = response.body
         else:
             # If somebody used response.write, that data will be in the
-            # stdout BytesIO, so we put that before the body.
+            # response.stdout BytesIO, so we put that before the body.
             result = (response.stdout.getvalue(), response.body)
 
         for func in response.after_list:

--- a/src/ZPublisher/WSGIPublisher.py
+++ b/src/ZPublisher/WSGIPublisher.py
@@ -277,7 +277,7 @@ def publish_module(environ, start_response,
         else:
             # If somebody used response.write, that data will be in the
             # stdout BytesIO, so we put that before the body.
-            result = (stdout.getvalue(), response.body)
+            result = (response.stdout.getvalue(), response.body)
 
         for func in response.after_list:
             func()


### PR DESCRIPTION
If `publish_module` is called with a `_response` parameter which is not `None` its stdout is written to but is not read from.

Detected in zopefoundation/Products.ExternalEditor#10.