### PR TITLE
Don't always flag PubBeforeAbort and PubBeforeAbort as retry

### DIFF
--- a/src/ZPublisher/WSGIPublisher.py
+++ b/src/ZPublisher/WSGIPublisher.py
@@ -160,13 +160,15 @@ def transaction_pubevents(request, response, tm=transaction.manager):
                 response._unauthorized()
                 response.setStatus(exc.getStatus())
 
-            notify(pubevents.PubBeforeAbort(
-                request, exc_info, request.supports_retry()))
-            tm.abort()
-            notify(pubevents.PubFailure(
-                request, exc_info, request.supports_retry()))
-
+            retry = False
             if isinstance(exc, TransientError) and request.supports_retry():
+                retry = True
+
+            notify(pubevents.PubBeforeAbort(request, exc_info, retry))
+            tm.abort()
+            notify(pubevents.PubFailure(request, exc_info, retry))
+
+            if retry:
                 reraise(*exc_info)
 
             if not (exc_view_created or isinstance(exc, Unauthorized)):


### PR DESCRIPTION
Only mark the events when the request will actually be retried.
Fixes a issue uncovered in https://github.com/plone/buildout.coredev/pull/564