### PR TITLE
Fix handling of globals and locals in zconsole scripts.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,11 @@ https://github.com/zopefoundation/Zope/blob/4.0a6/CHANGES.rst
 4.0b7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+Bugfixes
+++++++++
+
+- Fix a bug with scopes in scripts with zconsole, which made it impossible to
+  reach global imports in the script within a function.
 
 
 4.0b6 (2018-10-11)

--- a/src/Zope2/utilities/tests/test_zconsole.py
+++ b/src/Zope2/utilities/tests/test_zconsole.py
@@ -21,12 +21,19 @@ instancehome $INSTANCE
 
 test_script = """
 import sys
+import Testing
 
+
+
+def print_info():
+    # This tests the availability of global variables and imports.
+    print(sys.argv[1:])
+    print(Testing.__doc__[:7])  # `Set up`
 
 if __name__ == '__main__':
     app.foo = '42'
     print(app.foo)
-    print(sys.argv[1:])
+    print_info()
 """
 
 
@@ -75,5 +82,6 @@ class ZConsoleTestCase(unittest.TestCase):
         finally:
             sys.argv = self.stored_sys_argv
             sys.stdout = self.stored_stdout
-        expected = "42\n['run', '{}', '{}', 'bar', 'baz']\n".format(self.zopeconf, script)  # noqa: E501
+        expected = "42\n['run', '{}', '{}', 'bar', 'baz']\n\nSet up\n".format(
+            self.zopeconf, script)
         self.assertEqual(expected, got)

--- a/src/Zope2/utilities/zconsole.py
+++ b/src/Zope2/utilities/zconsole.py
@@ -15,11 +15,12 @@ def runscript(zopeconf, script_name, *extra_args):
     app.REQUEST['PARENTS'] = [app]
     setRequest(app.REQUEST)
     newSecurityManager(None, user)
-    scriptglobals = globals()
+    scriptglobals = {}
     scriptglobals.update(__name__='__main__')
+    scriptglobals.update(app=app)
     with open(script_name) as script:
         scriptcode = script.read()
-    exec(compile(scriptcode, script_name, 'exec'))
+    exec(compile(scriptcode, script_name, 'exec'), scriptglobals)
 
 
 def debug(zopeconf):


### PR DESCRIPTION
In case `exec` is called without arguments, the current scope is used. This
results in a overfull `globals` missing the `app` which is only in `locals`.