### PR TITLE
Zope 2.13: SiteAccess: Make VirtualHostMonster support IPv6

### DIFF
--- a/src/Products/SiteAccess/VirtualHostMonster.py
+++ b/src/Products/SiteAccess/VirtualHostMonster.py
@@ -15,6 +15,7 @@ from ZPublisher.BeforeTraverse import queryBeforeTraverse
 from ZPublisher.BeforeTraverse import registerBeforeTraverse
 from ZPublisher.BeforeTraverse import unregisterBeforeTraverse
 from ZPublisher.BaseRequest import quote
+from ZPublisher.HTTPRequest import splitport
 from zExceptions import BadRequest
 
 class VirtualHostMonster(Persistent, Item, Implicit):
@@ -150,11 +151,7 @@ class VirtualHostMonster(Persistent, Item, Implicit):
                 stack.pop()
                 protocol = stack.pop()
                 host = stack.pop()
-                if ':' in host:
-                    host, port = host.split(':')
-                    request.setServerURL(protocol, host, port)
-                else:
-                    request.setServerURL(protocol, host)
+                request.setServerURL(protocol, *splitport(host))
                 path = list(stack)
 
             # Find and convert VirtualHostRoot directive

--- a/src/Products/SiteAccess/tests/testVirtualHostMonster.py
+++ b/src/Products/SiteAccess/tests/testVirtualHostMonster.py
@@ -139,6 +139,66 @@ for i, (vaddr, vr, _vh, p, ubase) in enumerate(gen_cases()):
 
     setattr(VHMRegressions, 'testTraverse%s' % i, test)
 
+class VHMPort(unittest.TestCase):
+
+    def setUp(self):
+        import transaction
+        from Testing.makerequest import makerequest
+        from Testing.ZopeTestCase.ZopeLite import app
+        transaction.begin()
+        self.app = makerequest(app())
+        if 'virtual_hosting' not in  self.app.objectIds():
+            # If ZopeLite was imported, we have no default virtual
+            # host monster
+            from Products.SiteAccess.VirtualHostMonster \
+                import manage_addVirtualHostMonster
+            manage_addVirtualHostMonster(self.app, 'virtual_hosting')
+        self.app.manage_addFolder('folder')
+        self.app.folder.manage_addDTMLMethod('doc', '')
+        self.app.REQUEST.set('PARENTS', [self.app])
+        self.traverse = self.app.REQUEST.traverse
+
+    def tearDown(self):
+        import transaction
+        transaction.abort()
+        self.app._p_jar.close()
+
+    def testIPv4(self):
+      ob = self.traverse('/VirtualHostBase/http/www.mysite.com:80'
+                           '/folder/')
+      self.assertEqual(self.app.REQUEST['ACTUAL_URL'],
+                           'http://www.mysite.com/folder/')
+
+    def testIPv4Noport(self):
+      ob = self.traverse('/VirtualHostBase/http/www.mysite.com'
+                           '/folder/')
+      self.assertEqual(self.app.REQUEST['ACTUAL_URL'],
+                           'http://www.mysite.com/folder/')
+
+    def testPassedPortIPv4(self):
+      ob = self.traverse('/VirtualHostBase/http/www.mysite.com:81'
+                           '/folder/')
+      self.assertEqual(self.app.REQUEST['ACTUAL_URL'],
+                           'http://www.mysite.com:81/folder/')
+
+    def testIPv6(self):
+        ob = self.traverse('/VirtualHostBase/http/[::1]:80'
+                           '/folder/')
+        self.assertEqual(self.app.REQUEST['ACTUAL_URL'],
+                           'http://[::1]/folder/')
+
+    def testIPv6NoPort(self):
+        ob = self.traverse('/VirtualHostBase/http/[::1]'
+                           '/folder/')
+        self.assertEqual(self.app.REQUEST['ACTUAL_URL'],
+                           'http://[::1]/folder/')
+
+    def testIPv6PassedPort(self):
+        ob = self.traverse('/VirtualHostBase/http/[::1]:81'
+                           '/folder/')
+        self.assertEqual(self.app.REQUEST['ACTUAL_URL'],
+                           'http://[::1]:81/folder/')
+
 
 class VHMAddingTests(unittest.TestCase):
 
@@ -198,8 +258,3 @@ class VHMAddingTests(unittest.TestCase):
         hook = queryBeforeTraverse(self.root, VirtualHostMonster.meta_type)
         self.assertTrue(hook)
 
-def test_suite():
-    suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(VHMRegressions))
-    suite.addTest(unittest.makeSuite(VHMAddingTests))
-    return suite

--- a/src/Products/SiteAccess/tests/testVirtualHostMonster.py
+++ b/src/Products/SiteAccess/tests/testVirtualHostMonster.py
@@ -97,7 +97,7 @@ class VHMRegressions(unittest.TestCase):
         ob = self.traverse('/VirtualHostBase/http/www.mysite.com:80'
                            '/folder/VirtualHostRoot')
         self.assertEqual(self.app.REQUEST['ACTUAL_URL'],
-                         'http://www.mysite.com/') 
+                         'http://www.mysite.com/')
 
 def gen_cases():
     for vbase, ubase in (
@@ -163,41 +163,50 @@ class VHMPort(unittest.TestCase):
         transaction.abort()
         self.app._p_jar.close()
 
+    def testHostname(self):
+        self.traverse('/VirtualHostBase/http/www.mysite.com:80/folder/')
+        self.assertEqual(self.app.REQUEST['ACTUAL_URL'],
+                         'http://www.mysite.com/folder/')
+
+    def testHostnameNoport(self):
+        self.traverse('/VirtualHostBase/http/www.mysite.com/folder/')
+        self.assertEqual(self.app.REQUEST['ACTUAL_URL'],
+                         'http://www.mysite.com/folder/')
+
+    def testPassedPortHostname(self):
+        self.traverse('/VirtualHostBase/http/www.mysite.com:81/folder/')
+        self.assertEqual(self.app.REQUEST['ACTUAL_URL'],
+                         'http://www.mysite.com:81/folder/')
+
     def testIPv4(self):
-      ob = self.traverse('/VirtualHostBase/http/www.mysite.com:80'
-                           '/folder/')
-      self.assertEqual(self.app.REQUEST['ACTUAL_URL'],
-                           'http://www.mysite.com/folder/')
+        self.traverse('/VirtualHostBase/http/127.0.0.1:80/folder/')
+        self.assertEqual(self.app.REQUEST['ACTUAL_URL'],
+                         'http://127.0.0.1/folder/')
 
     def testIPv4Noport(self):
-      ob = self.traverse('/VirtualHostBase/http/www.mysite.com'
-                           '/folder/')
-      self.assertEqual(self.app.REQUEST['ACTUAL_URL'],
-                           'http://www.mysite.com/folder/')
+        self.traverse('/VirtualHostBase/http/127.0.0.1/folder/')
+        self.assertEqual(self.app.REQUEST['ACTUAL_URL'],
+                         'http://127.0.0.1/folder/')
 
     def testPassedPortIPv4(self):
-      ob = self.traverse('/VirtualHostBase/http/www.mysite.com:81'
-                           '/folder/')
-      self.assertEqual(self.app.REQUEST['ACTUAL_URL'],
-                           'http://www.mysite.com:81/folder/')
+        self.traverse('/VirtualHostBase/http/127.0.0.1:81/folder/')
+        self.assertEqual(self.app.REQUEST['ACTUAL_URL'],
+                         'http://127.0.0.1:81/folder/')
 
     def testIPv6(self):
-        ob = self.traverse('/VirtualHostBase/http/[::1]:80'
-                           '/folder/')
+        self.traverse('/VirtualHostBase/http/[::1]:80/folder/')
         self.assertEqual(self.app.REQUEST['ACTUAL_URL'],
-                           'http://[::1]/folder/')
+                         'http://[::1]/folder/')
 
     def testIPv6NoPort(self):
-        ob = self.traverse('/VirtualHostBase/http/[::1]'
-                           '/folder/')
+        self.traverse('/VirtualHostBase/http/[::1]/folder/')
         self.assertEqual(self.app.REQUEST['ACTUAL_URL'],
-                           'http://[::1]/folder/')
+                         'http://[::1]/folder/')
 
     def testIPv6PassedPort(self):
-        ob = self.traverse('/VirtualHostBase/http/[::1]:81'
-                           '/folder/')
+        self.traverse('/VirtualHostBase/http/[::1]:81/folder/')
         self.assertEqual(self.app.REQUEST['ACTUAL_URL'],
-                           'http://[::1]:81/folder/')
+                         'http://[::1]:81/folder/')
 
 
 class VHMAddingTests(unittest.TestCase):


### PR DESCRIPTION
from https://bugs.launchpad.net/zope2/+bug/699865 :

VirtualHostMonster does not work with IPv6 named hosts.

In case of such rewrite configuration:

RewriteRule (.*) http://10.0.243.129:9280/VirtualHostBase/https/[%{SERVER_ADDR}]:4080$1 [L,P]

When SERVER_ADDR is fd00::74ba VirtualHostMonster dies with:

Traceback (most recent call last):
  File "/eggs/Zope2-2.12.14-py2.6-linux-x86_64.egg/ZPublisher/BeforeTraverse.py", line 145, in __call__
    meth(*(container, request, None)[:args])
  File "/eggs/Zope2-2.12.14-py2.6-linux-x86_64.egg/Products/SiteAccess/VirtualHostMonster.py", line 154, in __call__
    host, port = host.split(':')
ValueError: too many values to unpack

This is because IPv6 addresses contain ":" in them.

--
This is backport of https://github.com/zopefoundation/Zope/pull/314 to
2.13 branch

This also include part of:
2e9d01ea2b3ac0bac2e59dd06e070dd34329a4fe - flake8 Products/Shared/ZTUtils.
removing test_suite function from the test