### PR TITLE
Remove section "Traversal Interfaces"

### DIFF
--- a/docs/zdgbook/ObjectPublishing.rst
+++ b/docs/zdgbook/ObjectPublishing.rst
@@ -141,19 +141,6 @@ published, otherwise an error is returned.
 Now let's take a closer look at traversal.
 
 
-Traversal Interfaces
-====================
-
-Zope defines interfaces for publishable objects, and publishable
-modules.
-
-
-When you are developing for Zope you almost always use the 'Zope'
-package as your published module. However, if you are using
-'ZPublisher' outside of Zope you'll be interested in the published
-module interface.
-
-
 Publishable Object Requirements
 ===============================
 


### PR DESCRIPTION
- interfaces are neither listed nor mentioned where to find
- hard to understand
- more detailed infos are provided later in section "4.10.7. Publishable Module"

modified:   docs/zdgbook/ObjectPublishing.rst