### PR TITLE
Add ability to paste objects without limits. [2.13]

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,11 +1,6 @@
 [buildout]
 extensions = mr.developer
-index = https://pypi.python.org/simple/
-
-allow-hosts =
-    *.python.org
-    *.zope.org
-    argparse.googlecode.com
+index = https://pypi.org/simple/
 show-picked-versions = true
 always-accept-server-certificate = true
 develop = .

--- a/doc/CHANGES.rst
+++ b/doc/CHANGES.rst
@@ -8,7 +8,9 @@ http://docs.zope.org/zope2/
 2.13.28 (unreleased)
 --------------------
 
-- ...
+- Add ``OFS.CopySupport.CopyContainer._pasteObjects()`` to be able to paste
+  objects no matter how many objects where cut or copied.
+  (`#217 <https://github.com/zopefoundation/Zope/issues/217>`_)
 
 
 2.13.27 (2018-01-27)

--- a/src/OFS/tests/testCopySupport.py
+++ b/src/OFS/tests/testCopySupport.py
@@ -307,6 +307,11 @@ class TestCopySupport( CopySupportTestBase ):
             self.folder1.manage_pasteObjects(make_data(300))
         self.assertTrue('Item Not Found' in str(err.exception))
 
+        # _pasteObjects allows to paste without restriction:
+        with self.assertRaises(CopyError) as err:
+            self.folder1._pasteObjects(make_data(3500))
+        self.assertTrue('Item Not Found' in str(err.exception))
+
 
 class _SensitiveSecurityPolicy:
 


### PR DESCRIPTION
6ca3691 introduces code to prevent a DoS attack.
This is PR mitigates the consequences for file system code by allowing to paste without limits as discussed in #217 for Zope 2.13.
