### PR TITLE
Create all scripts only once.

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -9,9 +9,9 @@ extends =
 installed = .installed.cfg
 parts =
     test
-    zopescripts
+    scripts
     zserverscripts
-    zopepy
+    zopescripts
     alltests
     ztktests
     allpy
@@ -36,25 +36,22 @@ initialization =
 eggs = Zope
 
 
-[zopescripts]
+[scripts]
 recipe = zc.recipe.egg
 eggs =
-    Zope
     tox
     wheel
     zest.releaser
-
 
 [zserverscripts]
 recipe = zc.recipe.egg
 eggs = ZServer
 
 
-[zopepy]
+[zopescripts]
 recipe = zc.recipe.egg
 interpreter = zopepy
 eggs = Zope
-       wheel
 
 
 [alltests]
@@ -135,6 +132,7 @@ eggs =
 recipe = zc.recipe.egg
 eggs = ${alltests:eggs}
 interpreter = allpy
+scripts = allpy
 
 
 [sphinx]
@@ -154,6 +152,6 @@ eggs = z3c.checkversions [buildout]
 [requirements]
 recipe = plone.recipe.command
 command =
-    ${zopepy:bin-directory}/${zopepy:interpreter} util.py
+    ${zopescripts:bin-directory}/${zopescripts:interpreter} util.py
 update-command = ${:command}
 stop-on-error = yes


### PR DESCRIPTION
Before this change the scripts of the Zope package where created three times.
The last created version was the one by `allpy`. That means that `bin/runwsgi`
contained all test eggs.

Now each script is only created once with its own scope. I think this makes it
clearer what each script contains.