### PR TITLE
Add notice that dev guide was written for Zope 2

### DIFF
--- a/docs/zdgbook/Acquisition.rst
+++ b/docs/zdgbook/Acquisition.rst
@@ -2,6 +2,8 @@
 Acquisition
 ###########
 
+.. include:: includes/zope2_notice.rst
+
 Acquisition is a mechanism that allows objects to obtain attributes
 from their environment.  It is similar to inheritance, except that,
 rather than searching an inheritance hierarchy to obtain attributes,

--- a/docs/zdgbook/AppendixA.rst
+++ b/docs/zdgbook/AppendixA.rst
@@ -2,6 +2,8 @@
 Appendix A: Zope Core Permissions
 #################################
 
+.. include:: includes/zope2_notice.rst
+
 This is a list of standard permissions included with Zope.  It is a
 good idea to use these permissions when applicable with your Zope
 products, rather than creating new ones.  A list of built-in Zope

--- a/docs/zdgbook/ComponentsAndInterfaces.rst
+++ b/docs/zdgbook/ComponentsAndInterfaces.rst
@@ -2,6 +2,8 @@
 Components and Interfaces
 #########################
 
+.. include:: includes/zope2_notice.rst
+
 Zope uses a component architecture internally in many places.  Zope
 components is nothing but Python objects with interfaces that
 describe them.  As a Zope developer you can use interfaces right now

--- a/docs/zdgbook/GettingStarted.rst
+++ b/docs/zdgbook/GettingStarted.rst
@@ -2,6 +2,8 @@
 Getting Started
 ###############
 
+.. include:: includes/zope2_notice.rst
+
 Introduction
 ============
 

--- a/docs/zdgbook/Introduction.rst
+++ b/docs/zdgbook/Introduction.rst
@@ -2,12 +2,10 @@
 Introduction
 ############
 
-.. include:: includes/zope2_notice.rst
-
 Overview
 ========
 
-Zope 2 is a free and open-source, object-oriented web application
+Zope is a free and open-source, object-oriented web application
 server written in the Python programming language.  The term ZOPE is
 an acronym for "Z Object Publishing Environment" (the Z doesn't
 really mean anything in particular).  However, nowadays ZOPE is
@@ -17,9 +15,7 @@ simply written as Zope.  It has three distinct audiences.
   Individuals who use of Zope's "out of the box" features to build
   websites.  This audience is interested in making use of Zope's
   existing array of features to create content management solutions.
-  They will likely make heavy use of "through the web" scripting
-  using DTML, Page Templates, and Python Scripts as well as (of
-  course) HTML and XML.  They are generally less concerned about code
+  They are generally less concerned about code
   reuse than the speed with which they can create a custom
   application or website.
 
@@ -27,8 +23,7 @@ simply written as Zope.  It has three distinct audiences.
   Individuals who wish to extend Zope to create highly customized
   solutions.  This audience is likely interested in creating highly
   reusable custom code that makes Zope do something new and
-  interesting.  They will likely make heavy use of "through the
-  file-system" style development.
+  interesting.
 
 *Administrators*
   Individuals responsible for keeping a Zope site running and
@@ -37,7 +32,7 @@ simply written as Zope.  It has three distinct audiences.
 This guide is intended to document Zope for the second audience,
 Developers, as defined above.  If you fit more into the "user"
 audience defined above, you'll probably want to start by reading `The
-Zope Book <http://docs.zope.org/zope2/zope2book>`_ .
+Zope Book <https://zope.readthedocs.io/en/latest/zope2book/>`_ .
 
 Throughout this guide, it is assumed that you know how to program in
 the Python programming language.  Most of the examples in this guide
@@ -60,7 +55,7 @@ covers the following topics:
   started with application development.
 
 *Components and Interfaces*
-  Zope use a component-centric development model.  This chapter
+  Zope uses a component-centric development model.  This chapter
   describes the component model in Zope and how Zope components are
   described through interfaces.
 

--- a/docs/zdgbook/Introduction.rst
+++ b/docs/zdgbook/Introduction.rst
@@ -2,6 +2,8 @@
 Introduction
 ############
 
+.. include:: includes/zope2_notice.rst
+
 Overview
 ========
 

--- a/docs/zdgbook/ObjectPublishing.rst
+++ b/docs/zdgbook/ObjectPublishing.rst
@@ -2,6 +2,8 @@
 Object Publishing
 #################
 
+.. include:: includes/zope2_notice.rst
+
 Introduction
 ============
 

--- a/docs/zdgbook/Products.rst
+++ b/docs/zdgbook/Products.rst
@@ -2,6 +2,8 @@
 Zope Products
 #############
 
+.. include:: includes/zope2_notice.rst
+
 Introduction
 ============
 

--- a/docs/zdgbook/Security.rst
+++ b/docs/zdgbook/Security.rst
@@ -2,6 +2,8 @@
 Security
 ########
 
+.. include:: includes/zope2_notice.rst
+
 Introduction
 ============
 

--- a/docs/zdgbook/TestingAndDebugging.rst
+++ b/docs/zdgbook/TestingAndDebugging.rst
@@ -2,6 +2,8 @@
 Testing and Debugging
 #####################
 
+.. include:: includes/zope2_notice.rst
+
 As you develop Zope applications you may run into problems.  This
 chapter covers debugging and testing techniques that can help you.
 The Zope debugger allow you to peek inside a running process and find

--- a/docs/zdgbook/ZODBPersistentComponents.rst
+++ b/docs/zdgbook/ZODBPersistentComponents.rst
@@ -2,6 +2,8 @@
 ZODB Persistent Components
 ##########################
 
+.. include:: includes/zope2_notice.rst
+
 Most Zope components live in the Zope Object DataBase (ZODB).
 Components that are stored in ZODB are said to be *persistent*.
 Creating persistent components is, for the most part, a trivial

--- a/docs/zdgbook/includes/zope2_notice.rst
+++ b/docs/zdgbook/includes/zope2_notice.rst
@@ -1,0 +1,3 @@
+.. attention::
+
+  This document was written for Zope2.

--- a/docs/zdgbook/includes/zope2_notice.rst
+++ b/docs/zdgbook/includes/zope2_notice.rst
@@ -1,3 +1,3 @@
 .. attention::
 
-  This document was written for Zope2.
+  This document was written for Zope 2.


### PR DESCRIPTION
This is the first step for #252.

Hereafter the documents will be updated to work with Zope 4/Python 3 one by one.