### PR TITLE
Remove reference to env variable PROFILE_PUBLISHER

### DIFF
--- a/docs/zdgbook/ObjectPublishing.rst
+++ b/docs/zdgbook/ObjectPublishing.rst
@@ -579,11 +579,6 @@ environment variables.
   dialog. You can also set the realm with the '__bobo_realm__' module
   variable, as mentioned previously.
 
-- 'PROFILE_PUBLISHER' -- Turns on profiling and sets the name of the
-  profile file. See the Python documentation for more information
-  about the Python profiler.
-
-
 Many more options can be set using switches on the startup script.
 See the *Zope Administrator's Guide* for more information.
 

--- a/docs/zdgbook/TestingAndDebugging.rst
+++ b/docs/zdgbook/TestingAndDebugging.rst
@@ -20,40 +20,6 @@ Zope provides debugging information through a number of sources.  It
 also allows you a couple avenues for getting information about Zope
 as it runs.
 
-The Control Panel
------------------
-
-The control panel provides a number of views that can help you debug
-Zope, especially in the area of performance.  The *Debugging
-Information* link on the control panel provides two views, *Debugging
-Info* and *Profiling*.
-
-Debugging info provides information on the number of object
-references and the status of open requests.  The object references
-list displays the name of the object and the number of references to
-that object in Zope.  Understanding how reference counts help
-debugging is a lengthy subject, but in general you can spot memory
-leaks in your application if the number of references to certain
-objects increases without bound.  The busier your site is, or the
-more content it holds, the more reference counts you will tend to
-have.
-
-Profiling uses the standard Python profiler.  This is turned on by
-setting the 'PROFILE_PUBLISHER' environment variable before executing
-Zope.
-
-When the profiler is running, the performance of your Zope system
-will suffer a lot.  Profiling should only be used for short periods
-of time, or on a separate ZEO client so that your normal users to not
-experience this significant penalty.
-
-Profiling provides you with information about which methods in your
-Zope system are taking the most time to execute.  It builds a
-*profile*, which lists the busiest methods on your system, sorted by
-increasing resource usage.  For details on the meaning of the
-profiler's output, read the `standard Python documentation
-<http://www.python.org/doc/current/lib/profile.html>`_
-
 Product Refresh Settings
 ------------------------
 


### PR DESCRIPTION
... from documenation, as it had been removed already 2003.

cf https://github.com/zopefoundation/Zope/commit/688d79acc94624b1f477879cf531bd28f806e873

Also, the section about getting debug and profiling information from Control Panel was removed.

No skipped ci, as otherwise only admins could merge.