### PR TITLE
Fix renaming of images and files via ZMI.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,7 @@ https://github.com/zopefoundation/Zope/blob/4.0a6/CHANGES.rst
 4.0b4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix renaming of images and files via ZMI. (#247).
 
 
 4.0b3 (2018-01-27)

--- a/src/OFS/dtml/renameForm.dtml
+++ b/src/OFS/dtml/renameForm.dtml
@@ -12,14 +12,14 @@
   <td align="left" valign="bottom" width="16"></td>
   <td align="left" valign="bottom">
   <div class="form-text">
-  &dtml-id;
+  &dtml-getId;
   </div>
   </td>
   <td align="left" valign="bottom">
 <dtml-if cb_isMoveable>
   <span class="form-text">to:</span>
-  <input type="hidden" name="ids:list" value="&dtml-id;" />
-  <input type="text" name="new_ids:list" size="<dtml-var "_.max(40,_.len(getId())+4)">" value="&dtml-id;" />
+  <input type="hidden" name="ids:list" value="&dtml-getId;" />
+  <input type="text" name="new_ids:list" size="<dtml-var "_.max(40,_.len(getId())+4)">" value="&dtml-getId;" />
 <dtml-else>
   <span class="form-text">
   may not be renamed.


### PR DESCRIPTION
`Image` and `File` do not have an `id` (no more).

Fixes #247.