### PR TITLE
Drop some subsections.

### DIFF
--- a/docs/zdgbook/ObjectPublishing.rst
+++ b/docs/zdgbook/ObjectPublishing.rst
@@ -607,10 +607,6 @@ in Chapter 8, "Security".
 Calling the Published Object
 ----------------------------
 
-Now that we've covered how the publisher located the published object
-and what it does with the results of calling it, let's take a closer
-look at how the published object is called.
-
 The publisher marshals arguments from the request and automatically
 makes them available to the published object. This allows you to
 accept parameters from web forms without having to parse the

--- a/docs/zdgbook/ObjectPublishing.rst
+++ b/docs/zdgbook/ObjectPublishing.rst
@@ -604,30 +604,6 @@ Finally, traversal security can be circumvented with the
 in Chapter 8, "Security".
 
 
-Publishable Module
-------------------
-
-If you are using the Zope framework, this section will be irrelevant
-to you. However, if you are publishing your own modules with
-'ZPublisher' read on.
-
-The publisher begins the traversal process by locating an object in
-the module's global namespace that corresponds to the first element of
-the path. Alternately the first object can be located by one of two
-hooks.
-
-If the module defines a 'web_objects' or 'bobo_application' object,
-the first object is searched for in those objects. The search happens
-according to the normal rules of traversal, using '__bobo_traverse__',
-'getattr', and '__getitem__'.
-
-The module can receive callbacks before and after traversal. If the
-module defines a '__bobo_before__' object, it will be called with no
-arguments before traversal. Its return value is ignored. Likewise,
-if the module defines a '__bobo_after__' object, it will be called
-after traversal with no arguments. These callbacks can be used for
-things like acquiring and releasing locks.
-
 Calling the Published Object
 ----------------------------
 

--- a/docs/zdgbook/ObjectPublishing.rst
+++ b/docs/zdgbook/ObjectPublishing.rst
@@ -604,13 +604,6 @@ Finally, traversal security can be circumvented with the
 in Chapter 8, "Security".
 
 
-Testing
--------
-
-ZPublisher comes with built-in support for testing and working with
-the Python debugger. This topic is covered in more detail in Chapter
-7, "Testing and Debugging".
-
 Publishable Module
 ------------------
 


### PR DESCRIPTION
... as they offer no relevant information.

    Drop subsection testing.
    
    As there is no information about the mentioned "builtin support" for
    testing.
    
    A link to the testing section is already in the table of contents.


    Drop subsection "Publishable Module".
    
    The introductory sentence says it all: "If you are using the Zope
    framework, this section will be irrelevant to you."
    
    Also see discussion about "ZPublisher for Zope vs own module", see
    https://github.com/zopefoundation/Zope/pull/546#issuecomment-482854693

