### PR TITLE
Restore old `__repr__`.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,13 @@ Bugfixes
 
 - Fix zodbupdate conversion of ``OFS.Image.Pdata`` objects.
 
+Other changes
++++++++++++++
+
+- Restore old ``__repr__`` via ``OFS.SimpleItem.PathReprProvider``. Use this
+  as first base class for your custom classes, to restore the old behaviour.
+  (`#379 <https://github.com/zopefoundation/Zope/issues/379>`_)
+
 
 4.0b6 (2018-10-11)
 ------------------

--- a/src/OFS/DTMLMethod.py
+++ b/src/OFS/DTMLMethod.py
@@ -31,6 +31,7 @@ from OFS import bbb
 from OFS.Cache import Cacheable
 from OFS.role import RoleManager
 from OFS.SimpleItem import Item_w__name__
+from OFS.SimpleItem import PathReprProvider
 from six import binary_type
 from six import PY2
 from six import PY3
@@ -54,6 +55,7 @@ class Code(object):
 
 
 class DTMLMethod(
+    PathReprProvider,
     RestrictedDTML,
     HTML,
     Implicit,

--- a/src/OFS/Folder.py
+++ b/src/OFS/Folder.py
@@ -25,6 +25,7 @@ from OFS.ObjectManager import ObjectManager
 from OFS.PropertyManager import PropertyManager
 from OFS.role import RoleManager
 from OFS.SimpleItem import Item
+from OFS.SimpleItem import PathReprProvider
 from zope.interface import implementer
 
 
@@ -57,6 +58,7 @@ def manage_addFolder(
 
 @implementer(IFolder)
 class Folder(
+    PathReprProvider,
     ObjectManager,
     PropertyManager,
     RoleManager,

--- a/src/OFS/Image.py
+++ b/src/OFS/Image.py
@@ -31,6 +31,7 @@ from OFS.interfaces import IWriteLock
 from OFS.PropertyManager import PropertyManager
 from OFS.role import RoleManager
 from OFS.SimpleItem import Item_w__name__
+from OFS.SimpleItem import PathReprProvider
 from Persistence import Persistent
 from six import binary_type
 from six import PY2
@@ -105,6 +106,7 @@ def manage_addFile(
 
 @implementer(IWriteLock, HTTPRangeSupport.HTTPRangeInterface)
 class File(
+    PathReprProvider,
     Persistent,
     Implicit,
     PropertyManager,

--- a/src/Products/Five/browser/tests/pages.txt
+++ b/src/Products/Five/browser/tests/pages.txt
@@ -261,17 +261,13 @@ The parent of the view is the view's context:
 
 The direct parent of the context is
 
-  >>> aq_inner(context).__parent__.__class__
-  <class 'OFS.Folder.Folder'>
-  >>> print(aq_inner(context).__parent__.getId())
-  test_folder_1_
+  >>> aq_inner(context).__parent__
+  <Folder at /test_folder_1_> 
 
 C methods work the same
 
-  >>> aq_parent(aq_inner(context)).__class__
-  <class 'OFS.Folder.Folder'>
-  >>> print(aq_parent(aq_inner(context)).getId())
-  test_folder_1_
+  >>> aq_parent(aq_inner(context))
+  <Folder at /test_folder_1_> 
 
 The same applies to a view registered with <browser:view /> instead of
 <browser:page />
@@ -290,10 +286,10 @@ The same applies to a view registered with <browser:view /> instead of
   True
   >>> aq_parent(view) == view.context
   True
-  >>> print(aq_inner(context).__parent__.getId())
-  test_folder_1_
-  >>> print(aq_parent(aq_inner(context)).getId())
-  test_folder_1_
+  >>> aq_inner(context).__parent__
+  <Folder at /test_folder_1_> 
+  >>> aq_parent(aq_inner(context))
+  <Folder at /test_folder_1_> 
 
 Make sure that methods which are not included in the allowed interface or
 attributes, but which already had security declarations from a base class,

--- a/src/Zope2/App/tests/test_safe_formatter.py
+++ b/src/Zope2/App/tests/test_safe_formatter.py
@@ -197,10 +197,8 @@ class FormatterFunctionalTest(FunctionalTestCase):
         namespace = {'context': self.app}
         self.assertEqual(
             pt.pt_render(namespace).strip(),
-            u'<p>{}</p>\n'
-            u'<p>{}</p>'.format(
-                escape(repr(self.app).lower()),
-                escape(repr(self.app).upper())))
+            u'<p>&lt;application at &gt;</p>\n'
+            u'<p>&lt;APPLICATION AT &gt;</p>')
 
     def test_cook_zope3_page_templates_using_format(self):
         from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
@@ -214,22 +212,19 @@ class FormatterFunctionalTest(FunctionalTestCase):
         self.app.test_folder_1_.__roles__ = ['Manager']
         self.assertEqual(
             pt.pt_render(namespace).strip(),
-            u"<p>class of {app_lower} is "
+            u"<p>class of &lt;application at &gt; is "
             u"&lt;class 'ofs.application.application'&gt;</p>\n"
-            u"<p>CLASS OF {app_upper} IS "
+            u"<p>CLASS OF &lt;APPLICATION AT &gt; IS "
             u"&lt;CLASS 'OFS.APPLICATION.APPLICATION'&gt;</p>\n"
-            u"<p>{{'foo': {folder}}} has "
-            u"foo={folder}</p>\n"
-            u"<p>{{'foo': {folder}}} has "
-            u"foo={folder}</p>\n"
-            u"<p>[{folder}] has "
-            u"first item {folder}</p>\n"
-            u"<p>[{folder}] has "
-            u"first item {folder}</p>".format(
-                app_lower=escape(repr(self.app).lower()),
-                app_upper=escape(repr(self.app).upper()),
-                folder=escape(repr(self.app.test_folder_1_))
-        ))
+            u"<p>{'foo': &lt;Folder at /test_folder_1_&gt;} has "
+            u"foo=&lt;Folder at test_folder_1_&gt;</p>\n"
+            u"<p>{'foo': &lt;Folder at /test_folder_1_&gt;} has "
+            u"foo=&lt;Folder at test_folder_1_&gt;</p>\n"
+            u"<p>[&lt;Folder at /test_folder_1_&gt;] has "
+            u"first item &lt;Folder at test_folder_1_&gt;</p>\n"
+            u"<p>[&lt;Folder at /test_folder_1_&gt;] has "
+            u"first item &lt;Folder at test_folder_1_&gt;</p>"
+        )
 
     def test_cook_zope2_page_templates_bad_key_str(self):
         from Products.PageTemplates.ZopePageTemplate import ZopePageTemplate
@@ -237,8 +232,7 @@ class FormatterFunctionalTest(FunctionalTestCase):
         hack_pt(pt, self.app)
         self.assertEqual(
             pt.pt_render(),
-            '<p>access by key: {}</p>'.format(
-                escape(repr(self.app.test_folder_1_))))
+            '<p>access by key: &lt;Folder at test_folder_1_&gt;</p>')
         self.app.test_folder_1_.__roles__ = ['Manager']
         with self.assertRaises(Unauthorized) as err:
             pt.pt_render()
@@ -252,8 +246,7 @@ class FormatterFunctionalTest(FunctionalTestCase):
         hack_pt(pt, self.app)
         self.assertEqual(
             pt.pt_render(),
-            '<p>access by key: {}</p>'.format(
-                escape(repr(self.app.test_folder_1_))))
+            '<p>access by key: &lt;Folder at test_folder_1_&gt;</p>')
         self.app.test_folder_1_.__roles__ = ['Manager']
         with self.assertRaises(Unauthorized) as err:
             pt.pt_render()
@@ -268,8 +261,7 @@ class FormatterFunctionalTest(FunctionalTestCase):
         hack_pt(pt, self.app.testlist)
         self.assertEqual(
             pt.pt_render(),
-            '<p>access by item: {}</p>'.format(
-                escape(repr(self.app.test_folder_1_))))
+            '<p>access by item: &lt;Folder at test_folder_1_&gt;</p>')
         self.app.test_folder_1_.__roles__ = ['Manager']
         with self.assertRaises(Unauthorized) as err:
             pt.pt_render()
@@ -284,8 +276,7 @@ class FormatterFunctionalTest(FunctionalTestCase):
         hack_pt(pt, self.app.testlist)
         self.assertEqual(
             pt.pt_render(),
-            '<p>access by item: {}</p>'.format(
-                escape(repr(self.app.test_folder_1_))))
+            '<p>access by item: &lt;Folder at test_folder_1_&gt;</p>')
         self.app.test_folder_1_.__roles__ = ['Manager']
         with self.assertRaises(Unauthorized) as err:
             pt.pt_render()

--- a/src/Zope2/utilities/tests/test_zconsole.py
+++ b/src/Zope2/utilities/tests/test_zconsole.py
@@ -58,11 +58,11 @@ class ZConsoleTestCase(unittest.TestCase):
             from Zope2.utilities.zconsole import debug
             sys.stdout = StringIO()
             got = debug(self.zopeconf)
-            expected = '<Application '
+            expected = '<Application at >'
         finally:
             sys.argv = self.stored_sys_argv
             sys.stdout = self.stored_stdout
-        self.assertTrue(str(got).startswith(expected))
+        self.assertEqual(expected, str(got))
 
     def test_runscript(self):
         script = os.path.join(self.instancedir, 'test_script.py')


### PR DESCRIPTION
Fixes #379 .

@pbauer : Please test this within Plone. There might be other classes needed to get the old style repr.