### PR TITLE
Prevent `ValueError: I/O operation on closed file.`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,12 @@ Features
   which are deprecated in Python 3.8.
   (`#476 <https://github.com/zopefoundation/Zope/pull/476>`_)
 
+Fixes
++++++
+
+- Prevent ``ValueError: I/O operation on closed file.`` when using
+  ``ZPublisher.HTTPRequest.FileUpload`` in Python 3.
+
 
 4.0b10 (2019-03-08)
 -------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,7 @@ Fixes
 
 - Prevent ``ValueError: I/O operation on closed file.`` when using
   ``ZPublisher.HTTPRequest.FileUpload`` in Python 3.
+  (`#527 <https://github.com/zopefoundation/Zope/pull/527>`_)
 
 
 4.0b10 (2019-03-08)

--- a/src/ZPublisher/HTTPRequest.py
+++ b/src/ZPublisher/HTTPRequest.py
@@ -1684,6 +1684,9 @@ class FileUpload(object):
         self.headers = aFieldStorage.headers
         self.filename = aFieldStorage.filename
         self.name = aFieldStorage.name
+        # Keep a reference to the field storage to prevent it from closing
+        # its file during garbage collection:
+        self.__field_storage = aFieldStorage
 
         # Add an assertion to the rfc822.Message object that implements
         # self.headers so that managed code can access them.


### PR DESCRIPTION
when using `ZPublisher.HTTPRequest.FileUpload` in Python 3.

This happened before because Python 3 seems to garbage collect objects earlier
than Python 2 and FieldStorage was no longer referenced after storing its file
on the `FileUpload` instance. But `FieldStorage` closed its file in its
`__del__` method.

Also see #141.