### PR TITLE
[Do not merge] Fix converter basics

### DIFF
--- a/src/ZPublisher/Converters.py
+++ b/src/ZPublisher/Converters.py
@@ -31,9 +31,12 @@ default_encoding = 'utf-8'
 
 
 def field2string(v):
-    """Converts value to native strings.
+    """Converts a value into a native string.
 
     So always to `str` no matter which Python version you are on.
+    That means:
+    - str / byte string for Python 2
+    - str / "unicode string" for Python 3
     """
     if hasattr(v, 'read'):
         return v.read()

--- a/src/ZPublisher/Converters.py
+++ b/src/ZPublisher/Converters.py
@@ -30,7 +30,7 @@ except ImportError:  # PY2
 default_encoding = 'utf-8'
 
 
-def field2string(v):
+def field2string(value):
     """Converts a value into a native string.
 
     So always to `str` no matter which Python version you are on.
@@ -38,14 +38,14 @@ def field2string(v):
     - str / byte string for Python 2
     - str / "unicode string" for Python 3
     """
-    if hasattr(v, 'read'):
-        return v.read()
-    elif six.PY2 and isinstance(v, text_type):
-        return v.encode(default_encoding)
-    elif six.PY3 and isinstance(v, binary_type):
-        return v.decode(default_encoding)
+    if hasattr(value, 'read'):
+        return value.read()
+    elif six.PY2 and isinstance(value, text_type):
+        return value.encode(default_encoding)
+    elif six.PY3 and isinstance(value, binary_type):
+        return value.decode(default_encoding)
     else:
-        return str(v)
+        return str(value)
 
 
 def field2bytes(v):

--- a/src/ZPublisher/Converters.py
+++ b/src/ZPublisher/Converters.py
@@ -48,19 +48,19 @@ def field2string(value):
         return str(value)
 
 
-def field2bytes(v):
+def field2bytes(value):
     """Converts a value into bytes.
 
     That means:
     - str / byte string for Python 2
     - bytes for Python 3
     """
-    if hasattr(v, 'read'):
-        v = v.read()
-    if isinstance(v, text_type):
-        return v.encode(default_encoding)
+    if hasattr(value, 'read'):
+        value = value.read()
+    if isinstance(value, text_type):
+        return value.encode(default_encoding)
     else:
-        return v
+        return value
 
 
 def field2text(value, nl=re.compile('\r\n|\n\r').search):

--- a/src/ZPublisher/Converters.py
+++ b/src/ZPublisher/Converters.py
@@ -56,11 +56,11 @@ def field2bytes(v):
     - bytes for Python 3
     """
     if hasattr(v, 'read'):
-        return v.read()
-    elif isinstance(v, text_type):
+        v = v.read()
+    if isinstance(v, text_type):
         return v.encode(default_encoding)
     else:
-        return bytes(v)
+        return v
 
 
 def field2text(value, nl=re.compile('\r\n|\n\r').search):

--- a/src/ZPublisher/Converters.py
+++ b/src/ZPublisher/Converters.py
@@ -49,7 +49,12 @@ def field2string(value):
 
 
 def field2bytes(v):
-    # Converts value to bytes.
+    """Converts a value into bytes.
+
+    That means:
+    - str / byte string for Python 2
+    - bytes for Python 3
+    """
     if hasattr(v, 'read'):
         return v.read()
     elif isinstance(v, text_type):

--- a/src/ZPublisher/Converters.py
+++ b/src/ZPublisher/Converters.py
@@ -59,8 +59,7 @@ def field2bytes(value):
         value = value.read()
     if isinstance(value, text_type):
         return value.encode(default_encoding)
-    else:
-        return value
+    return value
 
 
 def field2text(value, nl=re.compile('\r\n|\n\r').search):

--- a/src/ZPublisher/tests/test_Converters.py
+++ b/src/ZPublisher/tests/test_Converters.py
@@ -155,12 +155,20 @@ class ConvertersTests(unittest.TestCase):
 
     def test_field2string_with_filelike_object(self):
         from ZPublisher.Converters import field2string
-        to_convert = 'to_convert'
 
         class Filelike(object):
-            def read(self):
-                return to_convert
-        self.assertEqual(field2string(Filelike()), to_convert)
+            @staticmethod
+            def read():
+                if PY2:
+                    return b"to_convert"
+                if PY3:
+                    return "to_convert"
+        if PY2:
+            expected = b'to_convert'
+            self.assertEqual(field2string(Filelike()), expected)
+        if PY3:
+            expected = 'to_convert'
+            self.assertEqual(field2string(Filelike()), expected)
 
     def test_field2bytes_with_bytes(self):
         from ZPublisher.Converters import field2bytes

--- a/src/ZPublisher/tests/test_Converters.py
+++ b/src/ZPublisher/tests/test_Converters.py
@@ -181,6 +181,19 @@ class ConvertersTests(unittest.TestCase):
         expected = b'to_convert'
         self.assertEqual(field2bytes(to_convert), expected)
 
+    def test_field2bytes_with_filelike_object(self):
+        from ZPublisher.Converters import field2bytes
+
+        class Filelike(object):
+            @staticmethod
+            def read():
+                if PY2:
+                    return b'to_convert'
+                if PY3:
+                    return 'to_convert'
+        expected = b'to_convert'
+        self.assertEqual(field2bytes(Filelike()), expected)
+
     def test_field2date_international_with_proper_date_string(self):
         from ZPublisher.Converters import field2date_international
         to_convert = "2.1.2019"


### PR DESCRIPTION
Most of the converters rely on field2string and field2bytes.

field2bytes was broken for Python 3 and file-like input.

This has been fixed and a test has been added to prevent regression.

Also, the docstrings has been improved.

This is the first pull request for #558