### PR TITLE
Support for installing zope via pipenv #272

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@
 /var/
 coverage.xml
 pip-selfcheck.json
+Pipfile
+Pipfile.lock

--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,7 @@ Zope can either be installed using:
 
 * `zc.buildout`, see https://zope.readthedocs.io/en/latest/INSTALL-buildout.html
 * `virtualenv` and `pip`, see https://zope.readthedocs.io/en/latest/INSTALL-virtualenv.html
+* `pipenv`, see https://zope.readthedocs.io/en/latest/INSTALL-pipenv.html
 
 License
 =======

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,1 @@
+ZServer==4.0b1 ; python_version < '3.0'

--- a/docs/INSTALL-pipenv.txt
+++ b/docs/INSTALL-pipenv.txt
@@ -1,0 +1,78 @@
+Installing Zope via ``pipenv``
+==============================
+
+.. highlight:: bash
+
+This document describes how to install Zope via ``pipenv``. Python 3 only.
+
+
+Create a Virtual Environment
+----------------------------
+
+.. code-block:: sh
+
+   $ python3.6 -m venv zope
+   $ cd zope
+
+
+Install pipenv
+--------------
+
+.. code-block:: sh
+    
+    $ bin/pip install pipenv
+
+
+Install the Zope Software Packages
+----------------------------------
+
+Look for the release you want to install on
+https://zopefoundation.github.io/Zope/. Than use the specific
+version of ``requirements-full.txt`` in the URL, replacing 4.0b4 in the example below.
+(Remove the --pre option for final releases.)
+
+.. code-block:: sh
+
+   $ bin/pipenv install -r https://zopefoundation.github.io/Zope/releases/4.0b4/requirements-full.txt --pre
+   ...
+   Successfully installed ...
+
+
+Creating a Zope instance
+------------------------
+
+Once you've installed Zope, you will need to create an "instance
+home". This is a directory that contains configuration and data for a
+Zope server process.  The instance home is created using the
+``mkwsgiinstance`` script:
+
+.. code-block:: sh
+
+  $ bin/pipenv run mkwsgiinstance -d .
+
+You will be asked to provide a user name and password for an
+administrator's account during ``mkwsgiinstance``.  To see the available
+command-line options, run the script with the ``--help`` option:
+
+.. code-block:: sh
+
+   $ bin/pipenv run mkwsgiinstance --help
+
+The `-d .` specifies the directory to create the instance home in.
+If you follow the example and choose the current directory, you'll
+find the instances files in the subdirectories of the ``virtualenv``:
+
+- ``etc/`` will hold the configuration files.
+- ``var/`` will hold the database files.
+
+
+Starting your created instance
+------------------------------
+
+To start your newly created instance, run the provided runwsgi script 
+with the generated configuration:
+
+.. code-block:: sh
+
+    $ bin/pipenv run runwsgi etc/zope.ini
+    

--- a/docs/INSTALL-pipenv.txt
+++ b/docs/INSTALL-pipenv.txt
@@ -5,6 +5,10 @@ Installing Zope via ``pipenv``
 
 This document describes how to install Zope via ``pipenv``. Python 3 only.
 
+Please note, that the support for Pipenv is considered experimental.
+
+Also, currently there is no support to update the Zope installation via ``pipenv``.
+
 
 Create a Virtual Environment
 ----------------------------

--- a/docs/INSTALL-pipenv.txt
+++ b/docs/INSTALL-pipenv.txt
@@ -75,4 +75,3 @@ with the generated configuration:
 .. code-block:: sh
 
     $ bin/pipenv run runwsgi etc/zope.ini
-    

--- a/docs/INSTALL-virtualenv.rst
+++ b/docs/INSTALL-virtualenv.rst
@@ -67,7 +67,7 @@ Creating a Zope instance
 
   The following steps describe how to install a WSGI based Zope instance.
   If you want/have to use ZServer instead of WSGI (Python 2 only!) follow
-  the documentation `Creating a Zope instance for Zope 2.13`_, but 
+  the documentation `Creating a Zope instance for Zope 2.13`_.
 
 .. _`Creating a Zope instance for Zope 2.13` : http://zope.readthedocs.io/en/2.13/INSTALL-virtualenv.html#creating-a-zope-instance
 

--- a/docs/INSTALL-virtualenv.rst
+++ b/docs/INSTALL-virtualenv.rst
@@ -40,15 +40,24 @@ Install the Zope Software Packages
 
 Look for the release you want to install on
 https://zopefoundation.github.io/Zope/. Than use the specific
-version of ``requirements-full.txt`` in the URL, replacing 4.0b4 in the example below:
+version of ``requirements-full.txt`` in the URL, replacing 4.0b6 in the example below:
 
 .. code-block:: sh
 
    $ bin/pip install \
-   -r https://zopefoundation.github.io/Zope/releases/4.0b4/requirements-full.txt
+   -r https://zopefoundation.github.io/Zope/releases/4.0b6/requirements-full.txt
    Obtaining Zope
    ...
    Successfully installed ...
+
+If you are on Python 2 and want to use ZServer instead of WSGI , you'll have to 
+install that package seperately using the version spec in constraints.txt
+
+.. code-block:: sh
+
+    $ bin/pip install \
+    -c https://zopefoundation.github.io/Zope/releases/4.0b6/constraints.txt \
+    ZServer
 
 
 Creating a Zope instance
@@ -58,8 +67,7 @@ Creating a Zope instance
 
   The following steps describe how to install a WSGI based Zope instance.
   If you want/have to use ZServer instead of WSGI (Python 2 only!) follow
-  the documentation `Creating a Zope instance for Zope 2.13`_, as it has not
-  changed since that version.
+  the documentation `Creating a Zope instance for Zope 2.13`_, but 
 
 .. _`Creating a Zope instance for Zope 2.13` : http://zope.readthedocs.io/en/2.13/INSTALL-virtualenv.html#creating-a-zope-instance
 

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -22,7 +22,6 @@ WebTest==2.0.29
 ZConfig==3.2.0
 ZEO==5.2.0
 ZODB==5.4.0
-ZServer==4.0b1 ; python_version < '3.0'
 Zope2==4.0b1
 five.globalrequest==99.1
 five.localsitemanager==3.1

--- a/util.py
+++ b/util.py
@@ -18,14 +18,15 @@ class CaseSensitiveParser(RawConfigParser):
         return value
 
 
-def generate(in_, out):
+def generate(in_, requirements_file, constraints_file):
     in_file = os.path.join(HERE, in_)
-    out_file = os.path.join(HERE, out)
-
+    out_file_requirements = os.path.join(HERE, requirements_file)
+    out_file_constraints = os.path.join(HERE, constraints_file)
     parser = CaseSensitiveParser()
     parser.read(in_file)
 
     requirements = []
+    constraints = []
     versions = parser.items('versions')
     zope_requirement = (
         '-e git+https://github.com/zopefoundation/Zope.git@master#egg=Zope\n')
@@ -41,16 +42,21 @@ def generate(in_, out):
         spec = '%s==%s' % (name, pin)
         if name in PY2_ONLY:
             spec += " ; python_version < '3.0'"
-        requirements.append(spec + '\n')
+            constraints.append(spec + '\n')
+        else:
+            requirements.append(spec + '\n')
 
-    with open(out_file, 'w') as fd:
+    with open(out_file_requirements, 'w') as fd:
         fd.write(zope_requirement)
         for req in sorted(requirements):
             fd.write(req)
+    with open(out_file_constraints, 'w') as fcon:
+        for con in sorted(constraints):
+            fcon.write(con)
 
 
 def main():
-    generate('versions-prod.cfg', 'requirements-full.txt')
+    generate('versions-prod.cfg', 'requirements-full.txt', 'constraints.txt')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This needs a change which requires an additional step if you install via pip and want to use ZServer. We did explicitly not document installation via pipenv with python 2.

This fixes #272.