### PR TITLE
Update name of installation document

### DIFF
--- a/docs/INSTALL-pip.rst
+++ b/docs/INSTALL-pip.rst
@@ -1,5 +1,5 @@
-Installing Zope in a ``virtualenv``
-===================================
+Installing Zope via ``pip``
+===========================
 
 .. highlight:: bash
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,7 +8,7 @@ Contents:
 
    WHATSNEW
    INSTALL-buildout
-   INSTALL-virtualenv
+   INSTALL-pip
    INSTALL-pipenv
    operation
    USERS


### PR DESCRIPTION
It was called "Install into a virtualenv" but actually a better name is "Install via pip", as also the other ways of installation  (via buildout and via pipenv)  make use of a virtualenv.