### PR TITLE
Restore the `View` ZMI tab on folders and their subclasses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,11 @@ https://github.com/zopefoundation/Zope/blob/4.0a6/CHANGES.rst
 4.0b9 (unreleased)
 ------------------
 
-- Nothing changed yet.
+Fixes
++++++
+
+- Restore the `View` ZMI tab on folders and their subclasses
+  (`#449 <https://github.com/zopefoundation/Zope/issues/449>`_)
 
 
 4.0b8 (2018-12-14)

--- a/src/OFS/Folder.py
+++ b/src/OFS/Folder.py
@@ -84,6 +84,7 @@ class Folder(
 
     manage_options = (
         ObjectManager.manage_options
+        + ({'label': 'View', 'action': ''}, )
         + PropertyManager.manage_options
         + RoleManager.manage_options
         + Item.manage_options


### PR DESCRIPTION
The View tab on OFS.Folder and derivatives was very useful and should be restored.

fixes #449