### PR TITLE
Fix persistent AccessRule instances.

### DIFF
--- a/src/Products/SiteAccess/AccessRule.py
+++ b/src/Products/SiteAccess/AccessRule.py
@@ -1,0 +1,2 @@
+# BBB
+from ZPublisher.BeforeTraverse import NameCaller as AccessRule  # noqa: F401


### PR DESCRIPTION
They were removed years ago but can exist in legacy ZODBs.

If the approach is okay, I'll add a change log entry, too.