### PR TITLE
SiteAccess: Make VirtualHostMonster support IPv6

### DIFF
--- a/src/Products/SiteAccess/VirtualHostMonster.py
+++ b/src/Products/SiteAccess/VirtualHostMonster.py
@@ -14,6 +14,7 @@ from ZPublisher.BeforeTraverse import queryBeforeTraverse
 from ZPublisher.BeforeTraverse import registerBeforeTraverse
 from ZPublisher.BeforeTraverse import unregisterBeforeTraverse
 from ZPublisher.BaseRequest import quote
+from ZPublisher.HTTPRequest import splitport
 from zExceptions import BadRequest
 
 
@@ -147,16 +148,7 @@ class VirtualHostMonster(Persistent, Item, Implicit):
                 stack.pop()
                 protocol = stack.pop()
                 host = stack.pop()
-                if ':' in host:
-                    if host.startswith('['):
-                        # IPv6 address passed
-                        host, port = host.rsplit(':', 1)
-                    else:
-                        # Name or IPv4 address passed
-                        host, port = host.split(':')
-                    request.setServerURL(protocol, host, port)
-                else:
-                    request.setServerURL(protocol, host)
+                request.setServerURL(protocol, *splitport(host))
                 path = list(stack)
 
             # Find and convert VirtualHostRoot directive

--- a/src/Products/SiteAccess/VirtualHostMonster.py
+++ b/src/Products/SiteAccess/VirtualHostMonster.py
@@ -148,7 +148,12 @@ class VirtualHostMonster(Persistent, Item, Implicit):
                 protocol = stack.pop()
                 host = stack.pop()
                 if ':' in host:
-                    host, port = host.split(':')
+                    if host.startswith('['):
+                        # IPv6 address passed
+                        host, port = host.rsplit(':', 1)
+                    else:
+                        # Name or IPv4 address passed
+                        host, port = host.split(':')
                     request.setServerURL(protocol, host, port)
                 else:
                     request.setServerURL(protocol, host)

--- a/src/Products/SiteAccess/tests/testVirtualHostMonster.py
+++ b/src/Products/SiteAccess/tests/testVirtualHostMonster.py
@@ -169,6 +169,12 @@ class VHMPort(unittest.TestCase):
       self.assertEqual(self.app.REQUEST['ACTUAL_URL'],
                            'http://www.mysite.com/folder/')
 
+    def testIPv4Noport(self):
+      ob = self.traverse('/VirtualHostBase/http/www.mysite.com'
+                           '/folder/')
+      self.assertEqual(self.app.REQUEST['ACTUAL_URL'],
+                           'http://www.mysite.com/folder/')
+
     def testPassedPortIPv4(self):
       ob = self.traverse('/VirtualHostBase/http/www.mysite.com:81'
                            '/folder/')
@@ -177,6 +183,12 @@ class VHMPort(unittest.TestCase):
 
     def testIPv6(self):
         ob = self.traverse('/VirtualHostBase/http/[::1]:80'
+                           '/folder/')
+        self.assertEqual(self.app.REQUEST['ACTUAL_URL'],
+                           'http://[::1]/folder/')
+
+    def testIPv6Noport(self):
+        ob = self.traverse('/VirtualHostBase/http/[::1]'
                            '/folder/')
         self.assertEqual(self.app.REQUEST['ACTUAL_URL'],
                            'http://[::1]/folder/')

--- a/src/Products/SiteAccess/tests/testVirtualHostMonster.py
+++ b/src/Products/SiteAccess/tests/testVirtualHostMonster.py
@@ -187,7 +187,7 @@ class VHMPort(unittest.TestCase):
         self.assertEqual(self.app.REQUEST['ACTUAL_URL'],
                            'http://[::1]/folder/')
 
-    def testIPv6Noport(self):
+    def testIPv6NoPort(self):
         ob = self.traverse('/VirtualHostBase/http/[::1]'
                            '/folder/')
         self.assertEqual(self.app.REQUEST['ACTUAL_URL'],


### PR DESCRIPTION
from https://bugs.launchpad.net/zope2/+bug/699865 :

VirtualHostMonster does not work with IPv6 named hosts.

In case of such rewrite configuration:

RewriteRule (.*) http://10.0.243.129:9280/VirtualHostBase/https/[%{SERVER_ADDR}]:4080$1 [L,P]

When SERVER_ADDR is fd00::74ba VirtualHostMonster dies with:

Traceback (most recent call last):
  File "/eggs/Zope2-2.12.14-py2.6-linux-x86_64.egg/ZPublisher/BeforeTraverse.py", line 145, in __call__
    meth(*(container, request, None)[:args])
  File "/eggs/Zope2-2.12.14-py2.6-linux-x86_64.egg/Products/SiteAccess/VirtualHostMonster.py", line 154, in __call__
    host, port = host.split(':')
ValueError: too many values to unpack

This is because IPv6 addresses contain ":" in them.