### PR TITLE
Fix str/bytes confusion on add DTMLDocument/DTMLMethod

### DIFF
--- a/src/OFS/DTMLDocument.py
+++ b/src/OFS/DTMLDocument.py
@@ -136,6 +136,10 @@ def addDTMLDocument(self, id, title='', file='', REQUEST=None, submit=None):
     """
     if hasattr(file, 'read'):
         file = file.read()
+    if PY3 and isinstance(file, binary_type):
+        file = file.decode('utf-8')
+    if PY2 and isinstance(file, text_type):
+        file = file.encode('utf-8')
     if not file:
         file = default_dd_html
     id = str(id)

--- a/src/OFS/DTMLMethod.py
+++ b/src/OFS/DTMLMethod.py
@@ -454,6 +454,10 @@ def addDTMLMethod(self, id, title='', file='', REQUEST=None, submit=None):
     """
     if hasattr(file, 'read'):
         file = file.read()
+    if PY3 and isinstance(file, binary_type):
+        file = file.decode('utf-8')
+    if PY2 and isinstance(file, text_type):
+        file = file.encode('utf-8')
     if not file:
         file = default_dm_html
     id = str(id)

--- a/src/Testing/ZopeTestCase/testFunctional.py
+++ b/src/Testing/ZopeTestCase/testFunctional.py
@@ -41,17 +41,17 @@ class TestFunctional(ZopeTestCase.FunctionalTestCase):
         self.basic_auth = '%s:%s' % (user_name, user_password)
 
         # A simple document
-        self.folder.addDTMLDocument('index_html', file='index')
+        self.folder.addDTMLDocument('index_html', file=b'index')
 
         # A document accessible only to its owner
-        self.folder.addDTMLDocument('secret_html', file='secret')
+        self.folder.addDTMLDocument('secret_html', file=b'secret')
         self.folder.secret_html.manage_permission(view, ['Owner'])
 
         # A method redirecting to the Zope root
         url = self.app.absolute_url()
         self.folder.addDTMLMethod(
             'redirect',
-            file='<dtml-call "RESPONSE.redirect(\'' + url + '\')">')
+            file=b'<dtml-call "RESPONSE.redirect(\'%s\')">' % url.encode('ascii'))
 
         # A method setting a cookie
         self.folder.addDTMLMethod('set_cookie', file=SET_COOKIE_DTML)


### PR DESCRIPTION
DTML documents need to be stored as native strings ("str" in both Py2 and Py3),
which was implemented in #265 for the manage_upload case (create a document,
then upload the content).

This commit introduces the conditional type conversion for the "add" case
as well (create a document with initial uploaded content).