### PR TITLE
Removed references to separate ``Products.ZCTextIndex``

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,6 +44,9 @@ Other changes
 - Specify supported Python versions using ``python_requires`` in setup.py
   (`#481 <https://github.com/zopefoundation/Zope/issues/481>`_)
 
+- Removed references to separate ``Products.ZCTextIndex``
+  (`516 <https://github.com/zopefoundation/Zope/issues/516>`_)
+
 
 4.0b9 (2019-02-09)
 ------------------

--- a/constraints.txt
+++ b/constraints.txt
@@ -11,7 +11,6 @@ MultiMapping==4.1
 PasteDeploy==2.0.1
 Persistence==3.0b4
 Products.BTreeFolder2==4.1
-Products.ZCTextIndex==4.0.3
 Products.ZCatalog==4.3
 Record==3.5
 RestrictedPython==4.0b8

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -12,7 +12,6 @@ MultiMapping==4.1
 PasteDeploy==2.0.1
 Persistence==3.0b4
 Products.BTreeFolder2==4.1
-Products.ZCTextIndex==4.0.3
 Products.ZCatalog==4.3
 Record==3.5
 RestrictedPython==4.0b8

--- a/sources.cfg
+++ b/sources.cfg
@@ -24,7 +24,6 @@ Products.BTreeFolder2 = git ${remotes:github}/Products.BTreeFolder2 pushurl=${re
 Products.MailHost = git ${remotes:github}/Products.MailHost pushurl=${remotes:github_push}/Products.MailHost
 Products.PythonScripts = git ${remotes:github}/Products.PythonScripts pushurl=${remotes:github_push}/Products.PythonScripts
 Products.ZCatalog = git ${remotes:github}/Products.ZCatalog pushurl=${remotes:github_push}/Products.ZCatalog
-Products.ZCTextIndex = git ${remotes:github}/Products.ZCTextIndex pushurl=${remotes:github_push}/Products.ZCTextIndex
 Products.Sessions = git ${remotes:github}/Products.Sessions pushurl=${remotes:github_push}/Products.Sessions
 Products.TemporaryFolder = git ${remotes:github}/Products.TemporaryFolder pushurl=${remotes:github_push}/Products.TemporaryFolder
 Products.SiteErrorLog = git ${remotes:github}/Products.SiteErrorLog pushurl=${remotes:github_push}/Products.SiteErrorLog

--- a/versions-prod.cfg
+++ b/versions-prod.cfg
@@ -26,7 +26,6 @@ Persistence = 3.0b4
 persistent = 4.4.3
 Products.BTreeFolder2 = 4.1
 Products.ZCatalog = 4.3
-Products.ZCTextIndex = 4.0.3
 pytz = 2018.9
 Record = 3.5
 RestrictedPython = 4.0b8


### PR DESCRIPTION
Fixes #516

All tests still pass. Those remaining references were most likely an oversight after the merge into ZCatalog.