### PR TITLE
remove import of ConflictError

### DIFF
--- a/src/ZPublisher/WSGIPublisher.py
+++ b/src/ZPublisher/WSGIPublisher.py
@@ -28,7 +28,6 @@ from zExceptions import (
     Unauthorized,
     upgradeException,
 )
-from ZODB.POSException import ConflictError
 from zope.component import queryMultiAdapter
 from zope.event import notify
 from zope.globalrequest import setRequest, clearRequest


### PR DESCRIPTION
ConflictError is no longer referenced, so the import should also go away.