### PR TITLE
WIP: Raise generic errors (catch all InternalError) when using WSGI

### DIFF
--- a/src/Testing/tests/test_testbrowser.py
+++ b/src/Testing/tests/test_testbrowser.py
@@ -98,9 +98,10 @@ class TestTestbrowser(FunctionalTestCase):
         self.folder._setObject('stub', ExceptionStub())
         browser = Browser()
 
-        with self.assertRaises(HTTPError):
+        # HTTP errors only for WSGI
+        with self.assertRaises(ValueError):
             browser.open('http://localhost/test_folder_1_/stub')
-        self.assertTrue(browser.headers['status'].startswith('500'))
+        self.assertIsNone(browser.contents)
 
         with self.assertRaises(HTTPError):
             browser.open('http://localhost/nothing-is-here')
@@ -165,8 +166,10 @@ class TestTestbrowser(FunctionalTestCase):
         browser = Browser()
         browser.raiseHttpErrors = False
 
-        browser.open('http://localhost/test_folder_1_/stub')
-        self.assertTrue(browser.headers['status'].startswith('500'))
+        # HTTP errors only for WSGI
+        with self.assertRaises(ValueError):
+            browser.open('http://localhost/test_folder_1_/stub')
+        self.assertIsNone(browser.contents)
 
         browser.open('http://localhost/nothing-is-here')
         self.assertTrue(browser.headers['status'].startswith('404'))

--- a/src/ZPublisher/httpexceptions.py
+++ b/src/ZPublisher/httpexceptions.py
@@ -38,6 +38,13 @@ class HTTPExceptionHandler(object):
                 # In debug mode, let the web server log a real
                 # traceback
                 raise
+            if environ.get('wsgi.errors') is not None:
+                # s. https://www.python.org/dev/peps/pep-0333/#id27
+                # Imho InternalError is the generic error case
+                # that should not be handled by the application but
+                # rather the WSGI server. This way the error along with
+                # the traceback ends up in the concfigured logs.
+                raise
             return self.catch_all_response(exc)(environ, start_response)
 
     def catch_all_response(self, exc):

--- a/src/ZPublisher/httpexceptions.py
+++ b/src/ZPublisher/httpexceptions.py
@@ -34,16 +34,17 @@ class HTTPExceptionHandler(object):
         except HTTPException as exc:
             return exc(environ, start_response)
         except Exception as exc:
-            if self.debug_mode or environ.get('x-wsgiorg.throw_errors', False):
+            if self.debug_mode:
                 # In debug mode, let the web server log a real
                 # traceback
                 raise
-            if environ.get('wsgi.errors') is not None:
+            elif environ.get('wsgi.errors') is not None:
                 # s. https://www.python.org/dev/peps/pep-0333/#id27
-                # Imho InternalError is the generic error case
+                # Imho the catch all InternalError is the generic error case
                 # that should not be handled by the application but
                 # rather the WSGI server. This way the error along with
-                # the traceback ends up in the concfigured logs.
+                # the traceback ends up in the configured logs.
+                # 'wsgi.errors' must be defined according to PEP-0333
                 raise
             return self.catch_all_response(exc)(environ, start_response)
 


### PR DESCRIPTION
Imho it makes sense to propagate errors to the WSGI server in order to make use of the configured logging facilities.