### PR TITLE
[WIP] Convert ZODB via zodbupdate to Python 3

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -62,6 +62,7 @@ eggs = ZServer
 recipe = zc.recipe.egg
 interpreter = zopepy
 eggs = Zope
+       zodbupdate
 
 
 [alltests]

--- a/setup.py
+++ b/setup.py
@@ -126,5 +126,8 @@ setup(
             'runwsgi=Zope2.Startup.serve:main',
             'mkwsgiinstance=Zope2.utilities.mkwsgiinstance:main',
         ],
+        'zodbupdate.decode': [
+            'decodes = OFS:zodbupdate_decode_dict',
+        ],
     },
 )

--- a/src/OFS/__init__.py
+++ b/src/OFS/__init__.py
@@ -1,0 +1,5 @@
+zodbupdate_decode_dict = {
+    'OFS.Image File data': 'binary',
+    'OFS.Image Image data': 'binary',
+    'OFS.Image File title': 'utf-8'
+}

--- a/versions.cfg
+++ b/versions.cfg
@@ -51,3 +51,4 @@ zc.buildout = 2.11.4
 zc.recipe.egg = 2.0.5
 zc.recipe.testrunner = 2.0.0
 zest.releaser = 6.15.0
+zodbupdate = 1.0


### PR DESCRIPTION
The `str` objects stored in the ZODB have either to be converted to `bytes` or `unicode`.

This PR contains the necessary conversion table for `zodbupdate`.

Status: The conversion table is not yet complete, but conversion worked for a ZODB containing `OFS File` and `OFS Image` objects.

Calling the migration (has to be done in a Zope instance running Zope 4 on Python 2):
`bin/zodbupdate --pack --convert-py3 -f var/Data.fs`

