### PR TITLE
Make sure the WSGI Response object respects lock semantics

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,11 @@ Fixes
 - Fix error when not selecting a file for upload in Files and Images
   (`#492 <https://github.com/zopefoundation/Zope/issues/492>`_)
 
+Other changes
++++++++++++++
+- Make sure the WSGI Response object respects lock semantics
+  (`#216 <https://github.com/zopefoundation/Zope/issues/216>`_)
+
 
 4.0b9 (2019-02-09)
 ------------------

--- a/src/ZPublisher/HTTPResponse.py
+++ b/src/ZPublisher/HTTPResponse.py
@@ -1065,6 +1065,10 @@ class WSGIResponse(HTTPBaseResponse):
         self.stdout.write(data)
 
     def setBody(self, body, title='', is_error=False, lock=None):
+        # allow locking of the body in the same way as the status
+        if self._locked_body:
+            return
+
         if isinstance(body, IOBase):
             body.seek(0, 2)
             length = body.tell()
@@ -1080,6 +1084,11 @@ class WSGIResponse(HTTPBaseResponse):
             super(WSGIResponse, self).setBody(b'', title, is_error)
         else:
             super(WSGIResponse, self).setBody(body, title, is_error)
+
+        # Have to apply the lock at the end in case the super class setBody
+        # is called, which will observe the lock and do nothing
+        if lock:
+            self._locked_body = 1
 
     def __bytes__(self):
         raise NotImplementedError

--- a/src/ZPublisher/tests/test_WSGIPublisher.py
+++ b/src/ZPublisher/tests/test_WSGIPublisher.py
@@ -152,6 +152,13 @@ class WSGIResponseTests(unittest.TestCase):
         self.assertEqual(response.getHeader('Content-Length'),
                          '%d' % len(TestStreamIterator.data))
 
+    def test_setBody_w_locking(self):
+        response = self._makeOne()
+        response.setBody(b'BEFORE', lock=True)
+        result = response.setBody(b'AFTER')
+        self.assertFalse(result)
+        self.assertEqual(response.body, b'BEFORE')
+
     def test___str___raises(self):
         response = self._makeOne()
         response.setBody('TESTING')


### PR DESCRIPTION
Fixes #216 
Expands #215 

I'm in favor of following the `HTTPResponse` behavior because IMHO there is no good reason for just discarding the lock semantics.