### PR TITLE
There's no Python 3.8 on Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,12 +2,11 @@
 
 matrix:
   allow_failures:
-  - PROFILE: py27-conventions
-  - PROFILE: py35-conventions
-  - PROFILE: py36-conventions
-  - PROFILE: py237-conventions
-  - PROFILE: py37
-  - PROFILE: py38
+    - PROFILE: py27-conventions
+    - PROFILE: py35-conventions
+    - PROFILE: py36-conventions
+    - PROFILE: py237-conventions
+    - PROFILE: py37
 
 environment:
   matrix:
@@ -35,9 +34,6 @@ environment:
     - PROFILE: py37
       PYTHON_VERSION: 3.7"
       TOXENV: "py37"
-    - PROFILE: py38
-      PYTHON_VERSION: 3.8"
-      TOXENV: "py38"
 
 cache:
   - '%LOCALAPPDATA%\pip\Cache'


### PR DESCRIPTION
https://www.appveyor.com/docs/windows-images-software/#python does not
list Python 3.8 as an available version.

(In fact Python 3.8 is not out yet.)

Having it listed in appveyor.yml confuses tools like my
check-python-versions, as they detect an inconsistency between supported
Python versions listed in appveyor.yml with those listed eg. in
setup.py.