### PR TITLE
Remove support for Bobo Call Interface headers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,9 @@ Other changes
 Breaking changes
 ++++++++++++++++
 
+- Removed support for Bobo Call Interface
+ (`#462 <https://github.com/zopefoundation/Zope/pull/462>`_)
+
 - Removed support for ``management_page_charset``
  (`#313 <https://github.com/zopefoundation/Zope/issues/313>`_)
 

--- a/src/Testing/ZopeTestCase/zopedoctest/functional.py
+++ b/src/Testing/ZopeTestCase/zopedoctest/functional.py
@@ -168,9 +168,7 @@ def http(request_string, handle_errors=True):
         raise TypeError('')
 
     header_output = HTTPHeaderOutput(
-        protocol, ('x-content-type-warning', 'x-powered-by',
-                   'bobo-exception-type', 'bobo-exception-file',
-                   'bobo-exception-value', 'bobo-exception-line'))
+        protocol, ('x-content-type-warning', 'x-powered-by'))
 
     # With a HeaderParser the payload is always a string, Parser would create a
     # list of messages for multipart messages.

--- a/src/ZPublisher/HTTPResponse.py
+++ b/src/ZPublisher/HTTPResponse.py
@@ -841,32 +841,6 @@ class HTTPResponse(HTTPBaseResponse):
                 m = m + '\nNo Authorization header found.'
         raise Unauthorized(m)
 
-    def _setBCIHeaders(self, t, tb):
-        try:
-            # Try to capture exception info for bci calls
-            et = str(t).replace('\n', ' ')
-            self.setHeader('bobo-exception-type', et)
-
-            ev = 'See the server error log for details'
-            self.setHeader('bobo-exception-value', ev)
-
-            # Get the tb tail, which is the interesting part:
-            while tb.tb_next is not None:
-                tb = tb.tb_next
-            el = str(tb.tb_lineno)
-            ef = str(tb.tb_frame.f_code.co_filename)
-
-            # Do not give out filesystem information.
-            ef = ef.split(os.sep)[-1]
-
-            self.setHeader('bobo-exception-file', ef)
-            self.setHeader('bobo-exception-line', el)
-        except Exception:
-            # Don't try so hard that we cause other problems ;)
-            pass
-
-        del tb
-
     def exception(self, fatal=0, info=None, abort=1):
         if isinstance(info, tuple) and len(info) == 3:
             t, v, tb = info
@@ -876,7 +850,6 @@ class HTTPResponse(HTTPBaseResponse):
         if issubclass(t, Unauthorized):
             self._unauthorized()
 
-        self._setBCIHeaders(t, tb)
         self.setStatus(t)
         if self.status >= 300 and self.status < 400:
             if isinstance(v, str) and absuri_match(v) is not None:

--- a/src/ZPublisher/tests/testHTTPResponse.py
+++ b/src/ZPublisher/tests/testHTTPResponse.py
@@ -1292,23 +1292,6 @@ class HTTPResponseTests(unittest.TestCase):
         self.assertEqual(len(lines), 1)
         self.assertEqual(lines[0], b'Kilroy was here!')
 
-    def test__setBCIHeaders(self):
-        response = self._makeOne()
-        try:
-            raise AttributeError('ERROR VALUE')
-        except AttributeError:
-            t, v, tb = sys.exc_info()
-            response._setBCIHeaders(t, tb)
-            # required by Bobo Call Interface (BCI)
-            self.assertIn('AttributeError',
-                          response.headers['bobo-exception-type'])
-            self.assertEqual(response.headers['bobo-exception-value'],
-                             'See the server error log for details')
-            self.assertTrue('bobo-exception-file' in response.headers)
-            self.assertTrue('bobo-exception-line' in response.headers)
-        finally:
-            del tb
-
     def test_exception_Internal_Server_Error(self):
         response = self._makeOne()
         try:
@@ -1318,13 +1301,6 @@ class HTTPResponseTests(unittest.TestCase):
             self.assertTrue(b'ERROR VALUE' in bytes(body))
             self.assertEqual(response.status, 500)
             self.assertEqual(response.errmsg, 'Internal Server Error')
-            # required by Bobo Call Interface (BCI)
-            self.assertIn('AttributeError',
-                          response.headers['bobo-exception-type'])
-            self.assertEqual(response.headers['bobo-exception-value'],
-                             'See the server error log for details')
-            self.assertTrue('bobo-exception-file' in response.headers)
-            self.assertTrue('bobo-exception-line' in response.headers)
 
     def test_exception_500_text(self):
         message = u'ERROR \xe4 VALUE'
@@ -1341,10 +1317,3 @@ class HTTPResponseTests(unittest.TestCase):
             self.assertTrue(expected in bytes(body))
             self.assertEqual(response.status, 500)
             self.assertEqual(response.errmsg, 'Internal Server Error')
-            # required by Bobo Call Interface (BCI)
-            self.assertIn('AttributeError',
-                          response.headers['bobo-exception-type'])
-            self.assertEqual(response.headers['bobo-exception-value'],
-                             'See the server error log for details')
-            self.assertTrue('bobo-exception-file' in response.headers)
-            self.assertTrue('bobo-exception-line' in response.headers)


### PR DESCRIPTION
I'm testing the waters here. This should probably not get merged before some reasonable time to object has passed so people have time to speak up.

As the headers disclose unnecessary information and my search engine fu on what would still rely on them leads to only the implementation and a discussion from 2003 on whether to drop them or not, I'm thus betting BCI to be dead and unused at this point.

I'm also open to making this configurable, if this is still actually used for something.