### PR TITLE
complete abrupt ending sentence

### DIFF
--- a/docs/zope2book/SearchingZCatalog.rst
+++ b/docs/zope2book/SearchingZCatalog.rst
@@ -1314,12 +1314,12 @@ handle objects that change. As objects evolve and change, the
 index information is always current, even for rapidly changing
 information sources like message boards.
 
-On the other hand, cataloging a complex object when it changes
-(especially if the catalog index attempts to translate the
-information, as TextIndexNG, described below, can do with
-PDF files or Microsoft Office files). Some sites may benefit
-from mass cataloging, and having a cron job or other scheduled
-job initiate the mass cataloging every night.
+On the other hand, cataloging a complex object when it changes may be too time
+consuming during operation (especially if the catalog index attempts to
+translate the information, as TextIndexNG, described below, can do with PDF
+files or Microsoft Office files). Some sites may benefit from mass cataloging,
+and having a cron job or other scheduled job initiate the mass cataloging every
+night.
 
 In standard (non-CMF, non-Plone) Zope, none of the built-in
 object types attempt to automatically catalog themselves. In


### PR DESCRIPTION
The sentence "On the other hand, cataloging a complex object when it changes" ends abrupt and is missing the message.

Imho cataloging a complex object could be too time consuming - which is exactly what I added to the text.

Also, I wrapped the paragraphs at 80 characters, which is was Tres told me a while ago, see
https://github.com/zopefoundation/Zope/pull/261#pullrequestreview-106874625