### PR TITLE
Zope 2.13: password possibly revealed in HTTPRequest.text() method

### DIFF
--- a/doc/CHANGES.rst
+++ b/doc/CHANGES.rst
@@ -8,7 +8,13 @@ http://docs.zope.org/zope2/
 2.13.29 (unreleased)
 --------------------
 
-- Nothing changed yet.
+Security related fixes
+++++++++++++++++++++++
+
+- ``HTTPRequest.text()`` now obscures values of fields those name
+  contain the string ``passw`` in the same way ``HTTPRequest.__str__`` already
+  did.
+  (`#375 <https://github.com/zopefoundation/Zope/issues/375>`_)
 
 
 2.13.28 (2018-04-23)

--- a/src/ZPublisher/HTTPRequest.py
+++ b/src/ZPublisher/HTTPRequest.py
@@ -1482,16 +1482,16 @@ class HTTPRequest(BaseRequest):
     def text(self):
         result = "FORM\n\n"
         row = '%-20s %s\n'
-        for k, v in self.form.items():
+        for k, v in _filterPasswordFields(self.form.items()):
             result = result + row % (k, repr(v))
         result = result + "\nCOOKIES\n\n"
-        for k, v in self.cookies.items():
+        for k, v in _filterPasswordFields(self.cookies.items()):
             result = result + row % (k, repr(v))
         result = result + "\nLAZY ITEMS\n\n"
-        for k, v in self._lazies.items():
+        for k, v in _filterPasswordFields(self._lazies.items()):
             result = result + row % (k, repr(v))
         result = result + "\nOTHER\n\n"
-        for k, v in self.other.items():
+        for k, v in _filterPasswordFields(self.other.items()):
             if k in ('PARENTS','RESPONSE'):
                 continue
             result = result + row % (k, repr(v))

--- a/src/ZPublisher/tests/testHTTPRequest.py
+++ b/src/ZPublisher/tests/testHTTPRequest.py
@@ -1059,16 +1059,16 @@ class HTTPRequestTests(unittest.TestCase, HTTPRequestFactoryMixin):
         req = self._makeOne()
         req.form['passwd'] = 'secret'
 
-        self.assertNotIn('secret', str(req))
-        self.assertIn('password obscured', str(req))
+        self.assert_('secret' not in str(req))
+        self.assert_('password obscured' in str(req))
 
     def test_text__password_field(self):
         # It obscures password fields.
         req = self._makeOne()
         req.form['passwd'] = 'secret'
 
-        self.assertNotIn('secret', req.text())
-        self.assertIn('password obscured', req.text())
+        self.assert_('secret' not in str(req))
+        self.assert_('password obscured' in str(req))
 
 
 class TestHTTPRequestZope3Views(TestRequestZope3ViewsBase,):

--- a/src/ZPublisher/tests/testHTTPRequest.py
+++ b/src/ZPublisher/tests/testHTTPRequest.py
@@ -1054,6 +1054,22 @@ class HTTPRequestTests(unittest.TestCase, HTTPRequestFactoryMixin):
         req._script = ['foo', 'bar']
         self.assertEquals(req.getVirtualRoot(), '/foo/bar')
 
+    def test___str____password_field(self):
+        # It obscures password fields.
+        req = self._makeOne()
+        req.form['passwd'] = 'secret'
+
+        self.assertNotIn('secret', str(req))
+        self.assertIn('password obscured', str(req))
+
+    def test_text__password_field(self):
+        # It obscures password fields.
+        req = self._makeOne()
+        req.form['passwd'] = 'secret'
+
+        self.assertNotIn('secret', req.text())
+        self.assertIn('password obscured', req.text())
+
 
 class TestHTTPRequestZope3Views(TestRequestZope3ViewsBase,):
 

--- a/version_ranges.cfg
+++ b/version_ranges.cfg
@@ -89,7 +89,7 @@ repoze.who = < 2.1.dev
 
 # tooling
 zc.buildout = < 2.4.dev
-zc.recipe.egg = < 2.1.dev
+zc.recipe.egg = < 2.0.6.dev
 Sphinx = < 1.1.dev
 collective.recipe.sphinxbuilder = < 0.7.2.dev
 docutils = < 0.13.dev
@@ -98,6 +98,7 @@ manuel = < 1.2.dev
 mechanize = < 0.3.dev
 python-gettext = < 1.3.dev
 zope.testbrowser = < 3.12.dev
+mr.developer = < 1.35.dev
 
 # pytz 2017.3 provokes a test failure in DateTime:
 # AssertionError: legacy timezone  Canada/East-Saskatchewan cannot be looked up


### PR DESCRIPTION
Port the fix for #375 to Zope 2.13.