### PR TITLE
Fix import sort order.

### DIFF
--- a/src/App/ApplicationManager.py
+++ b/src/App/ApplicationManager.py
@@ -11,14 +11,9 @@
 #
 ##############################################################################
 
-import os
-import sys
-
 from AccessControl.class_init import InitializeClass
 from AccessControl.requestmethod import requestmethod
 from Acquisition import Implicit
-from six.moves.urllib import parse
-
 from App.config import getConfiguration
 from App.Management import Tabs
 from App.special_dtml import DTMLFile
@@ -27,6 +22,10 @@ from App.version_txt import version_txt
 from OFS.Traversable import Traversable
 from Persistence import Persistent
 from Products.PageTemplates.PageTemplateFile import PageTemplateFile
+from six.moves.urllib import parse
+
+import os
+import sys
 
 
 class FakeConnection(object):

--- a/src/App/Common.py
+++ b/src/App/Common.py
@@ -12,14 +12,17 @@
 ##############################################################################
 """Commonly used utility functions."""
 
+from Acquisition import aq_base
+from Acquisition import aq_parent
+# BBB
+from os.path import realpath  # NOQA
+
 import os
 import sys
 import time
 
-from Acquisition import aq_base, aq_parent
 
 # BBB
-from os.path import realpath  # NOQA
 attrget = getattr
 
 # These are needed because the various date formats below must

--- a/src/App/Dialogs.py
+++ b/src/App/Dialogs.py
@@ -33,6 +33,7 @@
 
 from App.special_dtml import HTML
 
+
 MessageDialog = HTML("""
 <HTML>
 <HEAD>

--- a/src/App/Extensions.py
+++ b/src/App/Extensions.py
@@ -15,12 +15,11 @@
 Extensions currently include external methods.
 """
 from functools import total_ordering
-import os
-
 from six import exec_
-
-import Products
 from zExceptions import NotFound
+
+import os
+import Products
 
 
 @total_ordering

--- a/src/App/FactoryDispatcher.py
+++ b/src/App/FactoryDispatcher.py
@@ -10,23 +10,21 @@
 # FOR A PARTICULAR PURPOSE
 #
 ##############################################################################
-
-
-# Implement the manage_addProduct method of object managers
-import sys
-import types
+"""Implement the manage_addProduct method of object managers"""
 
 from AccessControl.class_init import InitializeClass
 from AccessControl.owner import UnownableOwner
-from AccessControl.SecurityInfo import ClassSecurityInfo
 from AccessControl.PermissionMapping import aqwrap
+from AccessControl.SecurityInfo import ClassSecurityInfo
 from Acquisition import Acquired
 from Acquisition import aq_base
 from Acquisition import Implicit
 from ExtensionClass import Base
+from OFS.metaconfigure import get_registered_packages
 from zExceptions import Redirect
 
-from OFS.metaconfigure import get_registered_packages
+import sys
+import types
 
 
 def _product_packages():

--- a/src/App/FindHomes.py
+++ b/src/App/FindHomes.py
@@ -13,6 +13,7 @@
 
 import os
 
+
 try:
     chome = os.environ['INSTANCE_HOME']
 except KeyError:

--- a/src/App/ImageFile.py
+++ b/src/App/ImageFile.py
@@ -12,11 +12,6 @@
 ##############################################################################
 """Image object that is stored in a file"""
 
-import os.path
-import stat
-import time
-import warnings
-
 from AccessControl.class_init import InitializeClass
 from AccessControl.SecurityInfo import ClassSecurityInfo
 from Acquisition import Explicit
@@ -28,7 +23,13 @@ from DateTime.DateTime import DateTime
 from zope.contenttype import guess_content_type
 from ZPublisher.Iterators import filestream_iterator
 
+import os.path
+import stat
+import time
+import warnings
 import Zope2
+
+
 PREFIX = os.path.realpath(
     os.path.join(os.path.dirname(Zope2.__file__), os.path.pardir))
 

--- a/src/App/Management.py
+++ b/src/App/Management.py
@@ -13,21 +13,24 @@
 """Standard management interface support
 """
 
-from AccessControl import Unauthorized
 from AccessControl import ClassSecurityInfo
+from AccessControl import Unauthorized
 from AccessControl.class_init import InitializeClass
 from AccessControl.Permissions import view_management_screens
-from App.interfaces import INavigation
 from App.interfaces import ICSSPaths
 from App.interfaces import IJSPaths
+from App.interfaces import INavigation
 from App.special_dtml import DTMLFile
 from ExtensionClass import Base
-from six.moves.urllib.parse import quote, unquote
+from six.moves.urllib.parse import quote
+from six.moves.urllib.parse import unquote
 from zExceptions import Redirect
 from zope.interface import implementer
+
 import itertools
 import six
 import zope.event
+
 
 try:
     from html import escape

--- a/src/App/ProductContext.py
+++ b/src/App/ProductContext.py
@@ -13,20 +13,19 @@
 """Objects providing context for product initialization
 """
 
-from logging import getLogger
-import os
-import sys
-
 from AccessControl.Permission import registerPermissions
 from AccessControl.PermissionRole import PermissionRole
+from App.FactoryDispatcher import FactoryDispatcher
+from logging import getLogger
 from OFS.ObjectManager import ObjectManager
-
 from zope.interface import implementedBy
 
-from App.FactoryDispatcher import FactoryDispatcher
-
+import os
 # Waaaa
 import Products
+import sys
+
+
 if not hasattr(Products, 'meta_types'):
     Products.meta_types = ()
 if not hasattr(Products, 'meta_classes'):

--- a/src/App/Undo.py
+++ b/src/App/Undo.py
@@ -13,17 +13,16 @@
 """Undo support.
 """
 
-import binascii
-
-from Acquisition import Implicit
 from AccessControl import ClassSecurityInfo
 from AccessControl.class_init import InitializeClass
 from AccessControl.Permissions import undo_changes
-from DateTime.DateTime import DateTime
-import transaction
-
+from Acquisition import Implicit
 from App.Management import Tabs
 from App.special_dtml import DTMLFile
+from DateTime.DateTime import DateTime
+
+import binascii
+import transaction
 
 
 class UndoSupport(Tabs, Implicit):

--- a/src/App/ZApplication.py
+++ b/src/App/ZApplication.py
@@ -19,6 +19,7 @@ and used when bobo publishes a bobo_application object.
 
 import sys
 
+
 if sys.version_info >= (3, ):
     basestring = str
 

--- a/src/App/bbb.py
+++ b/src/App/bbb.py
@@ -13,6 +13,7 @@
 
 import pkg_resources
 
+
 HAS_ZSERVER = True
 try:
     dist = pkg_resources.get_distribution('ZServer')

--- a/src/App/class_init.py
+++ b/src/App/class_init.py
@@ -15,6 +15,7 @@
 
 from zope.deferredimport import deprecated
 
+
 # BBB Zope 5.0
 deprecated(
     'Please import from AccessControl.Permission.',

--- a/src/App/config.py
+++ b/src/App/config.py
@@ -14,6 +14,7 @@
 
 import os
 
+
 _config = None
 
 

--- a/src/App/special_dtml.py
+++ b/src/App/special_dtml.py
@@ -11,23 +11,29 @@
 #
 ##############################################################################
 
-import os
-import sys
+from AccessControl import getSecurityManager
+from Acquisition import aq_acquire
+from Acquisition import aq_inner
+from Acquisition import aq_parent
+from Acquisition import Explicit
+from App import Common
+from App.config import getConfiguration
+from ComputedAttribute import ComputedAttribute
+from DocumentTemplate.DT_String import _marker
+from DocumentTemplate.DT_String import DTReturn
+from DocumentTemplate.DT_String import render_blocks
+from DocumentTemplate.DT_Util import InstanceDict
+from DocumentTemplate.DT_Util import TemplateDict
 from logging import getLogger
+from Shared.DC.Scripts.Bindings import Bindings
 
 import DocumentTemplate
 import MethodObject
+import os
 import Persistence
-from App import Common
-from App.config import getConfiguration
+import sys
 import Zope2
 
-from Shared.DC.Scripts.Bindings import Bindings
-from Acquisition import Explicit, aq_inner, aq_parent, aq_acquire
-from DocumentTemplate.DT_String import _marker, DTReturn, render_blocks
-from DocumentTemplate.DT_Util import TemplateDict, InstanceDict
-from AccessControl import getSecurityManager
-from ComputedAttribute import ComputedAttribute
 
 LOG = getLogger('special_dtml')
 

--- a/src/App/tests/testImageFile.py
+++ b/src/App/tests/testImageFile.py
@@ -1,12 +1,12 @@
-import io
-import os.path
 from io import BytesIO
-import unittest
-
-import App
 from Testing.ZopeTestCase.warnhook import WarningsHook
 from ZPublisher.HTTPRequest import WSGIRequest
 from ZPublisher.HTTPResponse import WSGIResponse
+
+import App
+import io
+import os.path
+import unittest
 
 
 class TestImageFile(unittest.TestCase):

--- a/src/App/tests/test_ApplicationManager.py
+++ b/src/App/tests/test_ApplicationManager.py
@@ -1,8 +1,8 @@
-import Testing.ZopeTestCase
 import os
 import shutil
 import sys
 import tempfile
+import Testing.ZopeTestCase
 import unittest
 
 

--- a/src/App/tests/test_class_init.py
+++ b/src/App/tests/test_class_init.py
@@ -14,10 +14,10 @@
 """Tests class initialization.
 """
 
-import unittest
-
 from AccessControl.class_init import InitializeClass
+
 import ExtensionClass
+import unittest
 
 
 class TestInitializeClass(unittest.TestCase):

--- a/src/App/tests/test_getZopeVersion.py
+++ b/src/App/tests/test_getZopeVersion.py
@@ -13,10 +13,11 @@
 ##############################################################################
 """Tests for the recreated `getZopeVersion`."""
 
+from App.version_txt import getZopeVersion
+from pkg_resources import get_distribution
+
 import unittest
 
-from pkg_resources import get_distribution
-from App.version_txt import getZopeVersion
 
 class Test(unittest.TestCase):
     def test_major(self):

--- a/src/App/tests/test_setConfiguration.py
+++ b/src/App/tests/test_setConfiguration.py
@@ -13,9 +13,9 @@
 ##############################################################################
 """Tests for App.config.setConfiguration()
 """
-import unittest
-
 from Testing.ZopeTestCase.layer import ZopeLite
+
+import unittest
 
 
 class SetConfigTests(unittest.TestCase):

--- a/src/App/version_txt.py
+++ b/src/App/version_txt.py
@@ -11,10 +11,10 @@
 #
 ##############################################################################
 import collections
+import pkg_resources
 import re
 import sys
 
-import pkg_resources
 
 _version_string = None
 _zope_version = None

--- a/src/OFS/tests/test_DTMLMethod.py
+++ b/src/OFS/tests/test_DTMLMethod.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
-import Testing.ZopeTestCase
-import Testing.testbrowser
-import Zope2.App.zcml
 import io
+import Testing.testbrowser
+import Testing.ZopeTestCase
 import unittest
 import zExceptions
+import Zope2.App.zcml
 
 
 def _lock_item(item):

--- a/src/Products/Five/browser/adding.py
+++ b/src/Products/Five/browser/adding.py
@@ -19,8 +19,9 @@ factory screen.
 (original: zope.app.container.browser.adding)
 """
 
-import operator
-
+from OFS.SimpleItem import SimpleItem
+from Products.Five import BrowserView
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from six import PY2
 from zExceptions import BadRequest
 from zope.browser.interfaces import IAdding
@@ -42,9 +43,7 @@ from zope.lifecycleevent import ObjectCreatedEvent
 from zope.publisher.interfaces import IPublishTraverse
 from zope.traversing.browser.absoluteurl import absoluteURL
 
-from OFS.SimpleItem import SimpleItem
-from Products.Five import BrowserView
-from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+import operator
 
 
 @implementer(IAdding, IPublishTraverse)

--- a/src/Products/Five/browser/decode.py
+++ b/src/Products/Five/browser/decode.py
@@ -15,13 +15,13 @@
     encoding.
 """
 
-import sys
+from six import binary_type
+from six import text_type
 from warnings import warn
-
-from ZPublisher.HTTPRequest import isCGI_NAMEs
 from zope.i18n.interfaces import IUserPreferredCharsets
+from ZPublisher.HTTPRequest import isCGI_NAMEs
 
-from six import text_type, binary_type
+import sys
 
 
 def _decode(text, charsets):

--- a/src/Products/Five/browser/metaconfigure.py
+++ b/src/Products/Five/browser/metaconfigure.py
@@ -17,11 +17,25 @@ Directives to emulate the 'http://namespaces.zope.org/browser'
 namespace in ZCML known from zope.app.
 """
 
-import os
-import sys
+from AccessControl.class_init import InitializeClass
+from AccessControl.security import CheckerPrivateId
+from AccessControl.security import getSecurityInfo
+from AccessControl.security import protectClass
+from AccessControl.security import protectName
 from inspect import isfunction
 from inspect import ismethod
-
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from Products.Five.browser.resource import DirectoryResourceFactory
+from Products.Five.browser.resource import FileResourceFactory
+from Products.Five.browser.resource import ImageResourceFactory
+from Products.Five.browser.resource import PageTemplateResourceFactory
+from zope.browserpage.metaconfigure import _handle_allowed_attributes
+from zope.browserpage.metaconfigure import _handle_allowed_interface
+from zope.browserpage.metaconfigure import _handle_for
+from zope.browserpage.metaconfigure import _handle_menu
+from zope.browserpage.metaconfigure import _handle_permission
+from zope.browserpage.metaconfigure import providesCallable
+from zope.browserpage.metadirectives import IViewDirective
 from zope.component import queryMultiAdapter
 from zope.component.interface import provideInterface
 from zope.component.zcml import handler
@@ -34,27 +48,10 @@ from zope.publisher.interfaces.browser import IBrowserRequest
 from zope.publisher.interfaces.browser import IDefaultBrowserLayer
 from zope.security.zcml import Permission
 
+import os
+import sys
 import zope.browserpage.metaconfigure
 import zope.browserpage.simpleviewclass
-from zope.browserpage.metaconfigure import _handle_allowed_attributes
-from zope.browserpage.metaconfigure import _handle_allowed_interface
-from zope.browserpage.metaconfigure import _handle_for
-from zope.browserpage.metaconfigure import _handle_menu
-from zope.browserpage.metaconfigure import _handle_permission
-from zope.browserpage.metaconfigure import providesCallable
-from zope.browserpage.metadirectives import IViewDirective
-
-from AccessControl.class_init import InitializeClass
-from AccessControl.security import getSecurityInfo
-from AccessControl.security import protectClass
-from AccessControl.security import protectName
-from AccessControl.security import CheckerPrivateId
-
-from Products.Five.browser.resource import FileResourceFactory
-from Products.Five.browser.resource import ImageResourceFactory
-from Products.Five.browser.resource import PageTemplateResourceFactory
-from Products.Five.browser.resource import DirectoryResourceFactory
-from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 
 
 def is_method(func):

--- a/src/Products/Five/browser/pagetemplatefile.py
+++ b/src/Products/Five/browser/pagetemplatefile.py
@@ -14,15 +14,15 @@
 """A 'PageTemplateFile' without security restrictions.
 """
 
-from os.path import basename
-from zope.component import getMultiAdapter
-from zope.pagetemplate.pagetemplatefile import PageTemplateFile
-from zope.pagetemplate.engine import TrustedAppPT
-
-from Acquisition import aq_get
 from AccessControl import getSecurityManager
-from Products.PageTemplates.Expressions import SecureModuleImporter
+from Acquisition import aq_get
+from os.path import basename
 from Products.PageTemplates.Expressions import createTrustedZopeEngine
+from Products.PageTemplates.Expressions import SecureModuleImporter
+from zope.component import getMultiAdapter
+from zope.pagetemplate.engine import TrustedAppPT
+from zope.pagetemplate.pagetemplatefile import PageTemplateFile
+
 
 _engine = createTrustedZopeEngine()
 

--- a/src/Products/Five/browser/resource.py
+++ b/src/Products/Five/browser/resource.py
@@ -14,19 +14,18 @@
 """Provide basic resource functionality
 """
 
-import os
-
+from Products.Five.browser import BrowserView
 from six.moves.urllib.parse import unquote
-import zope.browserresource.directory
-import zope.browserresource.file
 from zope.browserresource.file import File
 from zope.interface import implementer
-from zope.traversing.browser import absoluteURL
+from zope.ptresource.ptresource import PageTemplate
 from zope.publisher.interfaces import NotFound
 from zope.publisher.interfaces.browser import IBrowserPublisher
-from zope.ptresource.ptresource import PageTemplate
+from zope.traversing.browser import absoluteURL
 
-from Products.Five.browser import BrowserView
+import os
+import zope.browserresource.directory
+import zope.browserresource.file
 
 
 _marker = object()

--- a/src/Products/Five/browser/tests/classes.py
+++ b/src/Products/Five/browser/tests/classes.py
@@ -14,8 +14,9 @@
 """Test fixtures
 """
 
-from zope.interface import Interface, implementer
 from Products.Five import BrowserView
+from zope.interface import implementer
+from zope.interface import Interface
 
 
 class IOne(Interface):

--- a/src/Products/Five/browser/tests/i18n.py
+++ b/src/Products/Five/browser/tests/i18n.py
@@ -14,8 +14,9 @@
 """Test i18n.
 """
 
-from zope.i18nmessageid import MessageFactory
 from Products.Five import BrowserView
+from zope.i18nmessageid import MessageFactory
+
 
 _ = MessageFactory('fivetest')
 

--- a/src/Products/Five/browser/tests/test_scriptsecurity.py
+++ b/src/Products/Five/browser/tests/test_scriptsecurity.py
@@ -1,6 +1,6 @@
-import unittest
-
 from AccessControl import Unauthorized
+
+import unittest
 
 
 def addPythonScript(folder, id, params='', body=''):

--- a/src/Products/Five/component/__init__.py
+++ b/src/Products/Five/component/__init__.py
@@ -14,22 +14,25 @@
 """Five local component look-up support
 """
 
-import zope.component
-import zope.event
-import zope.interface
+from Acquisition import aq_base
+from Acquisition import aq_inner
+from Acquisition import aq_parent
+from zope.component.hooks import setHooks
 from zope.component.interfaces import IPossibleSite
 from zope.component.interfaces import ISite
 from zope.interface.interfaces import IComponentLookup
 from zope.traversing.interfaces import BeforeTraverseEvent
-
-import ExtensionClass
-from Acquisition import aq_base, aq_inner, aq_parent
 from ZPublisher.BeforeTraverse import NameCaller
 from ZPublisher.BeforeTraverse import registerBeforeTraverse
 from ZPublisher.BeforeTraverse import unregisterBeforeTraverse
 
+import ExtensionClass
+import zope.component
+import zope.event
+import zope.interface
+
+
 # Hook up custom component architecture calls
-from zope.component.hooks import setHooks
 setHooks()
 
 

--- a/src/Products/Five/component/browser.py
+++ b/src/Products/Five/component/browser.py
@@ -15,9 +15,9 @@
 """
 
 from Products.Five.browser import BrowserView
-from Products.Five.component import enableSite, disableSite
+from Products.Five.component import disableSite
+from Products.Five.component import enableSite
 from Products.Five.component.interfaces import IObjectManagerSite
-
 from zope.component.globalregistry import getGlobalSiteManager
 from zope.component.hooks import setSite
 from zope.component.persistentregistry import PersistentComponents

--- a/src/Products/Five/component/interfaces.py
+++ b/src/Products/Five/component/interfaces.py
@@ -14,8 +14,8 @@
 """Component interfaces
 """
 
-from zope.component.interfaces import ISite
 from OFS.interfaces import IObjectManager
+from zope.component.interfaces import ISite
 
 
 class IObjectManagerSite(IObjectManager, ISite):

--- a/src/Products/Five/component/tests.py
+++ b/src/Products/Five/component/tests.py
@@ -14,9 +14,10 @@
 """Component tests
 """
 
-import unittest
 from doctest import DocFileSuite
 from Testing.ZopeTestCase import FunctionalDocFileSuite
+
+import unittest
 
 
 def test_suite():

--- a/src/Products/Five/fiveconfigure.py
+++ b/src/Products/Five/fiveconfigure.py
@@ -16,16 +16,16 @@
 These directives are specific to Five and have no equivalents outside of it.
 """
 
-import logging
-import os
-import glob
-import sys
-
 from App.config import getConfiguration
+from Products.Five.browser.metaconfigure import page
 from zope.configuration.exceptions import ConfigurationError
 from zope.publisher.interfaces.browser import IDefaultBrowserLayer
 
-from Products.Five.browser.metaconfigure import page
+import glob
+import logging
+import os
+import sys
+
 
 if sys.version_info >= (3, ):
     basestring = str

--- a/src/Products/Five/fivedirectives.py
+++ b/src/Products/Five/fivedirectives.py
@@ -14,9 +14,9 @@
 """Five ZCML directive schemas
 """
 
-from zope.interface import Interface
 from zope.browserresource.metadirectives import IBasicResourceInformation
 from zope.configuration.fields import GlobalObject
+from zope.interface import Interface
 from zope.schema import TextLine
 
 

--- a/src/Products/Five/metaconfigure.py
+++ b/src/Products/Five/metaconfigure.py
@@ -2,6 +2,7 @@
 
 from zope.deferredimport import deprecated
 
+
 deprecated(
     'Please import from AccessControl.metaconfigure',
     ClassDirective='AccessControl.metaconfigure:ClassDirective',

--- a/src/Products/Five/sizeconfigure.py
+++ b/src/Products/Five/sizeconfigure.py
@@ -15,8 +15,11 @@
 Zope 2 objects.
 """
 
+from Products.Five import fivemethod
+from Products.Five import isFiveMethod
 from zope.size.interfaces import ISized
-from Products.Five import fivemethod, isFiveMethod
+from zope.testing.cleanup import addCleanUp  # NOQA
+
 
 # holds classes that were monkeyed with; for clean up
 _monkied = []
@@ -84,6 +87,5 @@ def cleanUp():
         unsizable(class_)
 
 
-from zope.testing.cleanup import addCleanUp  # NOQA
 addCleanUp(cleanUp)
 del addCleanUp

--- a/src/Products/Five/skin/standardmacros.py
+++ b/src/Products/Five/skin/standardmacros.py
@@ -14,9 +14,10 @@
 """Mimick the zope.app.basicskin skinning system.
 """
 
-import zope.interface
-import zope.component
 from Products.Five.browser import BrowserView
+
+import zope.component
+import zope.interface
 
 
 @zope.interface.implementer(zope.interface.common.mapping.IItemMapping)

--- a/src/Products/Five/tests/adapters.py
+++ b/src/Products/Five/tests/adapters.py
@@ -15,7 +15,8 @@
 """
 
 from zope.component import adapter
-from zope.interface import implementer, Interface
+from zope.interface import implementer
+from zope.interface import Interface
 
 
 class IAdaptable(Interface):

--- a/src/Products/Five/tests/metaconfigure.py
+++ b/src/Products/Five/tests/metaconfigure.py
@@ -14,8 +14,8 @@
 """Parrot directive and support classes
 """
 
-from zope.interface import Interface
 from zope.configuration.fields import GlobalObject
+from zope.interface import Interface
 from zope.schema import TextLine
 
 

--- a/src/Products/Five/tests/test_i18n.py
+++ b/src/Products/Five/tests/test_i18n.py
@@ -14,7 +14,8 @@
 """Unit tests for the i18n framework
 """
 
-from zope.component.testing import setUp, tearDown
+from zope.component.testing import setUp
+from zope.component.testing import tearDown
 
 
 def test_directive():

--- a/src/Products/Five/tests/test_size.py
+++ b/src/Products/Five/tests/test_size.py
@@ -14,7 +14,6 @@
 """Size adapters for testing
 """
 from __future__ import absolute_import
-
 from zope.interface import implementer
 from zope.size.interfaces import ISized
 

--- a/src/Products/Five/tests/testing/__init__.py
+++ b/src/Products/Five/tests/testing/__init__.py
@@ -14,9 +14,7 @@
 """Test helpers
 """
 
-from Products.Five.tests.testing.folder import (  # NOQA
-    FiveTraversableFolder,
-    manage_addFiveTraversableFolder,
-    manage_addNoVerifyPasteFolder,
-    NoVerifyPasteFolder,
-)
+from Products.Five.tests.testing.folder import FiveTraversableFolder  # NOQA
+from Products.Five.tests.testing.folder import manage_addFiveTraversableFolder
+from Products.Five.tests.testing.folder import manage_addNoVerifyPasteFolder
+from Products.Five.tests.testing.folder import NoVerifyPasteFolder

--- a/src/Products/Five/tests/testing/fancycontent.py
+++ b/src/Products/Five/tests/testing/fancycontent.py
@@ -18,7 +18,6 @@ from AccessControl.class_init import InitializeClass
 from AccessControl.SecurityInfo import ClassSecurityInfo
 from Acquisition import Explicit
 from OFS.SimpleItem import SimpleItem
-
 from zope.interface import implementer
 from zope.interface import Interface
 

--- a/src/Products/Five/tests/testing/simplecontent.py
+++ b/src/Products/Five/tests/testing/simplecontent.py
@@ -17,7 +17,6 @@
 from AccessControl.class_init import InitializeClass
 from AccessControl.SecurityInfo import ClassSecurityInfo
 from OFS.SimpleItem import SimpleItem
-
 from zope.interface import implementer
 from zope.interface import Interface
 

--- a/src/Products/Five/utilities/marker.py
+++ b/src/Products/Five/utilities/marker.py
@@ -16,13 +16,16 @@
 Allows for arbitrary application of marker interfaces to objects.
 """
 
-from zope.interface import implementer, implementedBy, providedBy
-from zope.interface import directlyProvides, directlyProvidedBy
-from zope.interface.interfaces import IInterface
-from zope.component.interface import getInterface, interfaceToName
-from zope.component.interface import searchInterface
-
 from .interfaces import IMarkerInterfaces
+from zope.component.interface import getInterface
+from zope.component.interface import interfaceToName
+from zope.component.interface import searchInterface
+from zope.interface import directlyProvidedBy
+from zope.interface import directlyProvides
+from zope.interface import implementedBy
+from zope.interface import implementer
+from zope.interface import providedBy
+from zope.interface.interfaces import IInterface
 
 
 def interfaceStringCheck(f):

--- a/src/Products/Five/viewlet/manager.py
+++ b/src/Products/Five/viewlet/manager.py
@@ -14,15 +14,14 @@
 """Viewlet manager.
 """
 
-from operator import itemgetter
-
 from AccessControl.ZopeGuards import guarded_hasattr
-import zope.interface
-import zope.security
+from operator import itemgetter
+from Products.Five.browser.pagetemplatefile import ZopeTwoPageTemplateFile
 from zope.viewlet import interfaces
 from zope.viewlet.manager import ViewletManagerBase as origManagerBase
 
-from Products.Five.browser.pagetemplatefile import ZopeTwoPageTemplateFile
+import zope.interface
+import zope.security
 
 
 class ViewletManagerBase(origManagerBase):

--- a/src/Products/Five/viewlet/metaconfigure.py
+++ b/src/Products/Five/viewlet/metaconfigure.py
@@ -14,22 +14,20 @@
 """Viewlet ZCML directives.
 """
 
-import os
-
+from AccessControl.class_init import InitializeClass
+from AccessControl.security import protectClass
+from AccessControl.security import protectName
+from Products.Five.viewlet import manager
+from Products.Five.viewlet import viewlet
+from zope.browser.interfaces import IBrowserView
 from zope.browserpage.metaconfigure import _handle_for
 from zope.component import zcml
 from zope.configuration.exceptions import ConfigurationError
 from zope.interface import Interface
-from zope.browser.interfaces import IBrowserView
 from zope.publisher.interfaces.browser import IDefaultBrowserLayer
 from zope.viewlet import interfaces
 
-from AccessControl.class_init import InitializeClass
-from AccessControl.security import protectClass
-from AccessControl.security import protectName
-
-from Products.Five.viewlet import manager
-from Products.Five.viewlet import viewlet
+import os
 
 
 def viewletManagerDirective(

--- a/src/Products/Five/viewlet/tests.py
+++ b/src/Products/Five/viewlet/tests.py
@@ -14,12 +14,13 @@
 """Viewlet tests
 """
 
-import unittest
-from Testing.ZopeTestCase import FunctionalDocFileSuite
-from zope.interface import Interface
-from zope.interface import implementer
-from zope.viewlet import interfaces
 from OFS.SimpleItem import SimpleItem
+from Testing.ZopeTestCase import FunctionalDocFileSuite
+from zope.interface import implementer
+from zope.interface import Interface
+from zope.viewlet import interfaces
+
+import unittest
 
 
 @implementer(Interface)

--- a/src/Products/Five/viewlet/viewlet.py
+++ b/src/Products/Five/viewlet/viewlet.py
@@ -14,10 +14,11 @@
 """Viewlet.
 """
 
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+
 import os
 import six
 import zope.viewlet.viewlet
-from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 
 
 class ViewletBase(zope.viewlet.viewlet.ViewletBase):

--- a/src/Products/OFSP/__init__.py
+++ b/src/Products/OFSP/__init__.py
@@ -13,8 +13,9 @@
 
 from AccessControl.Permissions import add_documents_images_and_files
 from AccessControl.Permissions import add_folders
-import OFS.DTMLMethod
+
 import OFS.DTMLDocument
+import OFS.DTMLMethod
 import OFS.Folder
 import OFS.Image
 import OFS.OrderedFolder

--- a/src/Products/PageTemplates/DeferExpr.py
+++ b/src/Products/PageTemplates/DeferExpr.py
@@ -13,6 +13,7 @@
 
 from zope.deferredimport import deprecated
 
+
 # BBB Zope 5.0
 deprecated(
     'Please import from zope.tales.expressions.',

--- a/src/Products/PageTemplates/Expressions.py
+++ b/src/Products/PageTemplates/Expressions.py
@@ -16,10 +16,16 @@ Page Template-specific implementation of TALES, with handlers
 for Python expressions, string literals, and paths.
 """
 
-import logging
-from six import text_type, binary_type
-
+from Acquisition import aq_base
+from MultiMapping import MultiMapping
+from Products.PageTemplates import ZRPythonExpr
+from Products.PageTemplates.interfaces import IUnicodeEncodingConflictResolver
+from six import binary_type
+from six import text_type
+from zExceptions import NotFound
+from zExceptions import Unauthorized
 from zope.component import queryUtility
+from zope.contentprovider.tales import TALESProviderExpression
 from zope.i18n import translate
 from zope.interface import implementer
 from zope.pagetemplate.engine import ZopeEngine as Z3Engine
@@ -34,18 +40,11 @@ from zope.tales.pythonexpr import PythonExpr
 from zope.tales.tales import Context
 from zope.tales.tales import ErrorInfo as BaseErrorInfo
 from zope.tales.tales import Iterator
-from zope.traversing.interfaces import ITraversable
 from zope.traversing.adapters import traversePathElement
+from zope.traversing.interfaces import ITraversable
 
+import logging
 import OFS.interfaces
-from MultiMapping import MultiMapping
-from Acquisition import aq_base
-from zExceptions import NotFound
-from zExceptions import Unauthorized
-
-from zope.contentprovider.tales import TALESProviderExpression
-from Products.PageTemplates import ZRPythonExpr
-from Products.PageTemplates.interfaces import IUnicodeEncodingConflictResolver
 
 
 SecureModuleImporter = ZRPythonExpr._SecureModuleImporter()

--- a/src/Products/PageTemplates/PageTemplate.py
+++ b/src/Products/PageTemplates/PageTemplate.py
@@ -13,15 +13,17 @@
 """Page Template module
 """
 
-import sys
-
-from Acquisition import aq_base, aq_inner, aq_parent
-import ExtensionClass
-import zope.pagetemplate.pagetemplate
-from zope.pagetemplate.pagetemplate import PTRuntimeError
-from zope.pagetemplate.pagetemplate import PageTemplateTracebackSupplement
-from zope.tales.expressions import SimpleModuleImporter
+from Acquisition import aq_base
+from Acquisition import aq_inner
+from Acquisition import aq_parent
 from Products.PageTemplates.Expressions import getEngine
+from zope.pagetemplate.pagetemplate import PageTemplateTracebackSupplement
+from zope.pagetemplate.pagetemplate import PTRuntimeError
+from zope.tales.expressions import SimpleModuleImporter
+
+import ExtensionClass
+import sys
+import zope.pagetemplate.pagetemplate
 
 
 class PageTemplate(ExtensionClass.Base,

--- a/src/Products/PageTemplates/PageTemplateFile.py
+++ b/src/Products/PageTemplates/PageTemplateFile.py
@@ -11,17 +11,16 @@
 #
 ##############################################################################
 
-import os
-import six
-from logging import getLogger
-
 from AccessControl.class_init import InitializeClass
 from AccessControl.SecurityInfo import ClassSecurityInfo
 from AccessControl.SecurityManagement import getSecurityManager
-from Acquisition import aq_parent, aq_inner, aq_get
+from Acquisition import aq_get
+from Acquisition import aq_inner
+from Acquisition import aq_parent
 from App.Common import package_home
 from App.config import getConfiguration
 from ComputedAttribute import ComputedAttribute
+from logging import getLogger
 from OFS.SimpleItem import SimpleItem
 from OFS.Traversable import Traversable
 from Products.PageTemplates.Expressions import SecureModuleImporter
@@ -30,12 +29,14 @@ from Products.PageTemplates.utils import encodingFromXMLPreamble
 from Shared.DC.Scripts.Script import Script
 from Shared.DC.Scripts.Signature import FuncCode
 from zope.contenttype import guess_content_type
-from zope.pagetemplate.pagetemplatefile import (
-    sniff_type,
-    XML_PREFIX_MAX_LENGTH,
-    DEFAULT_ENCODING,
-    meta_pattern,
-)
+from zope.pagetemplate.pagetemplatefile import DEFAULT_ENCODING
+from zope.pagetemplate.pagetemplatefile import meta_pattern
+from zope.pagetemplate.pagetemplatefile import sniff_type
+from zope.pagetemplate.pagetemplatefile import XML_PREFIX_MAX_LENGTH
+
+import os
+import six
+
 
 LOG = getLogger('PageTemplateFile')
 

--- a/src/Products/PageTemplates/ZRPythonExpr.py
+++ b/src/Products/PageTemplates/ZRPythonExpr.py
@@ -15,14 +15,16 @@
 Handler for Python expressions that uses the RestrictedPython package.
 """
 
-import sys
-
 from AccessControl import safe_builtins
-from AccessControl.ZopeGuards import guarded_getattr, get_safe_globals
-from DocumentTemplate.DT_Util import TemplateDict, InstanceDict
+from AccessControl.ZopeGuards import get_safe_globals
+from AccessControl.ZopeGuards import guarded_getattr
+from DocumentTemplate.DT_Util import InstanceDict
+from DocumentTemplate.DT_Util import TemplateDict
 from DocumentTemplate.security import RestrictedDTML
 from RestrictedPython import compile_restricted_eval
 from zope.tales.pythonexpr import PythonExpr
+
+import sys
 
 
 class PythonExpr(PythonExpr):

--- a/src/Products/PageTemplates/ZopePageTemplate.py
+++ b/src/Products/PageTemplates/ZopePageTemplate.py
@@ -13,38 +13,38 @@
 """Zope Page Template module (wrapper for the zope.pagetemplate implementation)
 """
 
-import os
-import sys
-
 from AccessControl.class_init import InitializeClass
 from AccessControl.Permissions import change_page_templates
 from AccessControl.Permissions import ftp_access
 from AccessControl.Permissions import view
 from AccessControl.Permissions import view_management_screens
-from AccessControl.SecurityManagement import getSecurityManager
 from AccessControl.SecurityInfo import ClassSecurityInfo
+from AccessControl.SecurityManagement import getSecurityManager
 from Acquisition import Acquired
 from Acquisition import aq_get
 from Acquisition import Explicit
-from zExceptions import ResourceLockedError
-
 from App.Common import package_home
 from OFS.Cache import Cacheable
-from OFS.SimpleItem import SimpleItem
 from OFS.PropertyManager import PropertyManager
+from OFS.SimpleItem import SimpleItem
 from OFS.Traversable import Traversable
-from Shared.DC.Scripts.Script import Script
-from Shared.DC.Scripts.Signature import FuncCode
 from Products.PageTemplates import bbb
 from Products.PageTemplates.Expressions import SecureModuleImporter
 from Products.PageTemplates.PageTemplate import PageTemplate
-from Products.PageTemplates.PageTemplateFile import PageTemplateFile
 from Products.PageTemplates.PageTemplateFile import guess_type
-from Products.PageTemplates.utils import encodingFromXMLPreamble
+from Products.PageTemplates.PageTemplateFile import PageTemplateFile
 from Products.PageTemplates.utils import charsetFromMetaEquiv
 from Products.PageTemplates.utils import convertToUnicode
+from Products.PageTemplates.utils import encodingFromXMLPreamble
+from Shared.DC.Scripts.Script import Script
+from Shared.DC.Scripts.Signature import FuncCode
+from six import binary_type
+from six import text_type
+from zExceptions import ResourceLockedError
 
-from six import text_type, binary_type
+import os
+import sys
+
 
 preferred_encodings = ['utf-8', 'iso-8859-15']
 if 'ZPT_PREFERRED_ENCODING' in os.environ:

--- a/src/Products/PageTemplates/bbb.py
+++ b/src/Products/PageTemplates/bbb.py
@@ -13,6 +13,7 @@
 
 import pkg_resources
 
+
 HAS_ZSERVER = True
 try:
     dist = pkg_resources.get_distribution('ZServer')

--- a/src/Products/PageTemplates/engine.py
+++ b/src/Products/PageTemplates/engine.py
@@ -1,30 +1,26 @@
-import re
-import logging
-
+from .expression import ExistsExpr
+from .expression import NocallExpr
+from .expression import PathExpr
+from .expression import TrustedPathExpr
+from .expression import UntrustedPythonExpr
+from AccessControl.class_init import InitializeClass
+from AccessControl.SecurityInfo import ClassSecurityInfo
+from chameleon.tal import RepeatDict
+from chameleon.tales import NotExpr
+from chameleon.tales import StringExpr
+from Products.PageTemplates import ZRPythonExpr
+from Products.PageTemplates.Expressions import getEngine
+from z3c.pt.expressions import ProviderExpr
+from z3c.pt.expressions import PythonExpr
+from z3c.pt.pagetemplate import PageTemplate as ChameleonPageTemplate
 from zope.interface import implementer
 from zope.interface import provider
-
 from zope.pagetemplate.interfaces import IPageTemplateEngine
 from zope.pagetemplate.interfaces import IPageTemplateProgram
 
-from z3c.pt.pagetemplate import PageTemplate as ChameleonPageTemplate
+import logging
+import re
 
-from AccessControl.class_init import InitializeClass
-from AccessControl.SecurityInfo import ClassSecurityInfo
-from Products.PageTemplates.Expressions import getEngine
-from Products.PageTemplates import ZRPythonExpr
-
-from chameleon.tales import StringExpr
-from chameleon.tales import NotExpr
-from chameleon.tal import RepeatDict
-
-from z3c.pt.expressions import PythonExpr, ProviderExpr
-
-from .expression import PathExpr
-from .expression import TrustedPathExpr
-from .expression import NocallExpr
-from .expression import ExistsExpr
-from .expression import UntrustedPythonExpr
 
 # Declare Chameleon's repeat dictionary public
 RepeatDict.security = ClassSecurityInfo()

--- a/src/Products/PageTemplates/expression.py
+++ b/src/Products/PageTemplates/expression.py
@@ -1,30 +1,24 @@
+from AccessControl.ZopeGuards import guarded_apply
+from AccessControl.ZopeGuards import guarded_getattr
+from AccessControl.ZopeGuards import guarded_getitem
+from AccessControl.ZopeGuards import guarded_iter
+from AccessControl.ZopeGuards import protected_inplacevar
 from ast import NodeTransformer
 from ast import parse
-from six import class_types
-
+from chameleon.astutil import Static
+from chameleon.astutil import Symbol
+from chameleon.codegen import template
 from OFS.interfaces import ITraversable
+from Products.PageTemplates.Expressions import render
+from RestrictedPython import RestrictingNodeTransformer
+from RestrictedPython.Utilities import utility_builtins
+from six import class_types
+from z3c.pt import expressions
 from zExceptions import NotFound
 from zExceptions import Unauthorized
-
 from zope.traversing.adapters import traversePathElement
 from zope.traversing.interfaces import TraversalError
 
-from RestrictedPython.Utilities import utility_builtins
-from RestrictedPython import RestrictingNodeTransformer
-
-from Products.PageTemplates.Expressions import render
-
-from AccessControl.ZopeGuards import guarded_getattr
-from AccessControl.ZopeGuards import guarded_getitem
-from AccessControl.ZopeGuards import guarded_apply
-from AccessControl.ZopeGuards import guarded_iter
-from AccessControl.ZopeGuards import protected_inplacevar
-
-from chameleon.astutil import Symbol
-from chameleon.astutil import Static
-from chameleon.codegen import template
-
-from z3c.pt import expressions
 
 _marker = object()
 

--- a/src/Products/PageTemplates/tests/batch.py
+++ b/src/Products/PageTemplates/tests/batch.py
@@ -16,6 +16,7 @@
 
 from . import util
 
+
 __allow_access_to_unprotected_subobjects__ = {'batch': 1}
 __roles__ = None
 

--- a/src/Products/PageTemplates/tests/testDTMLTests.py
+++ b/src/Products/PageTemplates/tests/testDTMLTests.py
@@ -11,19 +11,18 @@
 #
 ##############################################################################
 
-import unittest
-
-import zope.component.testing
-from zope.component import provideUtility
-from zope.traversing.adapters import DefaultTraversable
-from Products.PageTemplates.tests import util
-from Products.PageTemplates.PageTemplate import PageTemplate
-from Products.PageTemplates.interfaces import IUnicodeEncodingConflictResolver
-from Products.PageTemplates.unicodeconflictresolver import \
-    DefaultUnicodeEncodingConflictResolver
-from Acquisition import Implicit
 from AccessControl import SecurityManager
 from AccessControl.SecurityManagement import noSecurityManager
+from Acquisition import Implicit
+from Products.PageTemplates.interfaces import IUnicodeEncodingConflictResolver
+from Products.PageTemplates.PageTemplate import PageTemplate
+from Products.PageTemplates.tests import util
+from Products.PageTemplates.unicodeconflictresolver import DefaultUnicodeEncodingConflictResolver
+from zope.component import provideUtility
+from zope.traversing.adapters import DefaultTraversable
+
+import unittest
+import zope.component.testing
 
 
 class AqPageTemplate(Implicit, PageTemplate):

--- a/src/Products/PageTemplates/tests/testExpressions.py
+++ b/src/Products/PageTemplates/tests/testExpressions.py
@@ -1,9 +1,9 @@
 # *-* coding: iso-8859-1 -*-
 
-import unittest
 from six import text_type
-
 from zope.component.testing import PlacelessSetup
+
+import unittest
 
 
 class EngineTestsBase(PlacelessSetup):

--- a/src/Products/PageTemplates/tests/testHTMLTests.py
+++ b/src/Products/PageTemplates/tests/testHTMLTests.py
@@ -11,21 +11,19 @@
 #
 ##############################################################################
 
-import unittest
-
 from AccessControl import SecurityManager
 from AccessControl.SecurityManagement import noSecurityManager
 from Acquisition import Implicit
+from Products.PageTemplates.interfaces import IUnicodeEncodingConflictResolver
+from Products.PageTemplates.PageTemplate import PageTemplate
+from Products.PageTemplates.tests import util
+from Products.PageTemplates.unicodeconflictresolver import DefaultUnicodeEncodingConflictResolver
 from six import text_type
-import zope.component.testing
 from zope.component import provideUtility
 from zope.traversing.adapters import DefaultTraversable
 
-from Products.PageTemplates.tests import util
-from Products.PageTemplates.PageTemplate import PageTemplate
-from Products.PageTemplates.interfaces import IUnicodeEncodingConflictResolver
-from Products.PageTemplates.unicodeconflictresolver import \
-    DefaultUnicodeEncodingConflictResolver
+import unittest
+import zope.component.testing
 
 
 class AqPageTemplate(Implicit, PageTemplate):

--- a/src/Products/PageTemplates/tests/testZopePageTemplate.py
+++ b/src/Products/PageTemplates/tests/testZopePageTemplate.py
@@ -5,32 +5,30 @@ ZopePageTemplate regression tests.
 Ensures that adding a page template works correctly.
 """
 
-import codecs
-import unittest
-import transaction
-
-import zope.component.testing
-from zope.traversing.adapters import DefaultTraversable
-from zope.publisher.http import HTTPCharsets
-
+from Products.PageTemplates.interfaces import IUnicodeEncodingConflictResolver
+from Products.PageTemplates.PageTemplateFile import guess_type
+from Products.PageTemplates.unicodeconflictresolver import PreferredCharsetResolver
+from Products.PageTemplates.utils import charsetFromMetaEquiv
+from Products.PageTemplates.utils import encodingFromXMLPreamble
+from Products.PageTemplates.ZopePageTemplate import manage_addPageTemplate
+from Products.PageTemplates.ZopePageTemplate import ZopePageTemplate
+from six import text_type
 from Testing.makerequest import makerequest
 from Testing.testbrowser import Browser
 from Testing.ZopeTestCase import FunctionalTestCase
 from Testing.ZopeTestCase import installProduct
 from Testing.ZopeTestCase import ZopeTestCase
-from Products.PageTemplates.PageTemplateFile import guess_type
-from Products.PageTemplates.ZopePageTemplate import ZopePageTemplate
-from Products.PageTemplates.ZopePageTemplate import manage_addPageTemplate
-from Products.PageTemplates.utils import encodingFromXMLPreamble
-from Products.PageTemplates.utils import charsetFromMetaEquiv
 from zope.component import provideUtility
 from zope.pagetemplate.pagetemplatefile import DEFAULT_ENCODING
-from Products.PageTemplates.interfaces import IUnicodeEncodingConflictResolver
-from Products.PageTemplates.unicodeconflictresolver \
-    import PreferredCharsetResolver
-import Zope2
+from zope.publisher.http import HTTPCharsets
+from zope.traversing.adapters import DefaultTraversable
 
-from six import text_type
+import codecs
+import transaction
+import unittest
+import Zope2
+import zope.component.testing
+
 
 ascii_binary = b'<html><body>hello world</body></html>'
 iso885915_binary = u'<html><body>üöäÜÖÄß</body></html>'.encode('iso-8859-15')

--- a/src/Products/PageTemplates/tests/test_engine.py
+++ b/src/Products/PageTemplates/tests/test_engine.py
@@ -1,8 +1,9 @@
+from Testing.ZopeTestCase import ZopeTestCase
+from Testing.ZopeTestCase.sandbox import Sandboxed
+
 import os
 import unittest
 
-from Testing.ZopeTestCase import ZopeTestCase
-from Testing.ZopeTestCase.sandbox import Sandboxed
 
 path = os.path.dirname(__file__)
 

--- a/src/Products/PageTemplates/tests/test_pagetemplate.py
+++ b/src/Products/PageTemplates/tests/test_pagetemplate.py
@@ -1,10 +1,10 @@
+from Products.PageTemplates.PageTemplateFile import PageTemplateFile
+from six import PY3
+from Testing.ZopeTestCase import ZopeTestCase
+
 import os
 import unittest
 
-from six import PY3
-
-from Products.PageTemplates.PageTemplateFile import PageTemplateFile
-from Testing.ZopeTestCase import ZopeTestCase
 
 path = os.path.dirname(__file__)
 

--- a/src/Products/PageTemplates/tests/test_persistenttemplate.py
+++ b/src/Products/PageTemplates/tests/test_persistenttemplate.py
@@ -1,8 +1,9 @@
+from Products.PageTemplates.ZopePageTemplate import manage_addPageTemplate
+from Testing.ZopeTestCase import ZopeTestCase
+
 import re
 import unittest
 
-from Products.PageTemplates.ZopePageTemplate import manage_addPageTemplate
-from Testing.ZopeTestCase import ZopeTestCase
 
 try:
     from html import escape

--- a/src/Products/PageTemplates/tests/test_ptfile.py
+++ b/src/Products/PageTemplates/tests/test_ptfile.py
@@ -1,16 +1,15 @@
 # coding=utf-8
 """Tests of PageTemplateFile."""
 
+from Products.PageTemplates.PageTemplateFile import PageTemplateFile
+from Testing.makerequest import makerequest
+
 import os
 import os.path
 import tempfile
+import transaction
 import unittest
 import Zope2
-import transaction
-
-from Testing.makerequest import makerequest
-
-from Products.PageTemplates.PageTemplateFile import PageTemplateFile
 
 
 class TypeSniffingTestCase(unittest.TestCase):

--- a/src/Products/PageTemplates/tests/test_viewpagetemplatefile.py
+++ b/src/Products/PageTemplates/tests/test_viewpagetemplatefile.py
@@ -1,8 +1,8 @@
-import unittest
-
 from Products.Five import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from Testing.ZopeTestCase import ZopeTestCase
+
+import unittest
 
 
 class SimpleView(BrowserView):

--- a/src/Products/PageTemplates/tests/util.py
+++ b/src/Products/PageTemplates/tests/util.py
@@ -11,11 +11,11 @@
 #
 ##############################################################################
 
+from ExtensionClass import Base
+
 import os
 import re
 import sys
-
-from ExtensionClass import Base
 
 
 class Bruce(Base):

--- a/src/Products/PageTemplates/unicodeconflictresolver.py
+++ b/src/Products/PageTemplates/unicodeconflictresolver.py
@@ -13,15 +13,16 @@
 """Unicode conflict resolution.
 """
 
-import sys
-
 from Acquisition import aq_get
 from Products.PageTemplates.interfaces import IUnicodeEncodingConflictResolver
-from zope.interface import implementer
+from six import binary_type
+from six import text_type
 from zope.i18n.interfaces import IUserPreferredCharsets
+from zope.interface import implementer
+
+import sys
 import ZPublisher
 
-from six import text_type, binary_type
 
 default_encoding = sys.getdefaultencoding()
 

--- a/src/Products/PageTemplates/utils.py
+++ b/src/Products/PageTemplates/utils.py
@@ -13,9 +13,10 @@
 """Some helper methods
 """
 
+from zope.pagetemplate.pagetemplatefile import DEFAULT_ENCODING
+
 import re
 
-from zope.pagetemplate.pagetemplatefile import DEFAULT_ENCODING
 
 xml_preamble_reg = re.compile(
     br'^<\?xml.*?encoding="(.*?)".*?\?>', re.M)

--- a/src/Products/SiteAccess/VirtualHostMonster.py
+++ b/src/Products/SiteAccess/VirtualHostMonster.py
@@ -9,13 +9,13 @@ from Acquisition import Implicit
 from App.special_dtml import DTMLFile
 from OFS.SimpleItem import Item
 from Persistence import Persistent
+from zExceptions import BadRequest
+from ZPublisher.BaseRequest import quote
 from ZPublisher.BeforeTraverse import NameCaller
 from ZPublisher.BeforeTraverse import queryBeforeTraverse
 from ZPublisher.BeforeTraverse import registerBeforeTraverse
 from ZPublisher.BeforeTraverse import unregisterBeforeTraverse
-from ZPublisher.BaseRequest import quote
 from ZPublisher.HTTPRequest import splitport
-from zExceptions import BadRequest
 
 
 class VirtualHostMonster(Persistent, Item, Implicit):

--- a/src/Shared/DC/Scripts/Bindings.py
+++ b/src/Shared/DC/Scripts/Bindings.py
@@ -11,18 +11,20 @@
 #
 ##############################################################################
 
-import re
-
-from six import exec_
-
 from AccessControl.class_init import InitializeClass
+from AccessControl.PermissionRole import _what_not_even_god_should_do
+from AccessControl.Permissions import view_management_screens
 from AccessControl.SecurityInfo import ClassSecurityInfo
 from AccessControl.SecurityManagement import getSecurityManager
-from AccessControl.Permissions import view_management_screens
-from AccessControl.PermissionRole import _what_not_even_god_should_do
 from AccessControl.unauthorized import Unauthorized
 from AccessControl.ZopeGuards import guarded_getattr
-from Acquisition import aq_base, aq_inner, aq_parent
+from Acquisition import aq_base
+from Acquisition import aq_inner
+from Acquisition import aq_parent
+from six import exec_
+
+import re
+
 
 defaultBindings = {'name_context': 'context',
                    'name_container': 'container',

--- a/src/Shared/DC/Scripts/Script.py
+++ b/src/Shared/DC/Scripts/Script.py
@@ -15,20 +15,17 @@
 This provides generic script support
 """
 
-from six.moves.urllib.parse import quote
-
 from AccessControl.class_init import InitializeClass
 from AccessControl.Permissions import view_management_screens
 from AccessControl.SecurityInfo import ClassSecurityInfo
 from App.special_dtml import DTMLFile
 from DocumentTemplate.DT_Util import TemplateDict
 from OFS.SimpleItem import SimpleItem
-from zExceptions import Redirect
-
-from Shared.DC.Scripts.BindingsUI import BindingsUI
-
 from Shared.DC.Scripts.Bindings import defaultBindings  # NOQA
+from Shared.DC.Scripts.BindingsUI import BindingsUI
 from Shared.DC.Scripts.Signature import FuncCode  # NOQA
+from six.moves.urllib.parse import quote
+from zExceptions import Redirect
 
 
 class Script(SimpleItem, BindingsUI):

--- a/src/Testing/ZODButil.py
+++ b/src/Testing/ZODButil.py
@@ -1,7 +1,8 @@
-import os
 from glob import glob
-import ZODB
 from ZODB.FileStorage import FileStorage
+
+import os
+import ZODB
 
 
 def makeDB():

--- a/src/Testing/ZopeTestCase/PortalTestCase.py
+++ b/src/Testing/ZopeTestCase/PortalTestCase.py
@@ -28,15 +28,14 @@ getPortal() returns a usable portal object to the setup code.
 from . import base
 from . import interfaces
 from . import utils
-
-from zope.interface import implementer
+from .ZopeTestCase import user_name
+from .ZopeTestCase import user_password
 from AccessControl import getSecurityManager
 from AccessControl.SecurityManagement import newSecurityManager
 from AccessControl.SecurityManagement import noSecurityManager
 from Acquisition import aq_base
+from zope.interface import implementer
 
-from .ZopeTestCase import user_name
-from .ZopeTestCase import user_password
 
 portal_name = 'portal'
 

--- a/src/Testing/ZopeTestCase/ZopeLite.py
+++ b/src/Testing/ZopeTestCase/ZopeLite.py
@@ -23,14 +23,31 @@ Typically used as in
   app = Zope2.app()
 """
 
-import os
-import sys
-import time
-
+# Allow test authors to install Zope products into the test environment. Note
+# that installProduct() must be called at module level -- never from tests.
+from OFS.Application import get_folder_permissions  # NOQA; NOQA
+from OFS.Application import get_products
+from OFS.Application import install_package
+from OFS.Application import install_product
+from OFS.Folder import Folder  # NOQA
 from six import exec_
 from six import PY2
-
 from Testing.ZopeTestCase import layer
+# ZODB sandbox factory
+from ZODB.DemoStorage import DemoStorage  # NOQA
+
+import App.ProductContext  # NOQA
+import OFS.Application  # NOQA
+import OFS.ObjectManager  # NOQA
+import OFS.SimpleItem  # NOQA
+import os
+import Products  # NOQA
+import sys
+import time
+import ZODB  # NOQA
+import Zope2  # NOQA
+import Zope2.Startup.run  # NOQA
+
 
 # Allow code to tell it is run by the test framework
 os.environ['ZOPETESTCASE'] = '1'
@@ -99,21 +116,14 @@ _configure_debug_mode()
 _configure_client_cache()
 
 _exec('import Zope2')
-import Zope2  # NOQA
-import Zope2.Startup.run  # NOQA
 _exec('import ZODB')
-import ZODB  # NOQA
 _write('.')
 
 _exec('import OFS.SimpleItem')
-import OFS.SimpleItem  # NOQA
 _exec('import OFS.ObjectManager')
-import OFS.ObjectManager  # NOQA
 _write('.')
 
 _exec('import OFS.Application')
-import OFS.Application  # NOQA
-import App.ProductContext  # NOQA
 _write('.')
 
 _patched = False
@@ -159,12 +169,6 @@ def _startup():
 # Start ZopeLite
 _startup()
 
-# Allow test authors to install Zope products into the test environment. Note
-# that installProduct() must be called at module level -- never from tests.
-from OFS.Application import get_folder_permissions, get_products  # NOQA
-from OFS.Application import install_product, install_package  # NOQA
-from OFS.Folder import Folder  # NOQA
-import Products  # NOQA
 
 _installedProducts = {}
 _installedPackages = {}
@@ -251,8 +255,6 @@ def startup():
 Zope = Zope2
 active = _patched
 
-# ZODB sandbox factory
-from ZODB.DemoStorage import DemoStorage  # NOQA
 
 
 def sandbox(base=None):

--- a/src/Testing/ZopeTestCase/ZopeTestCase.py
+++ b/src/Testing/ZopeTestCase/ZopeTestCase.py
@@ -22,20 +22,20 @@ The default user is logged in and has the 'Access contents information'
 and 'View' permissions given to his role.
 """
 
-from zope.interface import implementer
 from AccessControl import getSecurityManager
-from AccessControl.SecurityManagement import newSecurityManager
-from AccessControl.SecurityManagement import noSecurityManager
 from AccessControl.Permissions import access_contents_information
 from AccessControl.Permissions import view
-
+from AccessControl.SecurityManagement import newSecurityManager
+from AccessControl.SecurityManagement import noSecurityManager
 from Testing.ZopeTestCase import base
-from Testing.ZopeTestCase.base import app  # NOQA
-from Testing.ZopeTestCase.base import close  # NOQA
+from Testing.ZopeTestCase import connections
 from Testing.ZopeTestCase import functional
 from Testing.ZopeTestCase import interfaces
 from Testing.ZopeTestCase import utils
-from Testing.ZopeTestCase import connections
+from Testing.ZopeTestCase.base import app  # NOQA
+from Testing.ZopeTestCase.base import close  # NOQA
+from zope.interface import implementer
+
 
 folder_name = 'test_folder_1_'
 user_name = 'test_user_1_'

--- a/src/Testing/ZopeTestCase/base.py
+++ b/src/Testing/ZopeTestCase/base.py
@@ -13,17 +13,16 @@
 """TestCase for Zope testing
 """
 
-import unittest
-import transaction
-
-from zope.interface import implementer
 from AccessControl.SecurityManagement import noSecurityManager
-
 from Testing.makerequest import makerequest
 from Testing.ZopeTestCase import connections
 from Testing.ZopeTestCase import interfaces
 from Testing.ZopeTestCase import layer
 from Testing.ZopeTestCase import ZopeLite as Zope2
+from zope.interface import implementer
+
+import transaction
+import unittest
 
 
 def app():

--- a/src/Testing/ZopeTestCase/functional.py
+++ b/src/Testing/ZopeTestCase/functional.py
@@ -16,16 +16,15 @@ After Marius Gedminas' functional.py module for Zope3.
 """
 
 from functools import partial
-import sys
-
 from six import PY2
-import transaction
-from zope.interface import implementer
-
 from Testing.ZopeTestCase import interfaces
 from Testing.ZopeTestCase import sandbox
+from zope.interface import implementer
 from ZPublisher.httpexceptions import HTTPExceptionHandler
 from ZPublisher.utils import basic_auth_encode
+
+import sys
+import transaction
 
 
 def savestate(func):

--- a/src/Testing/ZopeTestCase/layer.py
+++ b/src/Testing/ZopeTestCase/layer.py
@@ -15,6 +15,7 @@
 
 from Testing.ZopeTestCase import utils
 
+
 _deferred_setup = []
 
 

--- a/src/Testing/ZopeTestCase/placeless.py
+++ b/src/Testing/ZopeTestCase/placeless.py
@@ -13,15 +13,14 @@
 """Placeless setup
 """
 
-from zope.component.testing import PlacelessSetup as CAPlacelessSetup
+from AccessControl.security import newInteraction
+# For convenience
+from Zope2.App import zcml  # NOQA
 from zope.component.eventtesting import PlacelessSetup as EventPlacelessSetup
+from zope.component.testing import PlacelessSetup as CAPlacelessSetup
 from zope.container.testing import PlacelessSetup as ContainerPlacelessSetup
 from zope.i18n.testing import PlacelessSetup as I18nPlacelessSetup
 from zope.security.testing import addCheckerPublic
-from AccessControl.security import newInteraction
-
-# For convenience
-from Zope2.App import zcml  # NOQA
 
 
 class PlacelessSetup(CAPlacelessSetup,

--- a/src/Testing/ZopeTestCase/sandbox.py
+++ b/src/Testing/ZopeTestCase/sandbox.py
@@ -13,13 +13,13 @@
 """Support for ZODB sandboxes in ZTC
 """
 
-import contextlib
-import transaction
-
-import ZPublisher.WSGIPublisher
 from Testing.makerequest import makerequest
 from Testing.ZopeTestCase import connections
 from Testing.ZopeTestCase import ZopeLite as Zope2
+
+import contextlib
+import transaction
+import ZPublisher.WSGIPublisher
 
 
 class Sandboxed(object):

--- a/src/Testing/ZopeTestCase/testBaseTestCase.py
+++ b/src/Testing/ZopeTestCase/testBaseTestCase.py
@@ -19,18 +19,16 @@ See testPythonScript.py and testShoppingCart.py for
 example test cases. See testSkeleton.py for a quick
 way of getting started.
 """
-import gc
-
-import transaction
-
-from Testing.ZopeTestCase import base
-from Testing.ZopeTestCase import utils
-from Testing.ZopeTestCase import connections
-from Testing.ZopeTestCase import sandbox
-
-from Acquisition import aq_base
 from AccessControl import getSecurityManager
 from AccessControl.SecurityManagement import newSecurityManager
+from Acquisition import aq_base
+from Testing.ZopeTestCase import base
+from Testing.ZopeTestCase import connections
+from Testing.ZopeTestCase import sandbox
+from Testing.ZopeTestCase import utils
+
+import gc
+import transaction
 
 
 class HookTest(base.TestCase):

--- a/src/Testing/ZopeTestCase/testFunctional.py
+++ b/src/Testing/ZopeTestCase/testFunctional.py
@@ -16,16 +16,15 @@ Demonstrates how to use the publish() API to execute GET, POST, PUT, etc.
 requests against the ZPublisher and how to examine the response.
 """
 
-from io import BytesIO
-
 from AccessControl import getSecurityManager
-from AccessControl.Permissions import view
 from AccessControl.Permissions import manage_properties
+from AccessControl.Permissions import view
+from io import BytesIO
 from six.moves.urllib.parse import urlencode
-
 from Testing import ZopeTestCase
 from Testing.ZopeTestCase import user_name
 from Testing.ZopeTestCase import user_password
+
 
 SET_COOKIE_DTML = '''\
 <dtml-call "RESPONSE.setCookie('foo', 'Bar', path='/')">'''

--- a/src/Testing/ZopeTestCase/testInterfaces.py
+++ b/src/Testing/ZopeTestCase/testInterfaces.py
@@ -13,21 +13,16 @@
 """Interface tests
 """
 
-from Testing.ZopeTestCase import (
-    Functional,
-    FunctionalTestCase,
-    PortalTestCase,
-    TestCase,
-    ZopeTestCase,
-)
-from Testing.ZopeTestCase.interfaces import (
-    IFunctional,
-    IPortalSecurity,
-    IPortalTestCase,
-    IZopeSecurity,
-    IZopeTestCase,
-)
-
+from Testing.ZopeTestCase import Functional
+from Testing.ZopeTestCase import FunctionalTestCase
+from Testing.ZopeTestCase import PortalTestCase
+from Testing.ZopeTestCase import TestCase
+from Testing.ZopeTestCase import ZopeTestCase
+from Testing.ZopeTestCase.interfaces import IFunctional
+from Testing.ZopeTestCase.interfaces import IPortalSecurity
+from Testing.ZopeTestCase.interfaces import IPortalTestCase
+from Testing.ZopeTestCase.interfaces import IZopeSecurity
+from Testing.ZopeTestCase.interfaces import IZopeTestCase
 from zope.interface.verify import verifyClass
 from zope.interface.verify import verifyObject
 

--- a/src/Testing/ZopeTestCase/testPlaceless.py
+++ b/src/Testing/ZopeTestCase/testPlaceless.py
@@ -13,14 +13,14 @@
 """Placeless setup tests
 """
 
-from zope.component import adapter
-from zope.interface import implementer, Interface
-
 from Testing import ZopeTestCase
-
-from Testing.ZopeTestCase.placeless import setUp, tearDown
-from Testing.ZopeTestCase.placeless import zcml
+from Testing.ZopeTestCase.placeless import setUp
+from Testing.ZopeTestCase.placeless import tearDown
 from Testing.ZopeTestCase.placeless import temporaryPlacelessSetUp
+from Testing.ZopeTestCase.placeless import zcml
+from zope.component import adapter
+from zope.interface import implementer
+from zope.interface import Interface
 
 
 def setupZCML():

--- a/src/Testing/ZopeTestCase/testPortalTestCase.py
+++ b/src/Testing/ZopeTestCase/testPortalTestCase.py
@@ -20,15 +20,16 @@ example test cases. See testSkeleton.py for a quick
 way of getting started.
 """
 
+from AccessControl import getSecurityManager
+from Acquisition import aq_base
+from Acquisition import aq_inner
+from OFS.Folder import Folder
+from OFS.SimpleItem import SimpleItem
+from OFS.userfolder import UserFolder
 from Testing import ZopeTestCase
 
-from Acquisition import aq_base, aq_inner
-from AccessControl import getSecurityManager
-from OFS.SimpleItem import SimpleItem
-from OFS.Folder import Folder
-from OFS.userfolder import UserFolder
-
 import transaction
+
 
 portal_name = 'dummy_1_'
 user_name = ZopeTestCase.user_name

--- a/src/Testing/ZopeTestCase/testSkeleton.py
+++ b/src/Testing/ZopeTestCase/testSkeleton.py
@@ -15,6 +15,7 @@
 
 from Testing import ZopeTestCase
 
+
 ZopeTestCase.installProduct('SomeProduct')
 
 

--- a/src/Testing/ZopeTestCase/testZODBCompat.py
+++ b/src/Testing/ZopeTestCase/testZODBCompat.py
@@ -16,18 +16,17 @@ Demonstrates that cut/copy/paste/clone/rename and import/export
 work if a savepoint is made before performing the respective operation.
 """
 
-import os
-
-from Testing import ZopeTestCase
-
-from Testing.ZopeTestCase import layer
-from Testing.ZopeTestCase import utils
-from Testing.ZopeTestCase import transaction
-
 from AccessControl.Permissions import add_documents_images_and_files
 from AccessControl.Permissions import delete_objects
 from OFS.SimpleItem import SimpleItem
+from Testing import ZopeTestCase
+from Testing.ZopeTestCase import layer
+from Testing.ZopeTestCase import transaction
+from Testing.ZopeTestCase import utils
+
+import os
 import tempfile
+
 
 folder_name = ZopeTestCase.folder_name
 cutpaste_permissions = [add_documents_images_and_files, delete_objects]

--- a/src/Testing/ZopeTestCase/testZopeTestCase.py
+++ b/src/Testing/ZopeTestCase/testZopeTestCase.py
@@ -20,17 +20,16 @@ example test cases. See testSkeleton.py for a quick
 way of getting started.
 """
 
-import transaction
-
 from AccessControl import getSecurityManager
 from Acquisition import aq_base
 from OFS.userfolder import UserFolder
-
 from Testing import ZopeTestCase
 from Testing.ZopeTestCase import folder_name
+from Testing.ZopeTestCase import standard_permissions
 from Testing.ZopeTestCase import user_name
 from Testing.ZopeTestCase import user_role
-from Testing.ZopeTestCase import standard_permissions
+
+import transaction
 
 
 def hasattr_(ob, attr):

--- a/src/Testing/ZopeTestCase/tests.py
+++ b/src/Testing/ZopeTestCase/tests.py
@@ -13,9 +13,10 @@
 """Test runner that works with zope.testrunner
 """
 
-import unittest
 import os
 import Testing.ZopeTestCase
+import unittest
+
 
 suite = unittest.TestSuite()
 

--- a/src/Testing/ZopeTestCase/threadutils.py
+++ b/src/Testing/ZopeTestCase/threadutils.py
@@ -13,6 +13,7 @@
 
 from zope.deferredimport import deprecated
 
+
 # BBB Zope 5.0
 deprecated(
     'Please import from ZServer.Testing.threadutils.',

--- a/src/Testing/ZopeTestCase/utils.py
+++ b/src/Testing/ZopeTestCase/utils.py
@@ -11,8 +11,10 @@
 #
 ##############################################################################
 
-import transaction
 from zope.deferredimport import deprecated
+
+import transaction
+
 
 # BBB Zope 5.0
 deprecated(

--- a/src/Testing/ZopeTestCase/zopedoctest/functional.py
+++ b/src/Testing/ZopeTestCase/zopedoctest/functional.py
@@ -13,30 +13,29 @@
 """Support for (functional) doc tests
 """
 
-import doctest
-import email.parser
 from functools import partial
 from io import BytesIO
-import re
-import sys
-import warnings
-
 from six import text_type
-import transaction
-
-from Testing.ZopeTestCase import ZopeTestCase
-from Testing.ZopeTestCase import FunctionalTestCase
-from Testing.ZopeTestCase import Functional
 from Testing.ZopeTestCase import folder_name
+from Testing.ZopeTestCase import Functional
+from Testing.ZopeTestCase import FunctionalTestCase
+from Testing.ZopeTestCase import standard_permissions
 from Testing.ZopeTestCase import user_name
 from Testing.ZopeTestCase import user_password
 from Testing.ZopeTestCase import user_role
-from Testing.ZopeTestCase import standard_permissions
-from Testing.ZopeTestCase.sandbox import AppZapper
+from Testing.ZopeTestCase import ZopeTestCase
 from Testing.ZopeTestCase.functional import ResponseWrapper
 from Testing.ZopeTestCase.functional import savestate
+from Testing.ZopeTestCase.sandbox import AppZapper
 from ZPublisher.httpexceptions import HTTPExceptionHandler
 from ZPublisher.utils import basic_auth_encode
+
+import doctest
+import email.parser
+import re
+import sys
+import transaction
+import warnings
 
 
 if sys.version_info >= (3, ):

--- a/src/Testing/ZopeTestCase/zopedoctest/testAuthHeaderTest.py
+++ b/src/Testing/ZopeTestCase/zopedoctest/testAuthHeaderTest.py
@@ -13,9 +13,11 @@
 """Test for auth_header
 """
 
-from unittest import TestSuite, makeSuite
 from Testing.ZopeTestCase import TestCase
 from Testing.ZopeTestCase import zopedoctest
+from unittest import makeSuite
+from unittest import TestSuite
+
 
 auth_header = zopedoctest.functional.auth_header
 

--- a/src/Testing/ZopeTestCase/zopedoctest/testFunctionalDocTest.py
+++ b/src/Testing/ZopeTestCase/zopedoctest/testFunctionalDocTest.py
@@ -12,10 +12,10 @@
 ##############################################################################
 """Example functional doctest
 """
-import unittest
-
-from Testing.ZopeTestCase import FunctionalDocTestSuite
 from Testing.ZopeTestCase import FunctionalDocFileSuite
+from Testing.ZopeTestCase import FunctionalDocTestSuite
+
+import unittest
 
 
 class HTTPHeaderOutputTests(unittest.TestCase):

--- a/src/Testing/ZopeTestCase/zopedoctest/testLayerExtraction.py
+++ b/src/Testing/ZopeTestCase/zopedoctest/testLayerExtraction.py
@@ -13,12 +13,12 @@
 """Test layer extraction feature
 """
 
-from unittest import TestSuite
 from Testing import ZopeTestCase
+from Testing.ZopeTestCase import layer
+from Testing.ZopeTestCase import transaction
 from Testing.ZopeTestCase import ZopeDocFileSuite
 from Testing.ZopeTestCase import ZopeDocTestSuite
-from Testing.ZopeTestCase import transaction
-from Testing.ZopeTestCase import layer
+from unittest import TestSuite
 
 
 class TestLayer(layer.ZopeLite):

--- a/src/Testing/ZopeTestCase/zopedoctest/testPackageAsProduct.py
+++ b/src/Testing/ZopeTestCase/zopedoctest/testPackageAsProduct.py
@@ -13,14 +13,14 @@
 """Tests for installPackage
 """
 
-import sys
-from unittest import TestSuite
-
 from Testing import ZopeTestCase
-from Testing.ZopeTestCase import ZopeLite
 from Testing.ZopeTestCase import ZopeDocTestSuite
+from Testing.ZopeTestCase import ZopeLite
+from unittest import TestSuite
 from Zope2.App import zcml
 from zope.testing import cleanup
+
+import sys
 
 
 def testInstallPackage():

--- a/src/Testing/ZopeTestCase/zopedoctest/testWarningsTest.py
+++ b/src/Testing/ZopeTestCase/zopedoctest/testWarningsTest.py
@@ -13,8 +13,8 @@
 """Example doctest
 """
 
-from unittest import TestSuite
 from Testing.ZopeTestCase import ZopeDocFileSuite
+from unittest import TestSuite
 
 
 def test_suite():

--- a/src/Testing/ZopeTestCase/zopedoctest/testZopeDocTest.py
+++ b/src/Testing/ZopeTestCase/zopedoctest/testZopeDocTest.py
@@ -13,9 +13,9 @@
 """Example Zope doctest
 """
 
-from unittest import TestSuite
-from Testing.ZopeTestCase import ZopeDocTestSuite
 from Testing.ZopeTestCase import ZopeDocFileSuite
+from Testing.ZopeTestCase import ZopeDocTestSuite
+from unittest import TestSuite
 
 
 def setUp(self):

--- a/src/Testing/ZopeTestCase/zopedoctest/tests.py
+++ b/src/Testing/ZopeTestCase/zopedoctest/tests.py
@@ -13,9 +13,10 @@
 """Test runner that works with zope.testrunner
 """
 
-import unittest
 import os
 import Testing.ZopeTestCase.zopedoctest
+import unittest
+
 
 suite = unittest.TestSuite()
 

--- a/src/Testing/__init__.py
+++ b/src/Testing/__init__.py
@@ -14,9 +14,9 @@
 Set up testing environment
 """
 
+import App.config
 import os
 
-import App.config
 
 cfg = App.config.getConfiguration()
 

--- a/src/Testing/custom_zodb.py
+++ b/src/Testing/custom_zodb.py
@@ -1,5 +1,6 @@
-import os
 import logging
+import os
+
 
 LOG = logging.getLogger('Testing')
 

--- a/src/Testing/makerequest.py
+++ b/src/Testing/makerequest.py
@@ -16,10 +16,9 @@ ZODB objects
 """
 
 from io import BytesIO
-
+from ZPublisher.BaseRequest import RequestContainer
 from ZPublisher.HTTPRequest import HTTPRequest
 from ZPublisher.HTTPResponse import HTTPResponse
-from ZPublisher.BaseRequest import RequestContainer
 
 
 def makerequest(app, stdout=None, environ=None):

--- a/src/Testing/testbrowser.py
+++ b/src/Testing/testbrowser.py
@@ -14,15 +14,15 @@
 """Support for using zope.testbrowser from Zope2.
 """
 
-import codecs
-import transaction
-from zope.testbrowser import browser
-
 from Testing.ZopeTestCase.functional import savestate
 from Testing.ZopeTestCase.sandbox import AppZapper
 from Testing.ZopeTestCase.zopedoctest.functional import auth_header
+from zope.testbrowser import browser
 from ZPublisher.httpexceptions import HTTPExceptionHandler
 from ZPublisher.WSGIPublisher import publish_module
+
+import codecs
+import transaction
 
 
 class WSGITestApp(object):

--- a/src/Testing/tests/test_makerequest.py
+++ b/src/Testing/tests/test_makerequest.py
@@ -13,11 +13,11 @@
 """Unit tests of makequest.
 """
 
-import unittest
-
 from Acquisition import Implicit
-from Testing.makerequest import makerequest
 from OFS.SimpleItem import SimpleItem
+from Testing.makerequest import makerequest
+
+import unittest
 
 
 class MakerequestTests(unittest.TestCase):

--- a/src/Testing/tests/test_testbrowser.py
+++ b/src/Testing/tests/test_testbrowser.py
@@ -15,20 +15,18 @@
 """
 
 from AccessControl.Permissions import view
-from ZPublisher.WSGIPublisher import publish_module
-from ZPublisher.httpexceptions import HTTPExceptionHandler
-from six.moves.urllib.error import HTTPError
-from zExceptions import NotFound
-import transaction
-
 from OFS.SimpleItem import Item
+from six.moves.urllib.error import HTTPError
 from Testing.testbrowser import Browser
 from Testing.testbrowser import WSGITestApp
-from Testing.ZopeTestCase import (
-    FunctionalTestCase,
-    user_name,
-    user_password,
-)
+from Testing.ZopeTestCase import FunctionalTestCase
+from Testing.ZopeTestCase import user_name
+from Testing.ZopeTestCase import user_password
+from zExceptions import NotFound
+from ZPublisher.httpexceptions import HTTPExceptionHandler
+from ZPublisher.WSGIPublisher import publish_module
+
+import transaction
 
 
 class CookieStub(Item):

--- a/src/ZPublisher/BaseRequest.py
+++ b/src/ZPublisher/BaseRequest.py
@@ -13,11 +13,11 @@
 """ Basic ZPublisher request management.
 """
 
-import types
-
 from AccessControl.ZopeSecurityPolicy import getRoles
-from Acquisition import aq_base, aq_inner
+from Acquisition import aq_base
+from Acquisition import aq_inner
 from Acquisition.interfaces import IAcquirer
+from App.bbb import HAS_ZSERVER
 from ExtensionClass import Base
 from six.moves.urllib.parse import quote as urllib_quote
 from zExceptions import Forbidden
@@ -34,11 +34,12 @@ from zope.publisher.interfaces import NotFound as ztkNotFound
 from zope.publisher.interfaces.browser import IBrowserPublisher
 from zope.traversing.namespace import namespaceLookup
 from zope.traversing.namespace import nsParse
-from ZPublisher.xmlrpc import is_xmlrpc_response
-
-from App.bbb import HAS_ZSERVER
 from ZPublisher.Converters import type_converters
 from ZPublisher.interfaces import UseTraversalDefault
+from ZPublisher.xmlrpc import is_xmlrpc_response
+
+import types
+
 
 _marker = []
 UNSPECIFIED_ROLES = ''

--- a/src/ZPublisher/BaseResponse.py
+++ b/src/ZPublisher/BaseResponse.py
@@ -15,7 +15,10 @@
 
 from six import PY2
 from six import text_type
-from zExceptions import Unauthorized, Forbidden, NotFound, BadRequest
+from zExceptions import BadRequest
+from zExceptions import Forbidden
+from zExceptions import NotFound
+from zExceptions import Unauthorized
 
 
 class BaseResponse(object):

--- a/src/ZPublisher/BeforeTraverse.py
+++ b/src/ZPublisher/BeforeTraverse.py
@@ -15,6 +15,7 @@
 from Acquisition import aq_base
 from logging import getLogger
 
+
 LOG = getLogger('ZPublisher')
 
 

--- a/src/ZPublisher/Converters.py
+++ b/src/ZPublisher/Converters.py
@@ -11,12 +11,14 @@
 #
 ##############################################################################
 
-import re
 from DateTime import DateTime
 from DateTime.interfaces import SyntaxError
-import six
 from six import binary_type
 from six import text_type
+
+import re
+import six
+
 
 try:
     from html import escape

--- a/src/ZPublisher/HTTPRangeSupport.py
+++ b/src/ZPublisher/HTTPRangeSupport.py
@@ -19,9 +19,11 @@ flag-interface and some support functions for implementing this functionality.
 For an implementation example, see the File class in OFS/Image.py.
 """
 
+from zope.interface import Interface
+
 import re
 import sys
-from zope.interface import Interface
+
 
 WHITESPACE = re.compile(r'\s*', re.MULTILINE)
 

--- a/src/ZPublisher/HTTPRequest.py
+++ b/src/ZPublisher/HTTPRequest.py
@@ -14,16 +14,10 @@
 """ HTTP request management.
 """
 
-from cgi import FieldStorage
-import codecs
-from copy import deepcopy
-import os
-import random
-import re
-import time
-
 from AccessControl.tainted import should_be_tainted
 from AccessControl.tainted import taint_string
+from cgi import FieldStorage
+from copy import deepcopy
 from six import binary_type
 from six import PY2
 from six import PY3
@@ -31,18 +25,25 @@ from six import string_types
 from six import text_type
 from six.moves.urllib.parse import unquote
 from zope.i18n.interfaces import IUserPreferredLanguages
-from zope.i18n.locales import locales, LoadLocaleError
+from zope.i18n.locales import LoadLocaleError
+from zope.i18n.locales import locales
 from zope.interface import directlyProvidedBy
 from zope.interface import directlyProvides
 from zope.interface import implementer
 from zope.publisher.base import DebugFlags
 from zope.publisher.interfaces.browser import IBrowserRequest
-
+from ZPublisher import xmlrpc
 from ZPublisher.BaseRequest import BaseRequest
 from ZPublisher.BaseRequest import quote
 from ZPublisher.Converters import get_converter
 from ZPublisher.utils import basic_auth_decode
-from ZPublisher import xmlrpc
+
+import codecs
+import os
+import random
+import re
+import time
+
 
 if PY3:
     from html import escape

--- a/src/ZPublisher/HTTPResponse.py
+++ b/src/ZPublisher/HTTPResponse.py
@@ -13,6 +13,25 @@
 """ CGI Response Output formatter
 """
 from io import BytesIO
+from six import class_types
+from six import PY2
+from six import reraise
+from six import text_type
+from six.moves.urllib.parse import quote
+from zExceptions import BadRequest
+from zExceptions import HTTPRedirection
+from zExceptions import InternalError
+from zExceptions import NotFound
+from zExceptions import Redirect
+from zExceptions import status_reasons
+from zExceptions import Unauthorized
+from zExceptions.ExceptionFormatter import format_exception
+from zope.event import notify
+from ZPublisher import pubevents
+from ZPublisher.BaseResponse import BaseResponse
+from ZPublisher.Iterators import IStreamIterator
+from ZPublisher.Iterators import IUnboundStreamIterator
+
 import os
 import re
 import struct
@@ -20,25 +39,6 @@ import sys
 import time
 import zlib
 
-from six import class_types
-from six import PY2
-from six import reraise
-from six import text_type
-from six.moves.urllib.parse import quote
-from zope.event import notify
-from zExceptions import (
-    BadRequest,
-    HTTPRedirection,
-    InternalError,
-    NotFound,
-    Redirect,
-    status_reasons,
-    Unauthorized,
-)
-from zExceptions.ExceptionFormatter import format_exception
-from ZPublisher.BaseResponse import BaseResponse
-from ZPublisher.Iterators import IUnboundStreamIterator, IStreamIterator
-from ZPublisher import pubevents
 
 try:
     from html import escape

--- a/src/ZPublisher/Iterators.py
+++ b/src/ZPublisher/Iterators.py
@@ -1,7 +1,7 @@
-import io
-
-from zope.interface import Interface
 from zope.interface import implementer
+from zope.interface import Interface
+
+import io
 
 
 class IUnboundStreamIterator(Interface):

--- a/src/ZPublisher/Publish.py
+++ b/src/ZPublisher/Publish.py
@@ -13,6 +13,7 @@
 
 from zope.deferredimport import deprecated
 
+
 # BBB Zope 5.0
 deprecated(
     'Please import from ZServer.ZPublisher.Publish.',

--- a/src/ZPublisher/Request.py
+++ b/src/ZPublisher/Request.py
@@ -13,6 +13,7 @@
 
 from zope.deferredimport import deprecated
 
+
 # BBB: Zope 5.0
 deprecated(
     'Please import from ZPublisher.HTTPRequest',

--- a/src/ZPublisher/Response.py
+++ b/src/ZPublisher/Response.py
@@ -13,6 +13,7 @@
 
 from zope.deferredimport import deprecated
 
+
 # BBB: Zope 5.0
 deprecated(
     'Please import from ZPublisher.HTTPResponse',

--- a/src/ZPublisher/WSGIPublisher.py
+++ b/src/ZPublisher/WSGIPublisher.py
@@ -12,34 +12,35 @@
 ##############################################################################
 """ Python Object Publisher -- Publish Python objects on web servers
 """
-from contextlib import contextmanager, closing
-from io import BytesIO
-from io import IOBase
-import sys
-
 from AccessControl.SecurityManagement import newSecurityManager
 from AccessControl.SecurityManagement import noSecurityManager
+from contextlib import closing
+from contextlib import contextmanager
+from io import BytesIO
+from io import IOBase
 from six import PY3
 from six import reraise
 from six.moves._thread import allocate_lock
-import transaction
 from transaction.interfaces import TransientError
-from zExceptions import (
-    Unauthorized,
-    upgradeException,
-)
+from zExceptions import Unauthorized
+from zExceptions import upgradeException
 from zope.component import queryMultiAdapter
 from zope.event import notify
-from zope.globalrequest import setRequest, clearRequest
-from zope.security.management import newInteraction, endInteraction
+from zope.globalrequest import clearRequest
+from zope.globalrequest import setRequest
 from zope.publisher.skinnable import setDefaultSkin
-
+from zope.security.management import endInteraction
+from zope.security.management import newInteraction
+from ZPublisher import pubevents
 from ZPublisher.HTTPRequest import WSGIRequest
 from ZPublisher.HTTPResponse import WSGIResponse
 from ZPublisher.Iterators import IUnboundStreamIterator
 from ZPublisher.mapply import mapply
-from ZPublisher import pubevents
 from ZPublisher.utils import recordMetaData
+
+import sys
+import transaction
+
 
 if sys.version_info >= (3, ):
     _FILE_TYPES = (IOBase, )

--- a/src/ZPublisher/interfaces.py
+++ b/src/ZPublisher/interfaces.py
@@ -1,4 +1,6 @@
-from zope.interface import Interface, Attribute
+from zope.interface import Attribute
+from zope.interface import Interface
+
 
 #############################################################################
 # Publication events

--- a/src/ZPublisher/pubevents.py
+++ b/src/ZPublisher/pubevents.py
@@ -8,12 +8,13 @@ e.g. request and error rate determination, writing high resolution logfiles
 for detailed time related analysis, inline request monitoring.
 '''
 from zope.interface import implementer
-
-from ZPublisher.interfaces import (
-    IPubStart, IPubSuccess, IPubFailure,
-    IPubAfterTraversal, IPubBeforeCommit, IPubBeforeAbort,
-    IPubBeforeStreaming,
-)
+from ZPublisher.interfaces import IPubAfterTraversal
+from ZPublisher.interfaces import IPubBeforeAbort
+from ZPublisher.interfaces import IPubBeforeCommit
+from ZPublisher.interfaces import IPubBeforeStreaming
+from ZPublisher.interfaces import IPubFailure
+from ZPublisher.interfaces import IPubStart
+from ZPublisher.interfaces import IPubSuccess
 
 
 class _Base(object):

--- a/src/ZPublisher/tests/testBaseRequest.py
+++ b/src/ZPublisher/tests/testBaseRequest.py
@@ -1,9 +1,9 @@
-import unittest
-
 from zExceptions import NotFound
 from zope.interface import implementer
 from zope.publisher.interfaces import IPublishTraverse
 from zope.publisher.interfaces import NotFound as ztkNotFound
+
+import unittest
 
 
 @implementer(IPublishTraverse)

--- a/src/ZPublisher/tests/testBeforeTraverse.py
+++ b/src/ZPublisher/tests/testBeforeTraverse.py
@@ -1,8 +1,8 @@
-import doctest
-
 from Acquisition import Implicit
 from ZPublisher.BaseRequest import BaseRequest
 from ZPublisher.HTTPResponse import HTTPResponse
+
+import doctest
 
 
 def makeBaseRequest(root):

--- a/src/ZPublisher/tests/testHTTPRangeSupport.py
+++ b/src/ZPublisher/tests/testHTTPRangeSupport.py
@@ -11,9 +11,10 @@
 #
 ##############################################################################
 
-import sys
-from ZPublisher.HTTPRangeSupport import parseRange, expandRanges
+from ZPublisher.HTTPRangeSupport import expandRanges
+from ZPublisher.HTTPRangeSupport import parseRange
 
+import sys
 import unittest
 
 

--- a/src/ZPublisher/tests/testHTTPRequest.py
+++ b/src/ZPublisher/tests/testHTTPRequest.py
@@ -11,12 +11,9 @@
 #
 ##############################################################################
 
-from io import BytesIO
-import sys
-import unittest
-
-from six import PY2
 from AccessControl.tainted import should_be_tainted
+from io import BytesIO
+from six import PY2
 from zExceptions import NotFound
 from zope.component import provideAdapter
 from zope.i18n.interfaces import IUserPreferredLanguages
@@ -24,9 +21,12 @@ from zope.i18n.interfaces.locales import ILocale
 from zope.publisher.browser import BrowserLanguages
 from zope.publisher.interfaces.http import IHTTPRequest
 from zope.testing.cleanup import cleanUp
-
 from ZPublisher.tests.testBaseRequest import TestRequestViewsBase
 from ZPublisher.utils import basic_auth_encode
+
+import sys
+import unittest
+
 
 if sys.version_info >= (3, ):
     unicode = str

--- a/src/ZPublisher/tests/testHTTPResponse.py
+++ b/src/ZPublisher/tests/testHTTPResponse.py
@@ -1,19 +1,17 @@
 # -*- coding: utf-8 -*-
 
 from io import BytesIO
+from six import PY3
+from zExceptions import BadRequest
+from zExceptions import Forbidden
+from zExceptions import InternalError
+from zExceptions import NotFound
+from zExceptions import ResourceLockedError
+from zExceptions import Unauthorized
+
 import sys
 import traceback
 import unittest
-
-from six import PY3
-from zExceptions import (
-    BadRequest,
-    Forbidden,
-    InternalError,
-    NotFound,
-    ResourceLockedError,
-    Unauthorized,
-)
 
 
 class HTTPResponseTests(unittest.TestCase):

--- a/src/ZPublisher/tests/testIterators.py
+++ b/src/ZPublisher/tests/testIterators.py
@@ -1,6 +1,8 @@
-import unittest
 from zope.interface.verify import verifyClass
-from ZPublisher.Iterators import IStreamIterator, filestream_iterator
+from ZPublisher.Iterators import filestream_iterator
+from ZPublisher.Iterators import IStreamIterator
+
+import unittest
 
 
 class TestFileStreamIterator(unittest.TestCase):

--- a/src/ZPublisher/tests/testPostTraversal.py
+++ b/src/ZPublisher/tests/testPostTraversal.py
@@ -1,9 +1,10 @@
-from unittest import TestCase
-
 from Acquisition import Implicit
+from unittest import TestCase
 from ZPublisher.BaseRequest import BaseRequest
 from ZPublisher.HTTPResponse import HTTPResponse
+
 import Zope2
+
 
 Zope2.startup_wsgi()
 

--- a/src/ZPublisher/tests/test_Converters.py
+++ b/src/ZPublisher/tests/test_Converters.py
@@ -11,9 +11,9 @@
 #
 ##############################################################################
 
-import unittest
-
 from six import text_type
+
+import unittest
 
 
 class ConvertersTests(unittest.TestCase):

--- a/src/ZPublisher/tests/test_WSGIPublisher.py
+++ b/src/ZPublisher/tests/test_WSGIPublisher.py
@@ -11,21 +11,20 @@
 # FOR A PARTICULAR PURPOSE
 #
 ##############################################################################
-import io
-import unittest
-
-import transaction
+from six.moves.urllib_parse import quote
+from Testing.ZopeTestCase import FunctionalTestCase
+from Testing.ZopeTestCase import ZopeTestCase
 from ZODB.POSException import ConflictError
 from zope.interface.common.interfaces import IException
 from zope.publisher.interfaces import INotFound
-from zope.security.interfaces import IUnauthorized
 from zope.security.interfaces import IForbidden
-from six.moves.urllib_parse import quote
-
-from Testing.ZopeTestCase import FunctionalTestCase
-from Testing.ZopeTestCase import ZopeTestCase
+from zope.security.interfaces import IUnauthorized
 from ZPublisher.WSGIPublisher import get_module_info
+
+import io
 import Testing.testbrowser
+import transaction
+import unittest
 
 
 class WSGIResponseTests(unittest.TestCase):

--- a/src/ZPublisher/tests/test_mapply.py
+++ b/src/ZPublisher/tests/test_mapply.py
@@ -12,13 +12,12 @@
 #
 ##############################################################################
 
-import unittest
+from six import PY2
+from ZPublisher.mapply import mapply
 
 import Acquisition
 import ExtensionClass
-from six import PY2
-
-from ZPublisher.mapply import mapply
+import unittest
 
 
 class MapplyTests(unittest.TestCase):

--- a/src/ZPublisher/tests/test_pubevents.py
+++ b/src/ZPublisher/tests/test_pubevents.py
@@ -1,8 +1,10 @@
 from io import BytesIO
-from sys import modules, exc_info
+from sys import exc_info
+from sys import modules
+from Testing.ZopeTestCase import FunctionalTestCase
+from Testing.ZopeTestCase import user_name
+from Testing.ZopeTestCase import user_password
 from unittest import TestCase
-
-import zExceptions
 from ZODB.POSException import ConflictError
 from zope.component import adapter
 from zope.component import getSiteManager
@@ -12,24 +14,27 @@ from zope.interface import Interface
 from zope.interface.verify import verifyObject
 from zope.publisher.interfaces import INotFound
 from zope.publisher.interfaces.browser import IDefaultBrowserLayer
-
-from Testing.ZopeTestCase import FunctionalTestCase
-from Testing.ZopeTestCase import user_name
-from Testing.ZopeTestCase import user_password
 from ZPublisher.BaseRequest import BaseRequest
 from ZPublisher.HTTPRequest import WSGIRequest
 from ZPublisher.HTTPResponse import WSGIResponse
-from ZPublisher.interfaces import (
-    IPubEvent, IPubStart, IPubEnd, IPubSuccess, IPubFailure,
-    IPubAfterTraversal, IPubBeforeCommit,
-    IPubBeforeStreaming,
-)
-from ZPublisher.pubevents import (
-    PubStart, PubSuccess, PubFailure,
-    PubAfterTraversal, PubBeforeCommit, PubBeforeAbort,
-    PubBeforeStreaming,
-)
+from ZPublisher.interfaces import IPubAfterTraversal
+from ZPublisher.interfaces import IPubBeforeCommit
+from ZPublisher.interfaces import IPubBeforeStreaming
+from ZPublisher.interfaces import IPubEnd
+from ZPublisher.interfaces import IPubEvent
+from ZPublisher.interfaces import IPubFailure
+from ZPublisher.interfaces import IPubStart
+from ZPublisher.interfaces import IPubSuccess
+from ZPublisher.pubevents import PubAfterTraversal
+from ZPublisher.pubevents import PubBeforeAbort
+from ZPublisher.pubevents import PubBeforeCommit
+from ZPublisher.pubevents import PubBeforeStreaming
+from ZPublisher.pubevents import PubFailure
+from ZPublisher.pubevents import PubStart
+from ZPublisher.pubevents import PubSuccess
 from ZPublisher.WSGIPublisher import publish_module
+
+import zExceptions
 
 
 PUBMODULE = 'TEST_testpubevents'

--- a/src/ZPublisher/tests/test_utils.py
+++ b/src/ZPublisher/tests/test_utils.py
@@ -13,9 +13,9 @@
 #
 ##############################################################################
 
-import unittest
-
 from six import PY2
+
+import unittest
 
 
 class SafeUnicodeTests(unittest.TestCase):

--- a/src/ZPublisher/tests/test_xmlrpc.py
+++ b/src/ZPublisher/tests/test_xmlrpc.py
@@ -1,10 +1,13 @@
+from DateTime import DateTime
+
 import unittest
+
+
 try:
     import xmlrpc.client as xmlrpclib
 except ImportError:
     import xmlrpclib
 
-from DateTime import DateTime
 
 
 class FauxResponse(object):

--- a/src/ZPublisher/utils.py
+++ b/src/ZPublisher/utils.py
@@ -11,14 +11,16 @@
 #
 ##############################################################################
 
+from Acquisition import aq_inner
+from Acquisition import aq_parent
+from six import binary_type
+from six import PY3
+from six import text_type
+
 import base64
 import logging
-
-from Acquisition import aq_inner, aq_parent
-from six import PY3
-from six import binary_type
-from six import text_type
 import transaction
+
 
 AC_LOGGER = logging.getLogger('event.AccessControl')
 

--- a/src/ZPublisher/xmlrpc.py
+++ b/src/ZPublisher/xmlrpc.py
@@ -19,21 +19,23 @@ See http://www.xmlrpc.com/ and http://linux.userland.com/ for more
 information about XML-RPC and Zope.
 """
 
+from App.config import getConfiguration
+from DateTime.DateTime import DateTime
+from zExceptions import Unauthorized
+from ZODB.POSException import ConflictError
+
 import re
 import sys
+
 
 try:
     import xmlrpc.client as xmlrpclib
 except ImportError:
     import xmlrpclib
 
-from App.config import getConfiguration
-from zExceptions import Unauthorized
-from ZODB.POSException import ConflictError
 
 # Make DateTime.DateTime marshallable via XML-RPC
 # http://www.zope.org/Collectors/Zope/2109
-from DateTime.DateTime import DateTime
 WRAPPERS = xmlrpclib.WRAPPERS + (DateTime, )
 
 

--- a/src/ZTUtils/Lazy.py
+++ b/src/ZTUtils/Lazy.py
@@ -13,6 +13,7 @@
 
 from six.moves import xrange
 
+
 _marker = object()
 
 

--- a/src/ZTUtils/SimpleTree.py
+++ b/src/ZTUtils/SimpleTree.py
@@ -13,8 +13,10 @@
 """Simple Tree classes
 """
 
+from .Tree import b2a
+from .Tree import TreeMaker
+from .Tree import TreeNode
 from Acquisition import aq_acquire
-from .Tree import TreeMaker, TreeNode, b2a
 
 
 class SimpleTreeNode(TreeNode):

--- a/src/ZTUtils/Tree.py
+++ b/src/ZTUtils/Tree.py
@@ -13,12 +13,12 @@
 """Tree manipulation classes
 """
 
-import base64
-import zlib
-
 from Acquisition import Explicit
 from ComputedAttribute import ComputedAttribute
+
+import base64
 import six
+import zlib
 
 
 class TreeNode(Explicit):

--- a/src/ZTUtils/Zope.py
+++ b/src/ZTUtils/Zope.py
@@ -20,14 +20,15 @@ from DateTime.DateTime import DateTime
 from six import binary_type
 from six import PY2
 from six import text_type
-from six.moves.urllib.parse import quote, unquote
-
+from six.moves.urllib.parse import quote
+from six.moves.urllib.parse import unquote
 from ZTUtils.Batch import Batch
 from ZTUtils.Lazy import Lazy
 from ZTUtils.SimpleTree import SimpleTreeMaker
 from ZTUtils.Tree import decodeExpansion
 from ZTUtils.Tree import encodeExpansion
 from ZTUtils.Tree import TreeMaker
+
 
 try:
     from html import escape

--- a/src/ZTUtils/__init__.py
+++ b/src/ZTUtils/__init__.py
@@ -12,14 +12,21 @@
 ##############################################################################
 """Package of template utility classes and functions.
 """
+from .Tree import a2b
+from .Tree import b2a
+from .Tree import decodeExpansion
+from .Tree import encodeExpansion
 from AccessControl.SecurityInfo import ModuleSecurityInfo
+from ZTUtils.Zope import Batch
+from ZTUtils.Zope import LazyFilter
+from ZTUtils.Zope import make_hidden_input
+from ZTUtils.Zope import make_query
+from ZTUtils.Zope import SimpleTreeMaker
+from ZTUtils.Zope import TreeMaker
+from ZTUtils.Zope import url_query
+
+
 security = ModuleSecurityInfo('ZTUtils')
-
 security.declarePublic('encodeExpansion', 'decodeExpansion', 'a2b', 'b2a')
-from .Tree import encodeExpansion, decodeExpansion, a2b, b2a  # NOQA
-
 security.declarePublic('Batch', 'TreeMaker', 'SimpleTreeMaker', 'LazyFilter')
-from ZTUtils.Zope import Batch, TreeMaker, SimpleTreeMaker, LazyFilter  # NOQA
-
 security.declarePublic('url_query', 'make_query', 'make_hidden_input')
-from ZTUtils.Zope import url_query, make_query, make_hidden_input  # NOQA

--- a/src/ZTUtils/tests/testBatch.py
+++ b/src/ZTUtils/tests/testBatch.py
@@ -1,6 +1,6 @@
-import unittest
-
 from ZTUtils import Batch
+
+import unittest
 
 
 class BatchTests(unittest.TestCase):

--- a/src/ZTUtils/tests/testTree.py
+++ b/src/ZTUtils/tests/testTree.py
@@ -1,6 +1,6 @@
-import unittest
-
 from ZTUtils import Tree
+
+import unittest
 
 
 class Item(object):

--- a/src/ZTUtils/tests/testZope.py
+++ b/src/ZTUtils/tests/testZope.py
@@ -1,15 +1,12 @@
-import unittest
-
 from DateTime import DateTime
 from six import PY2
 from six.moves.urllib.parse import quote
+from ZTUtils.Zope import complex_marshal
+from ZTUtils.Zope import make_hidden_input
+from ZTUtils.Zope import make_query
+from ZTUtils.Zope import simple_marshal
 
-from ZTUtils.Zope import (
-    complex_marshal,
-    simple_marshal,
-    make_hidden_input,
-    make_query,
-)
+import unittest
 
 
 class QueryTests(unittest.TestCase):

--- a/src/Zope2/App/patches/__init__.py
+++ b/src/Zope2/App/patches/__init__.py
@@ -2,6 +2,7 @@
 from . import persistence
 from . import publishing
 
+
 # Have the patches been applied yet?
 _patched = False
 

--- a/src/Zope2/App/startup.py
+++ b/src/Zope2/App/startup.py
@@ -13,25 +13,25 @@
 """Initialize the Zope2 Package and provide a published module
 """
 
-import os
-import sys
-from time import asctime
-import types
-
-import AccessControl.User
 from AccessControl.SecurityManagement import newSecurityManager
 from AccessControl.SecurityManagement import noSecurityManager
-import six
-import ZODB
+from App.config import getConfiguration
+from time import asctime
 from zope.deferredimport import deprecated
 from zope.event import notify
 from zope.processlifetime import DatabaseOpened
 from zope.processlifetime import DatabaseOpenedWithRoot
 
-from App.config import getConfiguration
+import AccessControl.User
 import App.ZApplication
 import OFS.Application
+import os
+import six
+import sys
+import types
+import ZODB
 import Zope2
+
 
 # BBB Zope 5.0
 deprecated(

--- a/src/Zope2/App/tests/test_safe_formatter.py
+++ b/src/Zope2/App/tests/test_safe_formatter.py
@@ -5,6 +5,7 @@ from zExceptions import Unauthorized
 
 import unittest
 
+
 try:
     from html import escape
     import functools

--- a/src/Zope2/App/tests/test_schema.py
+++ b/src/Zope2/App/tests/test_schema.py
@@ -11,8 +11,9 @@
 #
 ##############################################################################
 
-import unittest
 from zope.testing.cleanup import CleanUp
+
+import unittest
 
 
 class Zope2VocabularyRegistryTests(unittest.TestCase, CleanUp):

--- a/src/Zope2/App/tests/test_startup.py
+++ b/src/Zope2/App/tests/test_startup.py
@@ -11,12 +11,12 @@
 #
 ##############################################################################
 
+from Testing.ZopeTestCase import ZopeTestCase
+from zope.testing.loggingsupport import InstalledHandler
+
 import logging
 import unittest
 
-from Testing.ZopeTestCase import ZopeTestCase
-
-from zope.testing.loggingsupport import InstalledHandler
 
 logged = """Zope2.App.test_startup INFO
   <class 'zope.processlifetime.DatabaseOpened'>

--- a/src/Zope2/App/zcml.py
+++ b/src/Zope2/App/zcml.py
@@ -12,10 +12,12 @@
 #
 ##############################################################################
 
-import os.path
-
 from App.config import getConfiguration
 from zope.configuration import xmlconfig
+from zope.testing.cleanup import addCleanUp  # NOQA
+
+import os.path
+
 
 _initialized = False
 _context = None
@@ -68,6 +70,5 @@ def cleanUp():
     _context = None
 
 
-from zope.testing.cleanup import addCleanUp  # NOQA
 addCleanUp(cleanUp)
 del addCleanUp

--- a/src/Zope2/ClassFactory.py
+++ b/src/Zope2/ClassFactory.py
@@ -13,6 +13,7 @@
 
 from zope.deferredimport import deprecated
 
+
 # BBB Zope 5.0
 deprecated(
     'Please import from Zope2.App.ClassFactory.',

--- a/src/Zope2/Startup/__init__.py
+++ b/src/Zope2/Startup/__init__.py
@@ -13,8 +13,8 @@
 ##############################################################################
 
 from __future__ import absolute_import
-
 from zope.deferredimport import deprecated
+
 
 # BBB Zope 5.0
 deprecated(

--- a/src/Zope2/Startup/datatypes.py
+++ b/src/Zope2/Startup/datatypes.py
@@ -13,15 +13,16 @@
 ##############################################################################
 """Datatypes for the Zope schema for use with ZConfig."""
 
+from six import PY2
+from six import text_type
+from six.moves import UserDict
+from ZODB.config import ZODBDatabase
+from zope.deferredimport import deprecated
+
 import io
 import os
 import traceback
 
-from six.moves import UserDict
-from six import PY2, text_type
-
-from ZODB.config import ZODBDatabase
-from zope.deferredimport import deprecated
 
 # BBB Zope 5.0
 _prefix = 'ZServer.Zope2.Startup.datatypes:'

--- a/src/Zope2/Startup/handlers.py
+++ b/src/Zope2/Startup/handlers.py
@@ -12,11 +12,12 @@
 #
 ##############################################################################
 
+from socket import gethostbyaddr
+from zope.deferredimport import deprecated
+
 import ipaddress
 import os
-from socket import gethostbyaddr
 
-from zope.deferredimport import deprecated
 
 # BBB Zope 5.0
 _prefix = 'ZServer.Zope2.Startup.handlers:'

--- a/src/Zope2/Startup/misc/lock_file.py
+++ b/src/Zope2/Startup/misc/lock_file.py
@@ -14,6 +14,7 @@
 
 from zope.deferredimport import deprecated
 
+
 # BBB Zope 5.0
 deprecated(
     'Please import from ZServer.Zope2.Startup.utils',

--- a/src/Zope2/Startup/options.py
+++ b/src/Zope2/Startup/options.py
@@ -12,12 +12,14 @@
 #
 ##############################################################################
 
+from ZConfig.loader import ConfigLoader
+from ZConfig.loader import SchemaLoader
+from ZConfig.schema import SchemaParser
+from zope.deferredimport import deprecated
+
 import os
 import xml.sax
 
-from ZConfig.loader import ConfigLoader, SchemaLoader
-from ZConfig.schema import SchemaParser
-from zope.deferredimport import deprecated
 
 # BBB Zope 5.0
 _prefix = 'ZServer.Zope2.Startup.options:'

--- a/src/Zope2/Startup/run.py
+++ b/src/Zope2/Startup/run.py
@@ -14,6 +14,7 @@
 
 from zope.deferredimport import deprecated
 
+
 # BBB Zope 5.0
 deprecated(
     'Please import from ZServer.Zope2.Startup.run',

--- a/src/Zope2/Startup/serve.py
+++ b/src/Zope2/Startup/serve.py
@@ -15,13 +15,14 @@
 # (http://repoze.org/license.html).
 
 from logging.config import fileConfig
+from paste.deploy import loadapp
+from paste.deploy import loadserver
+
 import optparse
 import os
 import re
 import sys
 
-from paste.deploy import loadserver
-from paste.deploy import loadapp
 
 try:
     import configparser

--- a/src/Zope2/Startup/starter.py
+++ b/src/Zope2/Startup/starter.py
@@ -12,17 +12,17 @@
 #
 ##############################################################################
 
-import logging
-import sys
-import locale
-import codecs
-
 from six import PY2
 from ZConfig import ConfigurationError
+from Zope2.Startup.handlers import _name_to_ips
 from zope.event import notify
 from zope.processlifetime import ProcessStarting
 
-from Zope2.Startup.handlers import _name_to_ips
+import codecs
+import locale
+import logging
+import sys
+
 
 logger = logging.getLogger("Zope")
 

--- a/src/Zope2/Startup/tests/test_datatypes.py
+++ b/src/Zope2/Startup/tests/test_datatypes.py
@@ -12,14 +12,14 @@
 #
 ##############################################################################
 
+from Zope2.Startup.options import ZopeWSGIOptions
+
 import io
 import shutil
 import tempfile
 import unittest
-
 import ZConfig
 
-from Zope2.Startup.options import ZopeWSGIOptions
 
 _SCHEMA = None
 

--- a/src/Zope2/Startup/tests/test_schema.py
+++ b/src/Zope2/Startup/tests/test_schema.py
@@ -12,17 +12,17 @@
 #
 ##############################################################################
 
+from Zope2.Startup.options import ZopeWSGIOptions
+
 import codecs
-import os
 import io
+import os
 import tempfile
 import unittest
-
 import ZConfig
-import ZPublisher.HTTPRequest
 import Zope2.Startup.datatypes
+import ZPublisher.HTTPRequest
 
-from Zope2.Startup.options import ZopeWSGIOptions
 
 _SCHEMA = None
 TEMPNAME = tempfile.mktemp()

--- a/src/Zope2/Startup/tests/test_starter.py
+++ b/src/Zope2/Startup/tests/test_starter.py
@@ -12,18 +12,18 @@
 #
 ##############################################################################
 
+from Zope2.Startup import get_wsgi_starter
+from Zope2.Startup.options import ZopeWSGIOptions
+
 import io
 import os
 import shutil
+import six
 import sys
 import tempfile
 import unittest
-
-import six
 import ZConfig
 
-from Zope2.Startup import get_wsgi_starter
-from Zope2.Startup.options import ZopeWSGIOptions
 
 _SCHEMA = None
 

--- a/src/Zope2/Startup/zopectl.py
+++ b/src/Zope2/Startup/zopectl.py
@@ -14,6 +14,7 @@
 
 from zope.deferredimport import deprecated
 
+
 # BBB Zope 5.0
 deprecated(
     'Please import from ZServer.Zope2.Startup.zopectl',

--- a/src/Zope2/__init__.py
+++ b/src/Zope2/__init__.py
@@ -13,9 +13,10 @@
 ##############################################################################
 """Zope application package."""
 
+from zope.deferredimport import deprecated
+
 import os
 
-from zope.deferredimport import deprecated
 
 # BBB Zope 5.0
 deprecated(

--- a/src/Zope2/utilities/adduser.py
+++ b/src/Zope2/utilities/adduser.py
@@ -12,8 +12,9 @@
 ##############################################################################
 """ Add a Zope management user to the root Zope user folder """
 
-import sys
 from Zope2.utilities.finder import ZopeFinder
+
+import sys
 
 
 def adduser(app, user, pwd):

--- a/src/Zope2/utilities/copyzopeskel.py
+++ b/src/Zope2/utilities/copyzopeskel.py
@@ -60,10 +60,10 @@ the target directory, its ownership information and mode bit settings are left
 unchanged.
 """
 
+import getopt
 import os
 import shutil
 import sys
-import getopt
 
 
 def main():

--- a/src/Zope2/utilities/mkwsgiinstance.py
+++ b/src/Zope2/utilities/mkwsgiinstance.py
@@ -26,11 +26,13 @@ When run without arguments, this script will ask for the information
 necessary to create a Zope WSGI instance home.
 """
 
+from . import copyzopeskel
+
 import getopt
 import os
 import subprocess
 import sys
-from . import copyzopeskel
+
 
 if sys.version_info > (3, ):
     raw_input = input

--- a/src/Zope2/utilities/mkzopeinstance.py
+++ b/src/Zope2/utilities/mkzopeinstance.py
@@ -13,6 +13,7 @@
 
 from zope.deferredimport import deprecated
 
+
 _prefix = 'ZServer.Zope2.utilities.mkzopeinstance:'
 
 # BBB Zope 5.0

--- a/src/Zope2/utilities/tests/test_zconsole.py
+++ b/src/Zope2/utilities/tests/test_zconsole.py
@@ -1,10 +1,13 @@
+from App.config import getConfiguration
+from App.config import setConfiguration
+from six import StringIO
+
 import os
 import shutil
 import sys
 import tempfile
 import unittest
-from App.config import setConfiguration, getConfiguration
-from six import StringIO
+
 
 zope_conf_template = """
 %define INSTANCE {}

--- a/src/Zope2/utilities/zconsole.py
+++ b/src/Zope2/utilities/zconsole.py
@@ -1,11 +1,12 @@
-import os
-import sys
-import Zope2
 from AccessControl.SecurityManagement import newSecurityManager
 from AccessControl.SpecialUsers import system as user
 from Testing.makerequest import makerequest
 from Zope2.Startup.run import make_wsgi_app
 from zope.globalrequest import setRequest
+
+import os
+import sys
+import Zope2
 
 
 def runscript(zopeconf, script_name, *extra_args):

--- a/src/Zope2/utilities/zpasswd.py
+++ b/src/Zope2/utilities/zpasswd.py
@@ -14,6 +14,7 @@
 
 from zope.deferredimport import deprecated
 
+
 # BBB Zope 5.0
 deprecated(
     'Please import from ZServer.Zope2.utilities.zpasswd',

--- a/src/zmi/styles/tests.py
+++ b/src/zmi/styles/tests.py
@@ -1,6 +1,7 @@
 from Testing.ZopeTestCase.placeless import temporaryPlacelessSetUp
 from Testing.ZopeTestCase.placeless import zcml
 from zope.security.management import endInteraction
+
 import Testing.ZopeTestCase
 
 


### PR DESCRIPTION
This commit is mainly the result of `tox -eisort-apply`.
It makes the first part of the linting environments happy.

What do you think of it?
Is it worth the hassle?
Should the isort config be adapted?