### PR TITLE
Simplify buildout configuration

### DIFF
--- a/docs/INSTALL-buildout.rst
+++ b/docs/INSTALL-buildout.rst
@@ -72,19 +72,12 @@ On Linux, this can be done as follows::
         https://zopefoundation.github.io/Zope/releases/master/versions-prod.cfg
     parts =
         zopescripts
-        zopepy
     
     [zopescripts]
-    recipe = zc.recipe.egg
-    eggs =
-        Zope
-    
-    [zopepy]
     recipe = zc.recipe.egg
     interpreter = zopepy
     eggs =
         Zope
-
 
 Creating a Zope instance
 ::::::::::::::::::::::::


### PR DESCRIPTION
There is no need to have more than one part.