### PR TITLE
ZMI usability: ZMI root link, monotonized tab interface controls

### DIFF
--- a/src/App/dtml/manage_navbar.dtml
+++ b/src/App/dtml/manage_navbar.dtml
@@ -9,7 +9,7 @@
        aria-label="Toggle Tab-Navigation">
     <i class="fa fa-bars"></i>
   </div>
-  <a class="navbar-brand" href="http://www.zope.org" target="_blank">
+  <a class="navbar-brand" title="To Zope Root" href="/manage" target="_parent">
     <span class="product">ZOPE 4.0</span>
   </a>
   <ul class="navbar-nav flex-row ml-sm-auto d-flex">

--- a/src/App/dtml/menu.dtml
+++ b/src/App/dtml/menu.dtml
@@ -28,9 +28,11 @@
 			href="/Control_Panel/Database/main/manage_UndoForm" target="manage_main">Undo</a></li>
 
 		<li><a id="menu_logout" href="manage_zmi_logout">Logout</a></li>
-		<li role="separator" class="divider"></li>
+		<li role="separator" class="divider">&nbsp;</li>
 		<li><a id="menu_copyright" href="zope_copyright"
 			target="manage_main">&copy; Zope Foundation</a></li>
+		<li><a id="menu_zope" href="http://www.zope.org"
+			target="_blank">www.zope.org</a></li>
 	</ul>
 </div>
 

--- a/src/Products/Five/utilities/browser/edit_markers.pt
+++ b/src/Products/Five/utilities/browser/edit_markers.pt
@@ -12,9 +12,7 @@
       Change the behavior of this object by adding or removing marker
       interfaces. You can choose one or more interfaces to be added to the
       list of provided interfaces for this object.
-    </p>
-    
-    <p class="form-help formHelp" i18n:translate="">
+      <br />
       A marker interface is used to identify an instance of a piece of
       content. This allows you to enable and disable views based on marker
       interfaces for example.
@@ -65,15 +63,11 @@
           <td class="zmi-object-id"
               tal:content="interface/name">Interface Name</td>
         </tr>
-        <tr tal:condition="view/getAvailableInterfaceNames">
-          <td class="zmi-object-check text-right">&nbsp;</td>
-          <td class="zmi-controls">
+      </table>
+      <div class="zmi-controls form-group form-inline" tal:condition="view/getAvailableInterfaceNames">
             <input class="btn btn-primary" type="submit" name="SAVE"
                    value="Add" i18n:attributes="value"/>
-          </td>
-        </tr>
-      </table>
-
+      </div>
     </form>
   </metal:macro>
 </metal:slot>

--- a/src/zmi/styles/resources/zmi_base.css
+++ b/src/zmi/styles/resources/zmi_base.css
@@ -272,9 +272,10 @@ form.zmi-upload {
   }
 }
 @media (min-width: 960px) {
-   .zmi form#objectItems .zmi-controls > .input-group input.btn {
-    min-width:7rem;
-   }
+	.zmi.zmi-manage_interfaces .zmi-controls > input.btn
+	.zmi form#objectItems .zmi-controls > .input-group input.btn {
+		min-width:7rem;
+	}
 }
 
 /* Table Object-Items: Sorting Links*/

--- a/src/zmi/styles/resources/zmi_base.css
+++ b/src/zmi/styles/resources/zmi_base.css
@@ -272,7 +272,7 @@ form.zmi-upload {
   }
 }
 @media (min-width: 960px) {
-	.zmi.zmi-manage_interfaces .zmi-controls > input.btn
+	.zmi.zmi-manage_interfaces .zmi-controls > input.btn,
 	.zmi form#objectItems .zmi-controls > .input-group input.btn {
 		min-width:7rem;
 	}


### PR DESCRIPTION
Hi @dataflake, 
referring to #548 now the root link is added and zope.org link shifted into the sitemap popup. Moreover for #572 the control button spacing is monotonized. Both shown in the following screen image:

![manage_interface](https://user-images.githubusercontent.com/29705216/57110255-29e54c00-6d38-11e9-8066-2e470deff5d7.png)



