### PR TITLE
OFS.Traversable: use globalrequest

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ https://github.com/zopefoundation/Zope/blob/4.0a6/CHANGES.rst
 4.0b4 (unreleased)
 ------------------
 
+- In OFS.Traversable, use ``zope.globalrequest.getRequest`` throughout instead of acquiring the request.
+
 - Fix an edge case where the data which was set using ``response.write()`` was
   not returned by ``publish_module`` (#256).
 

--- a/src/OFS/Traversable.py
+++ b/src/OFS/Traversable.py
@@ -19,7 +19,6 @@ from AccessControl.SecurityManagement import getSecurityManager
 from AccessControl.unauthorized import Unauthorized
 from AccessControl.ZopeGuards import guarded_getattr
 from Acquisition import Acquired
-from Acquisition import aq_acquire
 from Acquisition import aq_base
 from Acquisition import aq_inner
 from Acquisition import aq_parent
@@ -31,6 +30,7 @@ from zExceptions import NotFound
 from ZPublisher.interfaces import UseTraversalDefault
 from ZODB.POSException import ConflictError
 
+from zope.globalrequest import getRequest
 from zope.interface import implementer
 from zope.interface import Interface
 from zope.component import queryMultiAdapter
@@ -69,7 +69,7 @@ class Traversable(object):
         spp = self.getPhysicalPath()
 
         try:
-            toUrl = aq_acquire(self, 'REQUEST').physicalPathToURL
+            toUrl = getRequest().physicalPathToURL
         except AttributeError:
             return path2url(spp[1:])
         return toUrl(spp)
@@ -83,7 +83,7 @@ class Traversable(object):
         """
         spp = self.getPhysicalPath()
         try:
-            toUrl = aq_acquire(self, 'REQUEST').physicalPathToURL
+            toUrl = getRequest().physicalPathToURL
         except AttributeError:
             return path2url(spp) or '/'
         return toUrl(spp, relative=1) or '/'
@@ -98,7 +98,7 @@ class Traversable(object):
         """
         spp = self.getPhysicalPath()
         try:
-            toVirt = aq_acquire(self, 'REQUEST').physicalPathToVirtualPath
+            toVirt = getRequest().physicalPathToVirtualPath
         except AttributeError:
             return path2url(spp[1:])
         return path2url(toVirt(spp))
@@ -227,7 +227,7 @@ class Traversable(object):
                         ns, nm = nsParse(name)
                         try:
                             next = namespaceLookup(
-                                ns, nm, obj, aq_acquire(self, 'REQUEST'))
+                                ns, nm, obj, getRequest())
                             if IAcquirer.providedBy(next):
                                 next = next.__of__(obj)
                             if restricted and not validate(
@@ -311,7 +311,7 @@ class Traversable(object):
                 except (AttributeError, NotFound, KeyError) as e:
                     # Try to look for a view
                     next = queryMultiAdapter(
-                        (obj, aq_acquire(self, 'REQUEST')),
+                        (obj, getRequest()),
                         Interface, name)
 
                     if next is not None:


### PR DESCRIPTION
In OFS.Traversable, use ``zope.globalrequest.getRequest`` throughout instead of acquiring the request.

I had a problem with plone tiles which use plone.subrequest - I cache relationfield result items on the parent request, but those result items lose their ``URL`` info from the ``REQUEST`` attribute (which seems to be stored on the portal root where we have to ``aq_acquire`` to).

Because we no not need to traverse to the portal root via attribute acquisition, the getRequest method is faster:

Speed comparison for a context with a path like: ``/Plone/folder/folder/folder``

    >>> # Acquiring the REQUEST
    >>> from datetime import datetime; dt1 = datetime.now(); [aq_acquire(self, 'REQUEST') for cnt in range(100)]; (datetime.now() - dt1).total_seconds()

min: 0.001813
max: 0.003554

    >>> # Using zope.globalrequest
    >>> from zope.globalrequest import getRequest
    >>> from datetime import datetime; dt1 = datetime.now(); [getRequest() for cnt in range(100)]; (datetime.now() - dt1).total_seconds()

min: 0.00051
max: 0.001266

The timing difference might not be very significant, but at least zope.globalrequest is more efficient than traversing up the stack.

Before I go further with this I wait for comments.