### PR TITLE
Re-add support for XML-RPC

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,8 +11,16 @@ https://github.com/zopefoundation/Zope/blob/4.0a6/CHANGES.rst
 4.0b6 (unreleased)
 ------------------
 
+New features
+++++++++++++
+
+- Restore support for XML-RPC when using the WSGI publisher.
+
 - Add a minimum ``buildout.cfg`` suggestion in the docs for creating ``wsgi``
   instances.
+
+Bugfixes
+++++++++
 
 - Fix ZMI upload of `DTMLMethod` and `DTMLDocument` to store the DTML as a
   native ``str`` on both Python versions.
@@ -21,6 +29,10 @@ https://github.com/zopefoundation/Zope/blob/4.0a6/CHANGES.rst
 - Inlcude the ``zmi.styles`` repository in this package to break a circular
   dependency.
   (`#307 <https://github.com/zopefoundation/Zope/pull/307>`_)
+
+- Work around Python bug (https://bugs.python.org/issue27777)
+  when reading request bodies not encoded as application/x-www-form-urlencoded
+  or multipart/form-data.
 
 
 4.0b5 (2018-05-18)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,7 @@ https://github.com/zopefoundation/Zope/blob/4.0a6/CHANGES.rst
 New features
 ++++++++++++
 
-- Restore support for XML-RPC when using the WSGI publisher.
+- Restore support for XML-RPC when using the WSGI publisher - dropped in 4.0a2.
 
 - Add a minimum ``buildout.cfg`` suggestion in the docs for creating ``wsgi``
   instances.

--- a/src/ZPublisher/BaseRequest.py
+++ b/src/ZPublisher/BaseRequest.py
@@ -34,16 +34,11 @@ from zope.publisher.interfaces import NotFound as ztkNotFound
 from zope.publisher.interfaces.browser import IBrowserPublisher
 from zope.traversing.namespace import namespaceLookup
 from zope.traversing.namespace import nsParse
+from ZPublisher.xmlrpc import is_xmlrpc_response
 
 from App.bbb import HAS_ZSERVER
 from ZPublisher.Converters import type_converters
 from ZPublisher.interfaces import UseTraversalDefault
-
-if HAS_ZSERVER:
-    from ZServer.ZPublisher.xmlrpc import is_xmlrpc_response
-else:
-    def is_xmlrpc_response(response):
-        return False
 
 _marker = []
 UNSPECIFIED_ROLES = ''

--- a/src/ZPublisher/HTTPRequest.py
+++ b/src/ZPublisher/HTTPRequest.py
@@ -24,7 +24,6 @@ import time
 
 from AccessControl.tainted import should_be_tainted
 from AccessControl.tainted import taint_string
-import pkg_resources
 from six import binary_type
 from six import PY2
 from six import PY3
@@ -43,6 +42,7 @@ from ZPublisher.BaseRequest import BaseRequest
 from ZPublisher.BaseRequest import quote
 from ZPublisher.Converters import get_converter
 from ZPublisher.utils import basic_auth_decode
+from ZPublisher import xmlrpc
 
 if PY3:
     from html import escape
@@ -52,14 +52,6 @@ else:
     from cgi import escape
     from urllib import splitport
     from urllib import splittype
-
-xmlrpc = None
-try:
-    dist = pkg_resources.get_distribution('ZServer')
-except pkg_resources.DistributionNotFound:
-    pass
-else:
-    from ZServer.ZPublisher import xmlrpc
 
 # Flags
 SEQUENCE = 1
@@ -505,7 +497,8 @@ class HTTPRequest(BaseRequest):
             environ['QUERY_STRING'] = ''
 
         meth = None
-        fs = FieldStorage(fp=fp, environ=environ, keep_blank_values=1)
+        fs = ZopeFieldStorage(
+            fp=fp, environ=environ, keep_blank_values=1)
 
         # Keep a reference to the FieldStorage. Otherwise it's
         # __del__ method is called too early and closing FieldStorage.file.
@@ -515,7 +508,7 @@ class HTTPRequest(BaseRequest):
             if 'HTTP_SOAPACTION' in environ:
                 # Stash XML request for interpretation by a SOAP-aware view
                 other['SOAPXML'] = fs.value
-            elif (xmlrpc is not None and method == 'POST' and
+            elif (method == 'POST' and
                   ('content-type' in fs.headers and
                    'text/xml' in fs.headers['content-type'])):
                 # Ye haaa, XML-RPC!
@@ -1635,7 +1628,15 @@ def sane_environment(env):
     return dict
 
 
-ZopeFieldStorage = FieldStorage  # BBB
+class ZopeFieldStorage(FieldStorage):
+    """This subclass exists to work around a Python bug
+    (see https://bugs.python.org/issue27777) to make sure
+    we can read binary data from a request body.
+    """
+
+    def read_binary(self):
+        self._binary_file = True
+        return FieldStorage.read_binary(self)
 
 
 # Original version: zope.publisher.browser.FileUpload

--- a/src/ZPublisher/tests/testHTTPRequest.py
+++ b/src/ZPublisher/tests/testHTTPRequest.py
@@ -766,6 +766,31 @@ class HTTPRequestTests(unittest.TestCase, HTTPRequestFactoryMixin):
         self.assertEqual(req.cookies['multi2'],
                          'cookie data with unquoted spaces')
 
+    def test_processInputs_xmlrpc(self):
+        TEST_METHOD_CALL = (
+            b'<?xml version="1.0"?>'
+            b'<methodCall><methodName>test</methodName></methodCall>'
+        )
+        environ = self._makePostEnviron(body=TEST_METHOD_CALL)
+        environ['CONTENT_TYPE'] = 'text/xml'
+        req = self._makeOne(stdin=BytesIO(TEST_METHOD_CALL), environ=environ)
+        req.processInputs()
+        self.assertEqual(req.PATH_INFO, '/test')
+        self.assertEqual(req.args, ())
+
+    def test_processInputs_w_urlencoded_and_qs(self):
+        body = b'foo=1'
+        environ = {
+            'CONTENT_TYPE': 'application/x-www-form-urlencoded',
+            'CONTENT_LENGTH': len(body),
+            'QUERY_STRING': 'bar=2',
+            'REQUEST_METHOD': 'POST',
+        }
+        req = self._makeOne(stdin=BytesIO(body), environ=environ)
+        req.processInputs()
+        self.assertEqual(req.form['foo'], '1')
+        self.assertEqual(req.form['bar'], '2')
+
     def test_postProcessInputs(self):
         from ZPublisher.HTTPRequest import default_encoding
 

--- a/src/ZPublisher/tests/test_xmlrpc.py
+++ b/src/ZPublisher/tests/test_xmlrpc.py
@@ -1,0 +1,203 @@
+import unittest
+try:
+    import xmlrpc.client as xmlrpclib
+except ImportError:
+    import xmlrpclib
+
+from DateTime import DateTime
+
+
+class FauxResponse(object):
+
+    def __init__(self):
+        self._headers = {}
+        self._body = None
+
+    def setBody(self, body):
+        self._body = body
+
+    def setHeader(self, name, value):
+        self._headers[name] = value
+
+    def setStatus(self, status):
+        self._status = status
+
+
+class FauxInstance(object):
+    def __init__(self, **kw):
+        self.__dict__.update(kw)
+
+
+class XMLRPCResponseTests(unittest.TestCase):
+
+    def _getTargetClass(self):
+        from ZPublisher.xmlrpc import Response
+        return Response
+
+    def _makeOne(self, *args, **kw):
+        return self._getTargetClass()(*args, **kw)
+
+    def test_setBody(self):
+        body = FauxInstance(_secret='abc', public='def')
+        faux = FauxResponse()
+        response = self._makeOne(faux)
+
+        response.setBody(body)
+
+        body_str = faux._body
+        self.assertEqual(type(body_str), type(''))
+
+        as_set, method = xmlrpclib.loads(body_str)
+        as_set = as_set[0]
+
+        self.assertEqual(method, None)
+        self.assertFalse('_secret' in as_set.keys())
+        self.assertTrue('public' in as_set.keys())
+        self.assertEqual(as_set['public'], 'def')
+
+    def test_nil(self):
+        body = FauxInstance(public=None)
+        faux = FauxResponse()
+        response = self._makeOne(faux)
+        response.setBody(body)
+        data, method = xmlrpclib.loads(faux._body)
+        self.assert_(data[0]['public'] is None)
+
+    def test_instance(self):
+        # Instances are turned into dicts with their private
+        # attributes removed.
+        body = FauxInstance(_secret='abc', public='def')
+        faux = FauxResponse()
+        response = self._makeOne(faux)
+        response.setBody(body)
+        data, method = xmlrpclib.loads(faux._body)
+        data = data[0]
+        self.assertEqual(data, {'public': 'def'})
+
+    def test_instanceattribute(self):
+        # While the removal of private ('_') attributes works fine for the
+        # top-level instance, how about attributes that are themselves
+        # instances?
+        body = FauxInstance(public=FauxInstance(_secret='abc', public='def'))
+        faux = FauxResponse()
+        response = self._makeOne(faux)
+        response.setBody(body)
+        data, method = xmlrpclib.loads(faux._body)
+        data = data[0]['public']
+        self.assertEqual(data, {'public': 'def'})
+
+    def test_instanceattribute_recursive(self):
+        # Instance "flattening" should work recursively, ad infinitum
+        body = FauxInstance(public=FauxInstance(public=FauxInstance(
+            _secret='abc', public='def')))
+        faux = FauxResponse()
+        response = self._makeOne(faux)
+        response.setBody(body)
+        data, method = xmlrpclib.loads(faux._body)
+        data = data[0]['public']['public']
+        self.assertEqual(data, {'public': 'def'})
+
+    def test_instance_in_list(self):
+        # Instances are turned into dicts with their private
+        # attributes removed, even when embedded in another
+        # data structure.
+        body = [FauxInstance(_secret='abc', public='def')]
+        faux = FauxResponse()
+        response = self._makeOne(faux)
+        response.setBody(body)
+        data, method = xmlrpclib.loads(faux._body)
+        data = data[0][0]
+        self.assertEqual(data, {'public': 'def'})
+
+    def test_instance_in_dict(self):
+        # Instances are turned into dicts with their private
+        # attributes removed, even when embedded in another
+        # data structure.
+        body = {'faux': FauxInstance(_secret='abc', public='def')}
+        faux = FauxResponse()
+        response = self._makeOne(faux)
+        response.setBody(body)
+        data, method = xmlrpclib.loads(faux._body)
+        data = data[0]['faux']
+        self.assertEqual(data, {'public': 'def'})
+
+    def test_zopedatetimeinstance(self):
+        # DateTime instance at top-level
+        body = DateTime('2006-05-24 07:00:00 GMT+0')
+        faux = FauxResponse()
+        response = self._makeOne(faux)
+        response.setBody(body)
+        data, method = xmlrpclib.loads(faux._body)
+        data = data[0]
+        self.assertTrue(isinstance(data, xmlrpclib.DateTime))
+        self.assertEqual(data.value, u'2006-05-24T07:00:00+00:00')
+
+    def test_zopedatetimeattribute(self):
+        # DateTime instance as attribute
+        body = FauxInstance(public=DateTime('2006-05-24 07:00:00 GMT+0'))
+        faux = FauxResponse()
+        response = self._makeOne(faux)
+        response.setBody(body)
+        data, method = xmlrpclib.loads(faux._body)
+        data = data[0]['public']
+        self.assertTrue(isinstance(data, xmlrpclib.DateTime))
+        self.assertEqual(data.value, u'2006-05-24T07:00:00+00:00')
+
+    def test_zopedatetimeattribute_recursive(self):
+        # DateTime encoding should work recursively
+        body = FauxInstance(public=FauxInstance(
+            public=DateTime('2006-05-24 07:00:00 GMT+0')))
+        faux = FauxResponse()
+        response = self._makeOne(faux)
+        response.setBody(body)
+        data, method = xmlrpclib.loads(faux._body)
+        data = data[0]['public']['public']
+        self.assertTrue(isinstance(data, xmlrpclib.DateTime))
+        self.assertEqual(data.value, u'2006-05-24T07:00:00+00:00')
+
+    def test_zopedatetimeinstance_in_list(self):
+        # DateTime instance embedded in a list
+        body = [DateTime('2006-05-24 07:00:00 GMT+0')]
+        faux = FauxResponse()
+        response = self._makeOne(faux)
+        response.setBody(body)
+        data, method = xmlrpclib.loads(faux._body)
+        data = data[0][0]
+        self.assertTrue(isinstance(data, xmlrpclib.DateTime))
+        self.assertEqual(data.value, u'2006-05-24T07:00:00+00:00')
+
+    def test_zopedatetimeinstance_in_dict(self):
+        # DateTime instance embedded in a dict
+        body = {'date': DateTime('2006-05-24 07:00:00 GMT+0')}
+        faux = FauxResponse()
+        response = self._makeOne(faux)
+        response.setBody(body)
+        data, method = xmlrpclib.loads(faux._body)
+        data = data[0]['date']
+        self.assertTrue(isinstance(data, xmlrpclib.DateTime))
+        self.assertEqual(data.value, u'2006-05-24T07:00:00+00:00')
+
+    def test_functionattribute(self):
+        # Cannot marshal functions or methods, obviously
+
+        def foo():
+            pass
+
+        body = FauxInstance(public=foo)
+        faux = FauxResponse()
+        response = self._makeOne(faux)
+        response.setBody(body)
+        func = xmlrpclib.loads(faux._body)
+        self.assertEqual(func, (({'public': {}},), None))
+
+    def test_emptystringattribute(self):
+        # Test an edge case: attribute name '' is possible,
+        # at least in theory.
+        body = FauxInstance(_secret='abc')
+        setattr(body, '', True)
+        faux = FauxResponse()
+        response = self._makeOne(faux)
+        response.setBody(body)
+        data, method = xmlrpclib.loads(faux._body)
+        data = data[0]
+        self.assertEqual(data, {'': True})

--- a/src/ZPublisher/xmlrpc.py
+++ b/src/ZPublisher/xmlrpc.py
@@ -10,15 +10,209 @@
 # FOR A PARTICULAR PURPOSE.
 #
 ##############################################################################
+"""XML-RPC support module
 
-from zope.deferredimport import deprecated
+Written by Eric Kidd at UserLand software, with much help from Jim Fulton
+at DC. This code hooks Zope up to Fredrik Lundh's Python XML-RPC library.
 
-# BBB Zope 5.0
-deprecated(
-    'Please import from ZServer.ZPublisher.xmlrpc.',
-    dump_instance='ZServer.ZPublisher.xmlrpc:dump_instance',
-    parse_input='ZServer.ZPublisher.xmlrpc:parse_input',
-    response='ZServer.ZPublisher.xmlrpc:response',
-    Response='ZServer.ZPublisher.xmlrpc:Response',
-    WRAPPERS='ZServer.ZPublisher.xmlrpc:WRAPPERS',
-)
+See http://www.xmlrpc.com/ and http://linux.userland.com/ for more
+information about XML-RPC and Zope.
+"""
+
+import re
+import sys
+
+try:
+    import xmlrpc.client as xmlrpclib
+except ImportError:
+    import xmlrpclib
+
+from App.config import getConfiguration
+from zExceptions import Unauthorized
+from ZODB.POSException import ConflictError
+
+# Make DateTime.DateTime marshallable via XML-RPC
+# http://www.zope.org/Collectors/Zope/2109
+from DateTime.DateTime import DateTime
+WRAPPERS = xmlrpclib.WRAPPERS + (DateTime, )
+
+
+def dump_instance(self, value, write):
+    # Check for special wrappers
+    if value.__class__ in WRAPPERS:
+        self.write = write
+        value.encode(self)
+        del self.write
+    else:
+        # Store instance attributes as a struct (really?).
+        # We want to avoid disclosing private attributes.
+        # Private attributes are by convention named with
+        # a leading underscore character.
+        value = dict([(k, v) for (k, v) in value.__dict__.items()
+                      if k[:1] != '_'])
+        self.dump_struct(value, write)
+
+
+# Override the standard marshaller for object instances
+# to skip private attributes.
+try:
+    from types import InstanceType
+    xmlrpclib.Marshaller.dispatch[InstanceType] = dump_instance  # py2
+except ImportError:
+    xmlrpclib.Marshaller.dispatch['_arbitrary_instance'] = dump_instance  # py3
+
+xmlrpclib.Marshaller.dispatch[DateTime] = dump_instance
+
+
+def parse_input(data):
+    """Parse input data and return a method path and argument tuple
+
+    The data is a string.
+    """
+    #
+    # For example, with the input:
+    #
+    #   <?xml version="1.0"?>
+    #   <methodCall>
+    #      <methodName>examples.getStateName</methodName>
+    #      <params>
+    #         <param>
+    #            <value><i4>41</i4></value>
+    #            </param>
+    #         </params>
+    #      </methodCall>
+    #
+    # the function should return:
+    #
+    #     ('examples.getStateName', (41,))
+    params, method = xmlrpclib.loads(data)
+    # Translate '.' to '/' in meth to represent object traversal.
+    method = method.replace('.', '/')
+    return method, params
+
+# See below
+#
+# def response(anHTTPResponse):
+#     """Return a valid ZPublisher response object
+#
+#     Use data already gathered by the existing response.
+#     The new response will replace the existing response.
+#     """
+#     # As a first cut, lets just clone the response and
+#     # put all of the logic in our refined response class below.
+#     r=Response()
+#     r.__dict__.update(anHTTPResponse.__dict__)
+#     return r
+
+########################################################################
+# Possible implementation helpers:
+
+
+def is_xmlrpc_response(response):
+    return isinstance(response, Response)
+
+
+class Response(object):
+    """Customized Response that handles XML-RPC-specific details.
+
+    We override setBody to marhsall Python objects into XML-RPC. We
+    also override exception to convert errors to XML-RPC faults.
+
+    If these methods stop getting called, make sure that ZPublisher is
+    using the xmlrpc.Response object created above and not the original
+    HTTPResponse object from which it was cloned.
+
+    It's probably possible to improve the 'exception' method quite a bit.
+    The current implementation, however, should suffice for now.
+    """
+
+    _error_format = 'text/plain'  # No html in error values
+
+    # Because we can't predict what kind of thing we're customizing,
+    # we have to use delegation, rather than inheritance to do the
+    # customization.
+
+    def __init__(self, real):
+        self.__dict__['_real'] = real
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)
+
+    def __setattr__(self, name, v):
+        return setattr(self._real, name, v)
+
+    def __delattr__(self, name):
+        return delattr(self._real, name)
+
+    def setBody(self, body, title='', is_error=0, bogus_str_search=None):
+        if isinstance(body, xmlrpclib.Fault):
+            # Convert Fault object to XML-RPC response.
+            body = xmlrpclib.dumps(body, methodresponse=1, allow_none=True)
+        else:
+            # Marshall our body as an XML-RPC response. Strings will be sent
+            # strings, integers as integers, etc. We do *not* convert
+            # everything to a string first.
+            # Previously this had special handling if the response
+            # was a Python None. This is now patched in xmlrpclib to
+            # allow Nones nested inside data structures too.
+            try:
+                body = xmlrpclib.dumps(
+                    (body,), methodresponse=1, allow_none=True)
+            except ConflictError:
+                raise
+            except:
+                self.exception()
+                return
+        # Set our body to the XML-RPC message, and fix our MIME type.
+        self._real.setBody(body)
+        self._real.setHeader('content-type', 'text/xml')
+        return self
+
+    def exception(self, fatal=0, info=None,
+                  absuri_match=None, tag_search=None):
+        # Fetch our exception info. t is type, v is value and tb is the
+        # traceback object.
+        if isinstance(info, tuple) and len(info) == 3:
+            t, v, tb = info
+        else:
+            t, v, tb = sys.exc_info()
+
+        # Don't mask 404 respnses, as some XML-RPC libraries rely on the HTTP
+        # mechanisms for detecting when authentication is required. Fixes Zope
+        # Collector issue 525.
+        if issubclass(t, Unauthorized):
+            return self._real.exception(fatal=fatal, info=info)
+
+        # Create an appropriate Fault object. Containing error information
+        Fault = xmlrpclib.Fault
+        f = None
+        try:
+            # Strip HTML tags from the error value
+            vstr = str(v)
+            remove = [r"<[^<>]*>", r"&[A-Za-z]+;"]
+            for pat in remove:
+                vstr = re.sub(pat, " ", vstr)
+            if getConfiguration().debug_mode:
+                from traceback import format_exception
+                value = '\n' + ''.join(format_exception(t, vstr, tb))
+            else:
+                value = '%s - %s' % (t, vstr)
+            if isinstance(v, Fault):
+                f = v
+            elif isinstance(v, Exception):
+                f = Fault(-1, 'Unexpected Zope exception: %s' % value)
+            else:
+                f = Fault(-2, 'Unexpected Zope error value: %s' % value)
+        except ConflictError:
+            raise
+        except Exception:
+            f = Fault(-3, "Unknown Zope fault type")
+
+        # Do the damage.
+        self.setBody(f)
+        self._real.setStatus(200)
+
+        return tb
+
+
+response = Response

--- a/tox.ini
+++ b/tox.ini
@@ -9,8 +9,8 @@ commands =
 skip_install = true
 deps =
     coverage
-    setuptools==39.0.1
-    zc.buildout
+    setuptools==39.1.0
+    zc.buildout==2.11.4
 setenv =
     COVERAGE_FILE=.coverage.{envname}
 


### PR DESCRIPTION
This restores support for XML-RPC when running in Python 3 with the WSGI publisher instead of ZServer. It turns out that we need this to run Plone's browser-based functional tests, because robotframework uses XML-RPC to get the available test keywords.

Mostly this involves moving the `xmlrpc` module back from ZServer.ZPublisher to ZPublisher, along with the corresponding tests. The XML-RPC implementation doesn't depend on using the ZServer, so I think it still belongs in Zope itself.

I fixed a couple Python 3 compatibility issues in `xmlrpc.py`:
- Import from xmlrpc.client instead of xmlrpclib
- Make sure that our override of the code for dumping an arbitrary object instance takes effect in both Python 2 and 3

I also had to work around a Python bug (https://bugs.python.org/issue27777) that was causing an error when processing a request with a text/xml body. The bug was causing the file to hold the body to be opened as text rather than binary, and the workaround is to add a content-disposition header to the request so that cgi.FieldStorage decides to open it as binary. I added a test for this case.