### PR TITLE
Enable history page for OFS.Image.File

### DIFF
--- a/doc/CHANGES.rst
+++ b/doc/CHANGES.rst
@@ -22,6 +22,9 @@ Features
 - Add wildcard rewrite to sub host name in virtualHostMonster.
   (`#317 <https://github.com/zopefoundation/Zope/issues/317>`_)
 
+- Enable ZMI History tab for ``OFS.Image.File``.
+  (`#396 <https://github.com/zopefoundation/Zope/pull/396>`_)
+
 
 2.13.28 (2018-04-23)
 --------------------

--- a/src/OFS/tests/testFileAndImage.py
+++ b/src/OFS/tests/testFileAndImage.py
@@ -302,6 +302,16 @@ class FileTests(unittest.TestCase):
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0][1], self.file)
 
+    def testHistoryCompare(self):
+        self.file.manage_edit('a', 'text/plain',
+                              filedata='a')
+        getattr(self.app, self.factory)('b',
+                file='b', content_type='text/plain')
+        self.file.manage_historyCompare(
+            self.file,
+            self.app.b,
+            self.app.REQUEST)
+
     def test_interfaces(self):
         from zope.interface.verify import verifyClass
         from OFS.Image import File

--- a/src/OFS/tests/testFileAndImage.py
+++ b/src/OFS/tests/testFileAndImage.py
@@ -304,13 +304,15 @@ class FileTests(unittest.TestCase):
 
     def testHistoryCompare(self):
         self.file.manage_edit('a', 'text/plain',
-                              filedata='a')
+                              filedata='content_of_a')
         getattr(self.app, self.factory)('b',
-                file='b', content_type='text/plain')
-        self.file.manage_historyCompare(
+                file='content_of_b', content_type='text/plain')
+        page = self.file.manage_historyCompare(
             self.file,
             self.app.b,
             self.app.REQUEST)
+        self.assertTrue('content_of_a' in page)
+        self.assertTrue('content_of_b' in page)
 
     def test_interfaces(self):
         from zope.interface.verify import verifyClass


### PR DESCRIPTION
Use the standard history page, enabled using the same condition than the one
that enables the text area on edit (ie. the file must be text or javascript and
reasonably sized)