### PR TITLE
fix for #505: no special handling for single `filtered_meta_types` in…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,12 @@ Fixes
 - Fix error when not selecting a file for upload in Files and Images
   (`#492 <https://github.com/zopefoundation/Zope/issues/492>`_)
 
+- Fix ZMI add handling of ``len(filtered_meta_types()) == 1`` 
+  (`#505 <https://github.com/zopefoundation/Zope/issues/505>`_)
+
+- Fix ZMI add handling of ``addItemSelect`` form
+  (`#506 <https://github.com/zopefoundation/Zope/issues/506>`_)
+
 Other changes
 +++++++++++++
 - Make sure the WSGI Response object respects lock semantics

--- a/src/App/dtml/manage_navbar.dtml
+++ b/src/App/dtml/manage_navbar.dtml
@@ -31,6 +31,7 @@
 				<i class="fa fa-cog"></i> <span class="zmi-label">Control&nbsp;Panel</span>
 			</a>
 		</li>
+		<dtml-if "aq_explicit"><dtml-with "aq_explicit" only>
 		<dtml-if filtered_meta_types>
 			<li class="form-inline zmi-addItemSelect">
 				<form method="get" class="form-group">
@@ -41,16 +42,15 @@
 							title="Select type to add"
 							onchange="addItem( elm=this, base_url='<dtml-var "REQUEST.get('URL1','')">'); this.selectedIndex = 0;"
 							><option value="" selected="selected">Select type to add</option>
-							<dtml-if "_.len(filtered_meta_types) > 1"
 								><dtml-in filtered_meta_types mapping sort=name
 									><dtml-if action><option value="&dtml.html_quote-action;">&dtml-name;</option>
 									</dtml-if
 								></dtml-in
-							></dtml-if>
 						</select>
 				</form>
 			</li>
 		</dtml-if>
+		</dtml-with></dtml-if>
 	</ul>
 
 	<a href="manage_zmi_logout" title="Logout"

--- a/src/App/dtml/manage_navbar.dtml
+++ b/src/App/dtml/manage_navbar.dtml
@@ -31,7 +31,7 @@
 				<i class="fa fa-cog"></i> <span class="zmi-label">Control&nbsp;Panel</span>
 			</a>
 		</li>
-		<dtml-if "aq_explicit"><dtml-with "aq_explicit" only>
+		<dtml-if "aq_explicit"><dtml-if "hasattr(aq_explicit, 'filtered_meta_types')">
 		<dtml-if filtered_meta_types>
 			<li class="form-inline zmi-addItemSelect">
 				<form method="get" class="form-group">
@@ -50,7 +50,7 @@
 				</form>
 			</li>
 		</dtml-if>
-		</dtml-with></dtml-if>
+		</dtml-if></dtml-if>
 	</ul>
 
 	<a href="manage_zmi_logout" title="Logout"

--- a/src/zmi/styles/resources/zmi_base.js
+++ b/src/zmi/styles/resources/zmi_base.js
@@ -204,15 +204,15 @@ $(function() {
 	// [1] Showing some Menu Elements only on List Page as Active
     // List Page is assumed if the ZMI tabs contain a "manage_findForm"
     // on folders or a "manage_catalogFind" on ZCatalogs
-    if ($('.nav a[href="manage_findForm"]').length > 0 || $('.nav a[href="manage_catalogFind"]').length > 0) {
-		$('#addItemSelect').removeClass('disabled');
-		$('#addItemSelect').removeAttr('disabled');
-		$('#addItemSelect').attr( 'title', $('#addItemSelect').attr('data-title-active') );
-	} else {
-		$('#addItemSelect').addClass('disabled');
-		$('#addItemSelect').attr('disabled','disabled');
-		$('#addItemSelect').attr( 'title', $('#addItemSelect').attr('data-title-inactive') );
-	}
+//     if ($('.nav a[href="manage_findForm"]').length > 0 || $('.nav a[href="manage_catalogFind"]').length > 0) {
+// 		$('#addItemSelect').removeClass('disabled');
+// 		$('#addItemSelect').removeAttr('disabled');
+// 		$('#addItemSelect').attr( 'title', $('#addItemSelect').attr('data-title-active') );
+// 	} else {
+// 		$('#addItemSelect').addClass('disabled');
+// 		$('#addItemSelect').attr('disabled','disabled');
+// 		$('#addItemSelect').attr( 'title', $('#addItemSelect').attr('data-title-inactive') );
+// 	}
 	
 
 	if (!window.matchMedia || (window.matchMedia("(max-width: 767px)").matches)) {


### PR DESCRIPTION
… `App.dtml.manage_navbar.dtml`

fix for #506: generate the `addItemSelect` form only for a context with unacquired `filtered_meta_types`

The pull request fixes #505 by not special casing "len(filtered_meta_types) == 1".

The pull request fixes #506 by replacing the fragile recognition of a "List page" in `zmi:styles/resources/zmi_base.js` by generating the `addItemSelect` form only for contexts with unacquired `filter_meta_types`.