### PR TITLE
Remove references to obsolete Z_REALM

### DIFF
--- a/docs/zdgbook/ObjectPublishing.rst
+++ b/docs/zdgbook/ObjectPublishing.rst
@@ -590,20 +590,6 @@ Finally, traversal security can be circumvented with the
 in Chapter 6, "Security".
 
 
-Environment Variables
-=====================
-
-You can control some facets of the publisher's operation by setting
-environment variables.
-
-- 'Z_REALM' -- Sets the basic authorization realm. This controls the
-  realm name as it appears in the web browser's username and password
-  dialog. You can also set the realm with the '__bobo_realm__' module
-  variable, as mentioned previously.
-
-Many more options can be set using switches on the startup script.
-See the *Zope Administrator's Guide* for more information.
-
 Testing
 -------
 

--- a/src/Zope2/Startup/handlers.py
+++ b/src/Zope2/Startup/handlers.py
@@ -62,11 +62,6 @@ def automatically_quote_dtml_request_data(value):
     return value
 
 
-def http_realm(value):
-    value is not None and _setenv('Z_REALM', value)
-    return value
-
-
 def root_wsgi_handler(cfg):
     # Set environment variables
     for k, v in cfg.environment.items():


### PR DESCRIPTION
The Z_REALM environment variable is no longer used to control the
realm name of a basic auth dialog.