### PR TITLE
Do all DOM modifications directly on the complete callback.

### DIFF
--- a/src/zmi/styles/resources/zmi_base.js
+++ b/src/zmi/styles/resources/zmi_base.js
@@ -40,10 +40,9 @@ function addItem( elm, base_url ) {
 		$('#zmi-modal .modal-body').load(modal_body_url, function(responseTxt, statusTxt, xhr) {
 			if(statusTxt == "error") {
 				window.location.href = url_full;
+					return;
 			}
-		});
-		// Shift Titel to Modal Header
-		$( document ).ajaxComplete(function() {
+			// Shift Title to Modal Header
 			$('#zmi-modal .modal-body h2').detach().prependTo('#zmi-modal .modal-header');
 			// STRANGE: Why is this Removing Necessary..
 			$('#zmi-modal .modal-body i').remove();


### PR DESCRIPTION
Otherwise, the `ajaxComplete` callback might be added multiple times in case the modal in aborted without submission.

Fixes #327 .