### PR TITLE
Remove "sudo" tag as it is deprecated.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-sudo: false
 
 matrix:
     include:


### PR DESCRIPTION
cf. https://blog.travis-ci.com/2018-10-04-combining-linux-infrastructures
and https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration