### PR TITLE
Retry: fix closing newly created request before processing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -54,6 +54,10 @@ Fixes
 - Update cookie expiration method in a way Firefox 63+ understands.
   (`#405 <https://github.com/zopefoundation/Zope/pull/405>`_)
 
+- Fix closing newly created request before processing it after a retryable
+  error has occurred.
+  (`#413 <https://github.com/zopefoundation/Zope/issues/413>`_)
+
 
 4.0b7 (2018-10-30)
 ------------------


### PR DESCRIPTION
See #413, item [3].

Because we do not have a special handling for `ConflictError` in the exception view code, the exception view for `IException` has to be unregistered as it otherwise prevents the `ConflictError` to propagate to the except block which does the retry handling.