### PR TITLE
Fix DTML upload for Python 3.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,9 @@ https://github.com/zopefoundation/Zope/blob/4.0a6/CHANGES.rst
 - Add a minimum ``buildout.cfg`` suggestion in the docs for creating ``wsgi``
   instances.
 
+- Fix ZMI upload of `DTMLMethod` and `DTMLDocument` to store the DTML as a
+  native ``str`` on both Python versions.
+  (`#265 <https://github.com/zopefoundation/Zope/pull/265>`_)
 
 4.0b5 (2018-05-18)
 ------------------

--- a/src/OFS/DTMLDocument.py
+++ b/src/OFS/DTMLDocument.py
@@ -17,7 +17,10 @@ from AccessControl import getSecurityManager
 from AccessControl.class_init import InitializeClass
 from DocumentTemplate.permissions import change_dtml_methods
 from DocumentTemplate.permissions import change_dtml_documents
+from six import PY2
+from six import PY3
 from six import binary_type
+from six import text_type
 from six.moves.urllib.parse import quote
 from zExceptions import ResourceLockedError
 from zExceptions.TracebackSupplement import PathTracebackSupplement
@@ -55,10 +58,15 @@ class DTMLDocument(PropertyManager, DTMLMethod):
         if self.wl_isLocked():
             raise ResourceLockedError('This document has been locked.')
 
-        if not isinstance(file, binary_type):
-            if REQUEST and not file:
-                raise ValueError('No file specified')
+        if REQUEST and not file:
+            raise ValueError('No file specified')
+
+        if hasattr(file, 'read'):
             file = file.read()
+        if PY3 and isinstance(file, binary_type):
+            file = file.decode('utf-8')
+        if PY2 and isinstance(file, text_type):
+            file = file.encode('utf-8')
 
         self.munge(file)
         self.ZCacheable_invalidate()

--- a/src/OFS/DTMLMethod.py
+++ b/src/OFS/DTMLMethod.py
@@ -27,7 +27,7 @@ from AccessControl.tainted import TaintedString
 from Acquisition import Implicit
 from DocumentTemplate.permissions import change_dtml_methods
 from DocumentTemplate.security import RestrictedDTML
-from six import binary_type
+from six import PY3
 from six.moves.urllib.parse import quote
 from zExceptions import Forbidden
 from zExceptions import ResourceLockedError
@@ -266,10 +266,12 @@ class DTMLMethod(RestrictedDTML,
         if self.wl_isLocked():
             raise ResourceLockedError('This DTML Method is locked.')
 
-        if not isinstance(file, binary_type):
+        if not isinstance(file, basestring):
             if REQUEST and not file:
                 raise ValueError('No file specified')
             file = file.read()
+            if PY3:
+                file = file.decode('utf-8')
 
         self.munge(file)
         self.ZCacheable_invalidate()

--- a/src/OFS/DTMLMethod.py
+++ b/src/OFS/DTMLMethod.py
@@ -44,8 +44,6 @@ from OFS.role import RoleManager
 from OFS.SimpleItem import Item_w__name__
 from ZPublisher.Iterators import IStreamIterator
 
-if PY3:
-    basestring = str
 
 _marker = []  # Create a new marker object.
 

--- a/src/OFS/DTMLMethod.py
+++ b/src/OFS/DTMLMethod.py
@@ -13,7 +13,6 @@
 """DTML Method objects.
 """
 import re
-import sys
 
 from AccessControl.class_init import InitializeClass
 from AccessControl.SecurityInfo import ClassSecurityInfo
@@ -27,7 +26,10 @@ from AccessControl.tainted import TaintedString
 from Acquisition import Implicit
 from DocumentTemplate.permissions import change_dtml_methods
 from DocumentTemplate.security import RestrictedDTML
+from six import PY2
 from six import PY3
+from six import binary_type
+from six import text_type
 from six.moves.urllib.parse import quote
 from zExceptions import Forbidden
 from zExceptions import ResourceLockedError
@@ -42,7 +44,7 @@ from OFS.role import RoleManager
 from OFS.SimpleItem import Item_w__name__
 from ZPublisher.Iterators import IStreamIterator
 
-if sys.version_info >= (3, ):
+if PY3:
     basestring = str
 
 _marker = []  # Create a new marker object.
@@ -261,17 +263,22 @@ class DTMLMethod(RestrictedDTML,
     security.declareProtected(change_dtml_methods, 'manage_upload')
     def manage_upload(self, file='', REQUEST=None):
         """ Replace the contents of the document with the text in 'file'.
+
+        Store `file` as a native `str`.
         """
         self._validateProxy(REQUEST)
         if self.wl_isLocked():
             raise ResourceLockedError('This DTML Method is locked.')
 
-        if not isinstance(file, basestring):
-            if REQUEST and not file:
-                raise ValueError('No file specified')
+        if REQUEST and not file:
+            raise ValueError('No file specified')
+
+        if hasattr(file, 'read'):
             file = file.read()
-            if PY3:
-                file = file.decode('utf-8')
+        if PY3 and isinstance(file, binary_type):
+            file = file.decode('utf-8')
+        if PY2 and isinstance(file, text_type):
+            file = file.encode('utf-8')
 
         self.munge(file)
         self.ZCacheable_invalidate()

--- a/src/OFS/tests/test_DTMLDocument.py
+++ b/src/OFS/tests/test_DTMLDocument.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+import io
 import unittest
 
 
@@ -14,6 +16,39 @@ class DTMLDocumentTests(unittest.TestCase):
         from zope.interface.verify import verifyClass
         from OFS.interfaces import IWriteLock
         verifyClass(IWriteLock, self._getTargetClass())
+
+    def test_manage_upload__bytes(self):
+        """It stores uploaded bytes as a native str."""
+        doc = self._makeOne()
+        data = u'bÿtës'.encode('utf-8')
+        self.assertIsInstance(data, bytes)
+        doc.manage_upload(data)
+        self.assertEqual(doc.read(), 'bÿtës')
+        self.assertIsInstance(doc.read(), str)
+
+    def test_manage_upload__str(self):
+        """It stores an uploaded str as a native str."""
+        doc = self._makeOne()
+        data = 'bÿtës'
+        doc.manage_upload(data)
+        self.assertEqual(doc.read(), 'bÿtës')
+        self.assertIsInstance(doc.read(), str)
+
+    def test_manage_upload__StringIO(self):
+        """It stores StringIO contents as a native str."""
+        doc = self._makeOne()
+        data = io.StringIO(u'bÿtës')
+        doc.manage_upload(data)
+        self.assertIsInstance(doc.read(), str)
+        self.assertEqual(doc.read(), 'bÿtës')
+
+    def test_manage_upload__BytesIO(self):
+        """It stores BytesIO contents as a native str."""
+        doc = self._makeOne()
+        data = io.BytesIO(u'bÿtës'.encode('utf-8'))
+        doc.manage_upload(data)
+        self.assertEqual(doc.read(), 'bÿtës')
+        self.assertIsInstance(doc.read(), str)
 
 
 class FactoryTests(unittest.TestCase):

--- a/src/OFS/tests/test_DTMLMethod.py
+++ b/src/OFS/tests/test_DTMLMethod.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+import io
 import unittest
 
 
@@ -23,6 +25,39 @@ class DTMLMethodTests(unittest.TestCase):
 
         doc.manage_edit(data, 'title')
         self.assertEqual(doc.read(), 'hello&lt;br/&gt;')
+
+    def test_manage_upload__bytes(self):
+        """It stores uploaded bytes as a native str."""
+        doc = self._makeOne()
+        data = u'bÿtës'.encode('utf-8')
+        self.assertIsInstance(data, bytes)
+        doc.manage_upload(data)
+        self.assertEqual(doc.read(), 'bÿtës')
+        self.assertIsInstance(doc.read(), str)
+
+    def test_manage_upload__str(self):
+        """It stores an uploaded str as a native str."""
+        doc = self._makeOne()
+        data = 'bÿtës'
+        doc.manage_upload(data)
+        self.assertEqual(doc.read(), 'bÿtës')
+        self.assertIsInstance(doc.read(), str)
+
+    def test_manage_upload__StringIO(self):
+        """It stores StringIO contents as a native str."""
+        doc = self._makeOne()
+        data = io.StringIO(u'bÿtës')
+        doc.manage_upload(data)
+        self.assertIsInstance(doc.read(), str)
+        self.assertEqual(doc.read(), 'bÿtës')
+
+    def test_manage_upload__BytesIO(self):
+        """It stores BytesIO contents as a native str."""
+        doc = self._makeOne()
+        data = io.BytesIO(u'bÿtës'.encode('utf-8'))
+        doc.manage_upload(data)
+        self.assertEqual(doc.read(), 'bÿtës')
+        self.assertIsInstance(doc.read(), str)
 
 
 class FactoryTests(unittest.TestCase):


### PR DESCRIPTION
Without this change uploading a file to a DTMLMethod via ZMI breaks because `self.munge(file)` tries to use a string regex on a bytes object (the `file` variable). 

What do you think is this patch the way to go?

Open tasks:

- [x] Discuss solution
- [x] Write test (method is currently untested)
- [x] Port fix to DTMLDocument (it duplicates the code)
- [x] Write test for DTMLDocument

See zopefoundation/Products.SiteErrorLog#11 which uses this method in tests and fails with `AttributeError: 'str' object has no attribute 'read'`. in OFS/DTMLMethod.py:272