### PR TITLE
Fix test layer isolation issue

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -66,9 +66,11 @@ Bugfixes
   (`#308 <https://github.com/zopefoundation/Zope/issue/308>`_)
 
 - Fix `HTTPResponse.setBody` when the published object returns a tuple.
+  (`#340 <https://github.com/zopefoundation/Zope/pull/340>`_)
 
 - Fix ``Products.Five.browser.ObjectManagerSiteView.makeSite``
   to interact well with plone.testing's patching of the global site manager.
+  (`#361 <https://github.com/zopefoundation/Zope/pull/361>`_)
 
 
 4.0b5 (2018-05-18)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -67,6 +67,9 @@ Bugfixes
 
 - Fix `HTTPResponse.setBody` when the published object returns a tuple.
 
+- Fix ``Products.Five.browser.ObjectManagerSiteView.makeSite``
+  to interact well with plone.testing's patching of the global site manager.
+
 
 4.0b5 (2018-05-18)
 ------------------

--- a/src/Products/Five/component/browser.py
+++ b/src/Products/Five/component/browser.py
@@ -18,7 +18,7 @@ from Products.Five.browser import BrowserView
 from Products.Five.component import enableSite, disableSite
 from Products.Five.component.interfaces import IObjectManagerSite
 
-from zope.component.globalregistry import base
+from zope.component.globalregistry import getGlobalSiteManager
 from zope.component.hooks import setSite
 from zope.component.persistentregistry import PersistentComponents
 
@@ -44,7 +44,7 @@ class ObjectManagerSiteView(BrowserView):
         # TODO in the future we'll have to walk up to other site
         # managers and put them in the bases
         components = PersistentComponents()
-        components.__bases__ = (base,)
+        components.__bases__ = (getGlobalSiteManager(),)
         self.context.setSiteManager(components)
 
     def unmakeSite(self):


### PR DESCRIPTION
This fixes an issue that was causing some Plone tests to end up with the wrong base site manager.