### PR TITLE
Extend zope-ecosystem.cfg by Products.ExternalMethod.

### DIFF
--- a/zope-ecosystem.cfg
+++ b/zope-ecosystem.cfg
@@ -13,6 +13,7 @@ allow-picked-versions = true
 show-picked-versions = true
 additional_packages =
     Products.CMFCore
+    Products.ExternalMethod
     Products.MailHost
     Products.PythonScripts
     Products.Sessions


### PR DESCRIPTION
... as opposed to PythonScripts, with ExternalMethod it is also possible
to set a breakpoint, raise exceptions or - more general - use not only
a restricted set of Python syntax.

This make debugging and setting up special cases, e.g. to validate
Zope behaviour for the documenation overhaul much easier.