### PR TITLE
Fix bin/mkwsgiinstance on Python 3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,10 @@ https://github.com/zopefoundation/Zope/blob/4.0a6/CHANGES.rst
 4.0b7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+Bugfixes
+++++++++
+
+- Fix `bin/mkwsgiinstance` on Python 3 when Zope was installed via ``pip``.
 
 
 4.0b6 (2018-10-11)

--- a/src/Zope2/utilities/mkwsgiinstance.py
+++ b/src/Zope2/utilities/mkwsgiinstance.py
@@ -217,6 +217,7 @@ def get_zope2path(python):
     try:
         output = subprocess.check_output(
             [python, '-c', 'import Zope2; print(Zope2.__file__)'],
+            universal_newlines=True,  # makes Python 3 return text, not bytes
             stderr=subprocess.PIPE)
         zope2file = output.strip()
     except subprocess.CalledProcessError:


### PR DESCRIPTION
When Zope was installed via `pip` an error occurs later on because the path
returned by `get_zope2path` is bytes but text is expected.

In Python 3.7+ there is an alias for `universal_newlines=True` which is
`text=True`. See https://docs.python.org/3.8/library/subprocess.html#subprocess.check_output