### PR TITLE
Add security declarations to SimpleItem's FTP methods.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,7 @@ Other changes
 - Add security declarations to ``SimpleItem.manage_FTPlist()`` and
   ``Simplified.manage_FTPstat()`` instead of requiring classes extending
   ``SimpleItem`` to do so.
+  (`#398 <https://github.com/zopefoundation/Zope/pull/398>`_)
 
 
 4.0b7 (2018-10-30)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,10 @@ Other changes
 
 - Update dependencies to newest versions.
 
+- Add security declarations to ``SimpleItem.manage_FTPlist()`` and
+  ``Simplified.manage_FTPstat()`` instead of requiring classes extending
+  ``SimpleItem`` to do so.
+
 
 4.0b7 (2018-10-30)
 ------------------

--- a/src/OFS/DTMLMethod.py
+++ b/src/OFS/DTMLMethod.py
@@ -381,9 +381,6 @@ class DTMLMethod(
             RESPONSE.setStatus(204)
             return RESPONSE
 
-        security.declareProtected(ftp_access, 'manage_FTPstat')  # NOQA: D001
-        security.declareProtected(ftp_access, 'manage_FTPlist')  # NOQA: D001
-
         @security.protected(ftp_access)
         def manage_FTPget(self):
             """ Get source for FTP download.

--- a/src/OFS/Image.py
+++ b/src/OFS/Image.py
@@ -707,9 +707,6 @@ class File(
             RESPONSE.setStatus(204)
             return RESPONSE
 
-        security.declareProtected(ftp_access, 'manage_FTPstat')  # NOQA: D001
-        security.declareProtected(ftp_access, 'manage_FTPlist')  # NOQA: D001
-
         @security.protected(ftp_access)
         def manage_FTPget(self):
             """Return body for ftp."""
@@ -877,12 +874,6 @@ class Image(File):
     security.declareProtected(View, 'index_html')  # NOQA: D001
     security.declareProtected(View, 'get_size')  # NOQA: D001
     security.declareProtected(View, 'getContentType')  # NOQA: D001
-
-    if bbb.HAS_ZSERVER:
-        security.declareProtected(change_images_and_files, 'PUT')  # NOQA: D001
-        security.declareProtected(ftp_access, 'manage_FTPstat')  # NOQA: D001
-        security.declareProtected(ftp_access, 'manage_FTPlist')  # NOQA: D001
-        security.declareProtected(ftp_access, 'manage_FTPget')  # NOQA: D001
 
     _properties = (
         {'id': 'title', 'type': 'string'},

--- a/src/OFS/SimpleItem.py
+++ b/src/OFS/SimpleItem.py
@@ -20,6 +20,7 @@ item types.
 
 from AccessControl.class_init import InitializeClass
 from AccessControl.Permissions import access_contents_information
+from AccessControl.Permissions import ftp_access
 from AccessControl.Permissions import view as View
 from AccessControl.SecurityInfo import ClassSecurityInfo
 from AccessControl.SecurityManagement import getSecurityManager
@@ -319,6 +320,7 @@ class Item(
     if bbb.HAS_ZSERVER:
         # FTP support methods
 
+        @security.protected(ftp_access)
         def manage_FTPstat(self, REQUEST):
             """Psuedo stat, used by FTP for directory listings.
             """
@@ -379,6 +381,7 @@ class Item(
             return marshal.dumps(
                 (mode, 0, 0, 1, owner, group, size, mtime, mtime, mtime))
 
+        @security.protected(ftp_access)
         def manage_FTPlist(self, REQUEST):
             """Directory listing for FTP.
 

--- a/src/Products/PageTemplates/ZopePageTemplate.py
+++ b/src/Products/PageTemplates/ZopePageTemplate.py
@@ -137,7 +137,7 @@ class ZopePageTemplate(Script, PageTemplate, Cacheable,
             self.output_encoding = output_encoding
 
         text_decoded = text_decoded.strip()
-        
+
         self.ZCacheable_invalidate()
         super(ZopePageTemplate, self).pt_edit(text_decoded, content_type)
 
@@ -294,9 +294,7 @@ class ZopePageTemplate(Script, PageTemplate, Cacheable,
         security.declareProtected(change_page_templates, 'manage_FTPput')
         manage_FTPput = PUT
 
-        security.declareProtected(ftp_access, 'manage_FTPstat')
-        security.declareProtected(ftp_access, 'manage_FTPlist')
-        security.declareProtected(ftp_access, 'manage_FTPget')
+        @security.protected(ftp_access)
         def manage_FTPget(self):
             "Get source for FTP download"
             result = self.read()


### PR DESCRIPTION
This no longer requires child classes to do so.
See zopefoundation/Products.CMFCore#53.