### PR TITLE
Fix subscript access on Page Template `macros` attribute

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,9 @@ https://github.com/zopefoundation/Zope/blob/4.0a6/CHANGES.rst
 Fixes
 +++++
 
+- Fix subscript access on Page Template ``macros`` attribute
+  (`#210 <https://github.com/zopefoundation/Zope/issues/210>`_)
+
 - Fix ``OFS.interfaces`` attribute declarations to match reality
   (`#498 <https://github.com/zopefoundation/Zope/issues/498`_)
 

--- a/src/Products/PageTemplates/engine.py
+++ b/src/Products/PageTemplates/engine.py
@@ -17,6 +17,7 @@ from Products.PageTemplates import ZRPythonExpr
 from chameleon.tales import StringExpr
 from chameleon.tales import NotExpr
 from chameleon.tal import RepeatDict
+from chameleon.zpt.template import Macros
 
 from z3c.pt.expressions import PythonExpr, ProviderExpr
 
@@ -32,6 +33,10 @@ RepeatDict.security.declareObjectPublic()
 RepeatDict.__allow_access_to_unprotected_subobjects__ = True
 
 InitializeClass(RepeatDict)
+
+# Declare Chameleon Macros object accessible
+# This makes subscripting work, as in template.macros['name']
+Macros.__allow_access_to_unprotected_subobjects__ = True
 
 re_match_pi = re.compile(r'<\?python([^\w].*?)\?>', re.DOTALL)
 logger = logging.getLogger('Products.PageTemplates')

--- a/src/Products/PageTemplates/tests/macros.pt
+++ b/src/Products/PageTemplates/tests/macros.pt
@@ -1,0 +1,1 @@
+<i metal:define-macro="foo">bar</i><i metal:use-macro="template/macros/foo" /><i metal:use-macro="python:template.macros['foo']" />

--- a/src/Products/PageTemplates/tests/test_engine.py
+++ b/src/Products/PageTemplates/tests/test_engine.py
@@ -85,6 +85,27 @@ class TestPatches(Sandboxed, ZopeTestCase):
         template.write(data)
         self.assertIn('world', template())
 
+    def test_macros_access(self):
+        from Products.PageTemplates.ZopePageTemplate import \
+            manage_addPageTemplate
+        from zExceptions import Unauthorized
+        template = manage_addPageTemplate(self.folder, 'test')
+
+        # aq-wrap before we proceed
+        template = template.__of__(self.folder)
+
+        # test rendering engine
+        with open(os.path.join(path, "macros.pt")) as fd:
+            data = fd.read()
+        template.write(data)
+        try:
+            output = template()
+            raised = False
+        except Unauthorized:
+            raised = True
+        self.assertFalse(raised, 'Unauthorized exception raised')
+        self.assertIn('<i>bar</i><i>bar</i><i>bar</i>', output)
+
 
 def test_suite():
     return unittest.TestSuite((


### PR DESCRIPTION
Fixes #210 

Under Zope 2.13, the `macros` attribute on a page template is a dictionary. The security machinery didn't care about it. With Chameleon, it is a real object.

`__allow_access_to_unprotected_subobjects__` is a bit of a sledge hammer here, but I can't see any way of getting to such a `macros` object without hitting all necessary security checks before you even get close. Attempts to install a `ClassSecurityInfo` on the class and declaring e.g. `__getitem__` public didn't work.