### PR TITLE
Remove obsolete environment var

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,9 @@ Other changes
 - Document filesystem caching for Chameleon page templates
   (`#291 <https://github.com/zopefoundation/Zope/issues/291>`_)
 
+- Remove obsolete environment variable "Z_DEBUG_MODE"
+  (`#445 <https://github.com/zopefoundation/Zope/issues/445>`_)
+
 Breaking changes
 ++++++++++++++++
 

--- a/docs/zdgbook/ObjectPublishing.rst
+++ b/docs/zdgbook/ObjectPublishing.rst
@@ -574,12 +574,6 @@ Environment Variables
 You can control some facets of the publisher's operation by setting
 environment variables.
 
-- 'Z_DEBUG_MODE' -- Sets debug mode. In debug mode tracebacks are not
-  hidden in error pages. Also debug mode causes 'DTMLFile' objects,
-  External Methods and help topics to reload their contents from disk
-  when changed. You can also set debug mode with the '-D' switch when
-  starting Zope.
-
 - 'Z_REALM' -- Sets the basic authorization realm. This controls the
   realm name as it appears in the web browser's username and password
   dialog. You can also set the realm with the '__bobo_realm__' module
@@ -971,10 +965,7 @@ There are two exceptions to the above rule:
    returned.
 
 When a body is returned, traceback information will be included in a
-comment in the output. As mentioned earlier, the environment variable
-'Z_DEBUG_MODE' can be used to control how tracebacks are included. If
-this variable is set then tracebacks are included in 'PRE' tags,
-rather than in comments. This is very handy during debugging.
+comment in the output.
 
 Exceptions and Transactions
 ---------------------------

--- a/docs/zdgbook/TestingAndDebugging.rst
+++ b/docs/zdgbook/TestingAndDebugging.rst
@@ -77,7 +77,7 @@ idea to only turn it on for a few products at a time.
 Debug Mode
 ----------
 
-Setting the 'Z_DEBUG_MODE=1' environment puts Zope into debug mode.
+Normally, debug mode is set using the '-D' switch when starting Zope.
 This mode reduces the performance of Zope a little bit.  Debug model
 has a number of wide ranging effects:
 
@@ -90,9 +90,6 @@ has a number of wide ranging effects:
 - Zope will not fork into the background in debug mode, instead, it
   will remain attached to the terminal that started it and the main
   logging information will be redirected to that terminal.
-
-Normally, debug mode is set using the '-D' switch when starting Zope,
-though you can set the environment variable directly if you wish.
 
 By using debug mode and product refresh together you will have little
 reason to restart Zope while developing.

--- a/docs/zope2book/MaintainingZope.rst
+++ b/docs/zope2book/MaintainingZope.rst
@@ -35,14 +35,13 @@ Debug Mode and Automatic Startup
 If you are planning to run Zope on a Unix production system you should also
 disable *debug mode*. This means removing the `-D` option in startup scripts
 (e.g. the `start` script created by Zope at installation time which calls z2.py
-with the `-D` switch) and if you've manually set it, unsetting the
-`Z_DEBUG_MODE` environment variable. In debug mode, Zope does not detach itself
+with the `-D` switch). In debug mode, Zope does not detach itself
 from the terminal, which could cause startup scripts to malfunction.
 
 On Windows, running Zope as a service disables debug mode by default. You still
-can run Zope in debug mode by setting the `Z_DEBUG_MODE` environment variable
-or running Zope manually from a startup script with the `-D` option. Again,
-this is not recommended for production systems, since debug mode causes
+can run Zope in debug mode by running Zope manually from a startup script with
+the `-D` option.
+Again, this is not recommended for production systems, since debug mode causes
 performance loss.
 
 Automatic Startup for Custom-Built Zopes

--- a/src/Zope2/Startup/handlers.py
+++ b/src/Zope2/Startup/handlers.py
@@ -46,11 +46,6 @@ def _setenv(name, value):
         os.environ[name] = repr(value)
 
 
-def debug_mode(value):
-    value and _setenv('Z_DEBUG_MODE', '1')
-    return value
-
-
 def locale(value):
     import locale
     locale.setlocale(locale.LC_ALL, value)


### PR DESCRIPTION
This environment variable is no longer valid. Still, it has been
referenced, both in code by a setter, and several times in the
documentation.

The focus of this commit was to remove the references, not to fix
the documenation about how to debug Zope, as the whole documenation
will be amended, anyway - step by step.


modified:   docs/zdgbook/ObjectPublishing.rst
modified:   docs/zdgbook/TestingAndDebugging.rst
modified:   docs/zope2book/MaintainingZope.rst
modified:   src/Zope2/Startup/handlers.py