### PR TITLE
Update ObjectPublishing.rst

### DIFF
--- a/docs/zdgbook/ObjectPublishing.rst
+++ b/docs/zdgbook/ObjectPublishing.rst
@@ -926,6 +926,8 @@ Record marshalling provides you with the ability to create complex
 forms.  However, it is a good idea to keep your web interfaces as
 simple as possible.
 
+Please note, that records do not work with input fields of type radio as you would expect, as all radio fields with the same name are considered as one group - even if they are in different records. That means, activating one radio button will also deactivate all other radio buttons from the other records.
+
 Exceptions
 ----------
 

--- a/docs/zdgbook/ObjectPublishing.rst
+++ b/docs/zdgbook/ObjectPublishing.rst
@@ -926,7 +926,10 @@ Record marshalling provides you with the ability to create complex
 forms.  However, it is a good idea to keep your web interfaces as
 simple as possible.
 
-Please note, that records do not work with input fields of type radio as you would expect, as all radio fields with the same name are considered as one group - even if they are in different records. That means, activating one radio button will also deactivate all other radio buttons from the other records.
+Please note, that records do not work with input fields of type radio as you
+might expect, as all radio fields with the same name are considered as one
+group - even if they are in different records. That means, activating one radio
+button will also deactivate all other radio buttons from the other records.
 
 Exceptions
 ----------


### PR DESCRIPTION
When I tried to refactor a form submission (which allows up to five users to sign up at once) to make use of records, I stumbled upon the problem, that clicking a gender radio button for one user deactivated all the other users' gender selections. The problem was the name attribute of the input radio button, ie  name="users.gender:records". Unwilling to go back to the solution which numbered the fields (ie user_5_gender), I switched from radio buttons to select boxes.