### PR TITLE
Fix handling of non-ASCII characters in URLs.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,8 @@ Bugfixes
 - Fix a bug with scopes in scripts with zconsole, which made it impossible to
   reach global imports in the script within a function.
 
+- Fix handling of non-ASCII characters in URLs on Python 2 introduced on 4.0b5.
+
 
 4.0b6 (2018-10-11)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,7 @@ Bugfixes
   reach global imports in the script within a function.
 
 - Fix handling of non-ASCII characters in URLs on Python 2 introduced on 4.0b5.
+  (`#380 <https://github.com/zopefoundation/Zope/pull/380>`_)
 
 
 4.0b6 (2018-10-11)

--- a/src/ZPublisher/WSGIPublisher.py
+++ b/src/ZPublisher/WSGIPublisher.py
@@ -241,16 +241,14 @@ def publish_module(environ, start_response,
     result = ()
 
     path_info = environ.get('PATH_INFO')
-    if path_info:
+    if path_info and PY3:
         # The WSGI server automatically treats the PATH_INFO as latin-1 encoded
         # bytestrings. Typically this is a false assumption as the browser
         # delivers utf-8 encoded PATH_INFO. We, therefore, need to encode it
-        # again with latin-1 to get a utf-8 encoded bytestring. This is
-        # sufficient for Python 2.
+        # again with latin-1 to get a utf-8 encoded bytestring.
         path_info = path_info.encode('latin-1')
-        if PY3:
-            # In Python 3 we need unicode here, so we decode the bytestring.
-            path_info = path_info.decode('utf-8')
+        # But in Python 3 we need text here, so we decode the bytestring.
+        path_info = path_info.decode('utf-8')
 
         environ['PATH_INFO'] = path_info
     with closing(BytesIO()) as stdout, closing(BytesIO()) as stderr:


### PR DESCRIPTION
On Python 2 everything is fine only on Python 3 the recoding has to be done.

This regression was introduced in #181.