### PR TITLE
Zope 2.13: Drop Python 2.6 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 sudo: false
 python:
-    - "2.6"
     - "2.7"
 
 notifications:

--- a/doc/CHANGES.rst
+++ b/doc/CHANGES.rst
@@ -16,6 +16,12 @@ Security related fixes
   did.
   (`#375 <https://github.com/zopefoundation/Zope/issues/375>`_)
 
+Backwards incompatible changes
+++++++++++++++++++++++++++++++
+
+- Drop support for Python 2.6. This means it is no longer tested from now on.
+  (`#475 <https://github.com/zopefoundation/Zope/issues/475>`_)
+
 Features
 ++++++++
 

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2 :: Only",
-        "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: Implementation :: CPython",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27
+envlist = py27
 
 [testenv]
 commands =


### PR DESCRIPTION
Fixes #475.