### PR TITLE
make FSImage.__str__ available in Python 3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,10 @@ Bugfixes
 - Accept bytes and text as cookie value.
   (`#263 <https://github.com/zopefoundation/Zope/pull/263>`_)
 
+- ``__str__`` of an Image object now returns the image HTML tag in
+  Python 3 as it already did on Python 2.
+  (`#282 <https://github.com/zopefoundation/Zope/pull/282>`_)
+
 
 4.0b4 (2018-04-23)
 ------------------

--- a/src/OFS/Image.py
+++ b/src/OFS/Image.py
@@ -876,9 +876,8 @@ class Image(File):
     def __bytes__(self):
         return self.tag().encode('utf-8')
 
-    if PY2:
-        def __str__(self):
-            return self.tag()
+    def __str__(self):
+        return self.tag()
 
     security.declareProtected(View, 'tag')
     def tag(self, height=None, width=None, alt=None,

--- a/src/OFS/tests/testFileAndImage.py
+++ b/src/OFS/tests/testFileAndImage.py
@@ -27,6 +27,8 @@ from zope.component import adapter
 from zope.lifecycleevent.interfaces import IObjectModifiedEvent
 from zope.lifecycleevent.interfaces import IObjectCreatedEvent
 
+import six
+
 here = os.path.dirname(os.path.abspath(__file__))
 filedata = os.path.join(here, 'test.gif')
 
@@ -328,3 +330,8 @@ class ImageTests(FileTests):
         from OFS.interfaces import IWriteLock
 
         verifyClass(IWriteLock, Image)
+
+    def test_text_representation_is_tag(self):
+        self.assertEqual(six.text_type(self.file),
+                         '<img src="http://nohost/file"'
+                         ' alt="" title="" height="16" width="16" />')


### PR DESCRIPTION
In both Python 2 and 3, the tag() method returns the respective str type, so
the result can always be used for `__str__`. Without having this method
available in Python 3, the image tag cannot be included, for example, in
Chamaeleon page templates by simply accessing the image object, as that uses
i18n which in turn casts the object to the respective text (unicode) type. Not
implementing `__str__` in Python 3 results in the object representation instead
of the tag in that case.