### PR TITLE
Set _p_repr to __repr__ to override Persistent's __repr__

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,8 +45,7 @@ Bugfixes
 Other changes
 +++++++++++++
 
-- Restore old ``__repr__`` via ``OFS.SimpleItem.PathReprProvider``. Use this
-  as first base class for your custom classes, to restore the old behaviour.
+- Restore old ``__repr__`` via ``OFS.SimpleItem.PathReprProvider``.
   (`#379 <https://github.com/zopefoundation/Zope/issues/379>`_)
 
 - Update dependencies to newest versions.

--- a/src/OFS/DTMLMethod.py
+++ b/src/OFS/DTMLMethod.py
@@ -31,7 +31,6 @@ from OFS import bbb
 from OFS.Cache import Cacheable
 from OFS.role import RoleManager
 from OFS.SimpleItem import Item_w__name__
-from OFS.SimpleItem import PathReprProvider
 from six import binary_type
 from six import PY2
 from six import PY3
@@ -55,7 +54,6 @@ class Code(object):
 
 
 class DTMLMethod(
-    PathReprProvider,
     RestrictedDTML,
     HTML,
     Implicit,

--- a/src/OFS/Folder.py
+++ b/src/OFS/Folder.py
@@ -25,6 +25,7 @@ from OFS.ObjectManager import ObjectManager
 from OFS.PropertyManager import PropertyManager
 from OFS.role import RoleManager
 from OFS.SimpleItem import Item
+from OFS.SimpleItem import PathReprProvider
 from zope.interface import implementer
 
 
@@ -58,6 +59,7 @@ def manage_addFolder(
 @implementer(IFolder)
 class Folder(
     ObjectManager,
+    PathReprProvider,
     PropertyManager,
     RoleManager,
     Collection,

--- a/src/OFS/Folder.py
+++ b/src/OFS/Folder.py
@@ -25,7 +25,6 @@ from OFS.ObjectManager import ObjectManager
 from OFS.PropertyManager import PropertyManager
 from OFS.role import RoleManager
 from OFS.SimpleItem import Item
-from OFS.SimpleItem import PathReprProvider
 from zope.interface import implementer
 
 
@@ -58,7 +57,6 @@ def manage_addFolder(
 
 @implementer(IFolder)
 class Folder(
-    PathReprProvider,
     ObjectManager,
     PropertyManager,
     RoleManager,

--- a/src/OFS/Folder.py
+++ b/src/OFS/Folder.py
@@ -58,8 +58,8 @@ def manage_addFolder(
 
 @implementer(IFolder)
 class Folder(
-    ObjectManager,
     PathReprProvider,
+    ObjectManager,
     PropertyManager,
     RoleManager,
     Collection,

--- a/src/OFS/Image.py
+++ b/src/OFS/Image.py
@@ -31,7 +31,6 @@ from OFS.interfaces import IWriteLock
 from OFS.PropertyManager import PropertyManager
 from OFS.role import RoleManager
 from OFS.SimpleItem import Item_w__name__
-from OFS.SimpleItem import PathReprProvider
 from Persistence import Persistent
 from six import binary_type
 from six import PY2
@@ -106,7 +105,6 @@ def manage_addFile(
 
 @implementer(IWriteLock, HTTPRangeSupport.HTTPRangeInterface)
 class File(
-    PathReprProvider,
     Persistent,
     Implicit,
     PropertyManager,

--- a/src/OFS/SimpleItem.py
+++ b/src/OFS/SimpleItem.py
@@ -73,9 +73,11 @@ logger = logging.getLogger()
 class PathReprProvider(Base):
     """Provides a representation that includes the physical path.
 
-    Should be in the MRO before persistent.Persistent as this provides an own
-    implementation of `__repr__` that includes information about connection and
-    oid.
+    Replaces the implementation of `__repr__` in persistent.Persistent that
+    that includes information about connection and oid but not physicalPath.
+    Persistent's __repr__ tries to delegate to a _p_repr. Setting _p_repr
+    works around the issue that in some MROs Persistent's __repr__
+    came before this one.
     """
 
     def __repr__(self):
@@ -98,6 +100,8 @@ class PathReprProvider(Base):
             res += ' used for %s' % context_path
         res += '>'
         return res
+
+    _p_repr = __repr__
 
 
 @implementer(IItem)


### PR DESCRIPTION
Persistent's `__repr__` tries to delegate to a `_p_repr` if it exists. Setting `_p_repr` works around the issue that in some MROs Persistent's `__repr__` came before the one in `OFS.SimpleItem`.