### PR TITLE
Fix #308: default-zpublisher-encoding breaks rendering

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -51,6 +51,10 @@ Bugfixes
   when reading request bodies not encoded as application/x-www-form-urlencoded
   or multipart/form-data.
 
+- Prevent breaking page rendering when setting `default-zpublisher-encoding`
+  in `zope.conf` on Python 2.
+  (`#308 <https://github.com/zopefoundation/Zope/issue/308>`_)
+
 
 4.0b5 (2018-05-18)
 ------------------

--- a/src/Zope2/Startup/datatypes.py
+++ b/src/Zope2/Startup/datatypes.py
@@ -206,6 +206,9 @@ def default_zpublisher_encoding(value):
     # so a module-level call to getConfiguration in any of them
     # results in getting config data structure without the necessary
     # value in it.
+    if PY2:
+        # unicode is not acceptable as encoding in HTTP headers:
+        value = str(value)
     from ZPublisher import Converters, HTTPRequest, HTTPResponse
     Converters.default_encoding = value
     HTTPRequest.default_encoding = value

--- a/src/Zope2/Startup/tests/test_schema.py
+++ b/src/Zope2/Startup/tests/test_schema.py
@@ -19,6 +19,8 @@ import tempfile
 import unittest
 
 import ZConfig
+import ZPublisher.HTTPRequest
+import Zope2.Startup.datatypes
 
 from Zope2.Startup.options import ZopeWSGIOptions
 
@@ -37,6 +39,13 @@ def getSchema():
 
 
 class WSGIStartupTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.default_encoding = ZPublisher.HTTPRequest.default_encoding
+
+    def tearDown(self):
+        Zope2.Startup.datatypes.default_zpublisher_encoding(
+            self.default_encoding)
 
     def load_config_text(self, text):
         # We have to create a directory of our own since the existence

--- a/src/Zope2/Startup/tests/test_schema.py
+++ b/src/Zope2/Startup/tests/test_schema.py
@@ -12,12 +12,12 @@
 #
 ##############################################################################
 
+import codecs
 import os
 import io
 import tempfile
 import unittest
 
-import six
 import ZConfig
 
 from Zope2.Startup.options import ZopeWSGIOptions
@@ -43,10 +43,7 @@ class WSGIStartupTestCase(unittest.TestCase):
         # of the directory is checked.  This handles this in a
         # platform-independent way.
         text = text.replace("<<INSTANCE_HOME>>", TEMPNAME)
-        if six.PY2:
-            sio = io.BytesIO(text)
-        else:
-            sio = io.StringIO(text)
+        sio = io.StringIO(text)
 
         os.mkdir(TEMPNAME)
         os.mkdir(TEMPVAR)
@@ -62,13 +59,12 @@ class WSGIStartupTestCase(unittest.TestCase):
         import Zope2.utilities
         base = os.path.dirname(Zope2.utilities.__file__)
         fn = os.path.join(base, "skel", "etc", "wsgi.conf.in")
-        f = open(fn)
-        text = f.read()
-        f.close()
+        with codecs.open(fn, encoding='utf-8') as f:
+            text = f.read()
         self.load_config_text(text)
 
     def test_environment(self):
-        conf, handler = self.load_config_text("""\
+        conf, handler = self.load_config_text(u"""\
             # instancehome is here since it's required
             instancehome <<INSTANCE_HOME>>
             <environment>
@@ -82,7 +78,7 @@ class WSGIStartupTestCase(unittest.TestCase):
             items, [("FEARFACTORY", "rocks"), ("NSYNC", "doesnt")])
 
     def test_zodb_db(self):
-        conf, handler = self.load_config_text("""\
+        conf, handler = self.load_config_text(u"""\
             instancehome <<INSTANCE_HOME>>
             <zodb_db main>
               <filestorage>
@@ -96,25 +92,25 @@ class WSGIStartupTestCase(unittest.TestCase):
         self.assertEqual(conf.databases[0].config.cache_size, 5000)
 
     def test_max_conflict_retries_default(self):
-        conf, handler = self.load_config_text("""\
+        conf, handler = self.load_config_text(u"""\
             instancehome <<INSTANCE_HOME>>
             """)
         self.assertEqual(conf.max_conflict_retries, 3)
 
     def test_max_conflict_retries_explicit(self):
-        conf, handler = self.load_config_text("""\
+        conf, handler = self.load_config_text(u"""\
             instancehome <<INSTANCE_HOME>>
             max-conflict-retries 15
             """)
         self.assertEqual(conf.max_conflict_retries, 15)
 
     def test_default_zpublisher_encoding(self):
-        conf, dummy = self.load_config_text("""\
+        conf, dummy = self.load_config_text(u"""\
             instancehome <<INSTANCE_HOME>>
             """)
         self.assertEqual(conf.default_zpublisher_encoding, 'utf-8')
 
-        conf, dummy = self.load_config_text("""\
+        conf, dummy = self.load_config_text(u"""\
             instancehome <<INSTANCE_HOME>>
             default-zpublisher-encoding iso-8859-15
             """)

--- a/src/Zope2/Startup/tests/test_schema.py
+++ b/src/Zope2/Startup/tests/test_schema.py
@@ -124,3 +124,6 @@ class WSGIStartupTestCase(unittest.TestCase):
             default-zpublisher-encoding iso-8859-15
             """)
         self.assertEqual(conf.default_zpublisher_encoding, 'iso-8859-15')
+        self.assertEqual(
+            ZPublisher.HTTPRequest.default_encoding, 'iso-8859-15')
+        self.assertEqual(type(ZPublisher.HTTPRequest.default_encoding), str)


### PR DESCRIPTION
Prevent breaking page rendering when setting `default-zpublisher-encoding` in `zope.conf` on Python 2.

Fixes #308.