### PR TITLE
Fix faulty ZMI links due to missing URL-quoting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,9 @@ https://github.com/zopefoundation/Zope/blob/4.0a6/CHANGES.rst
 Fixes
 +++++
 
+- Fix faulty ZMI links due to missing URL-quoting
+  (`#391 <https://github.com/zopefoundation/Zope/issues/391>`_)
+
 - Fix configuring the maximum number of conflict retries
   (`#413 <https://github.com/zopefoundation/Zope/issues/413>`_)
 

--- a/src/OFS/ObjectManager.py
+++ b/src/OFS/ObjectManager.py
@@ -50,6 +50,7 @@ from Persistence import Persistent
 from Products.PageTemplates.PageTemplateFile import PageTemplateFile
 from six import string_types
 from six import text_type
+from six.moves.urllib.parse import quote
 from zExceptions import BadRequest
 from zExceptions import ResourceLockedError
 from zope.container.contained import notifyContainerModified
@@ -897,7 +898,7 @@ class ObjectManager(
 
         items = []
         for id, obj in self.objectItems():
-            item = {'id': id, 'obj': obj}
+            item = {'id': id, 'quoted_id': quote(id), 'obj': obj}
             if sortkey not in ['id', 'position'] and hasattr(obj, sortkey):
                 # add the attribute by which we need to sort
                 item[sortkey] = getattr(obj, sortkey)
@@ -925,6 +926,7 @@ class ObjectManager(
         return [
             {
                 'id': item['id'],
+                'quoted_id': item['quoted_id'],
                 'obj': item['obj'],
             }
             for item in sorted_items

--- a/src/OFS/tests/testObjectManager.py
+++ b/src/OFS/tests/testObjectManager.py
@@ -16,6 +16,7 @@ from OFS.metaconfigure import setDeprecatedManageAddDelete
 from OFS.ObjectManager import ObjectManager
 from OFS.SimpleItem import SimpleItem
 from six import PY2
+from six.moves.urllib.parse import quote
 from zExceptions import BadRequest
 from Zope2.App import zcml
 from zope.component.testing import PlacelessSetup
@@ -501,6 +502,17 @@ class ObjectManagerTests(PlacelessSetup, unittest.TestCase):
             self.assertTrue(filename.endswith('.zexp') or
                             filename.endswith('.xml'))
 
+    def test_manage_get_sortedObjects_quote_id(self):
+        # manage_get_sortedObjects now returns a urlquoted version
+        # of the object ID to create correct links in the ZMI
+        om = self._makeOne()
+        hash_id = '#999'
+        om._setObject(hash_id, SimpleItem(hash_id))
+
+        result = om.manage_get_sortedObjects('id', 'asc')
+        self.assertEquals(len(result), 1)
+        self.assertEquals(result[0]['id'], hash_id)
+        self.assertEquals(result[0]['quoted_id'], quote(hash_id))
 
 _marker = object()
 

--- a/src/OFS/zpt/main.zpt
+++ b/src/OFS/zpt/main.zpt
@@ -81,7 +81,7 @@
                 </i>
               </td>
               <td class="zmi-object-id">
-                <a tal:attributes="href python:'%s/manage_workspace'%(ob_dict['id'])">
+                <a tal:attributes="href python:'%s/manage_workspace'%(ob_dict['quoted_id'])">
                   <span tal:replace="ob_dict/id">Id</span>
                   <span class="badge badge-warning" title="This item has been locked by WebDAV" tal:condition="ob/wl_isLocked | nothing">
                     <i class="fa fa-lock"></i>


### PR DESCRIPTION
Fixes #391 

The ZMI list view simply used the object's ID to construct the relative link for visiting the object. This works whenever the ID doesn't start with a character that has special meaning in URLs, like `#`. 

The fix adds another element to the mapping being iterated over which contains a URL-quoted representation of the ID, which is now used to construct that link.