### PR TITLE
Optionally control internal xmlrpc use

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,13 @@ https://github.com/zopefoundation/Zope/blob/4.0a6/CHANGES.rst
 4.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+Features
+++++++++
+
+- Optionally control the use of Zope's built-in XML-RPC support for
+  POST requests with Content-Type ``text/xml`` via the
+  registration of a ``ZPublisher.interfaces.IXmlrpcChecker` utility
+  (`#620 <https://github.com/zopefoundation/Zope/issues/620>`_).
 
 
 4.0 (2019-05-10)

--- a/src/ZPublisher/interfaces.py
+++ b/src/ZPublisher/interfaces.py
@@ -83,7 +83,7 @@ class UseTraversalDefault(Exception):
 # XML-RPC control
 
 class IXmlrpcChecker(Interface):
-    """Utility interface controlling the use of Zope's built-in XML-RPC support."""
+    """Utility interface to control Zope's built-in XML-RPC support."""
     def __call__(request):
         """return true, when Zope's internal XML-RPC support should be used.
 

--- a/src/ZPublisher/interfaces.py
+++ b/src/ZPublisher/interfaces.py
@@ -77,3 +77,24 @@ class UseTraversalDefault(Exception):
     indicate that it has no special casing for the given name and that standard
     traversal logic should be applied.
     """
+
+
+###############################################################################
+# XML-RPC control
+
+class IXmlrpcChecker(Interface):
+    """Utility interface controlling the use of Zope's built-in XML-RPC support."""
+    def __call__(request):
+        """return true, when Zope's internal XML-RPC support should be used.
+
+        Only called for a non-SOAP POST request whose `Content-Type`
+        contains `text/xml` (any other request automatically does not
+        use Zope's buildin XML-RPC).
+
+        Note: this is called very early during request handling when most
+        typical attributes of *request* are not yet set up -- e.g. it
+        cannot rely on information in `form` or `other`.
+        Usually, it will look up information in `request.environ`
+        which at this time is garanteed (only) to contain the
+        typical CGI information, such as `PATH_INFO` and `QUERY_STRING`.
+        """

--- a/src/ZPublisher/tests/testHTTPRequest.py
+++ b/src/ZPublisher/tests/testHTTPRequest.py
@@ -13,8 +13,8 @@
 
 import sys
 import unittest
-from io import BytesIO
 from contextlib import contextmanager
+from io import BytesIO
 
 from six import PY2
 
@@ -1217,7 +1217,6 @@ class HTTPRequestTests(unittest.TestCase, HTTPRequestFactoryMixin):
         self.assertNotIn('secret', req.text())
         self.assertIn('password obscured', req.text())
 
-
     _xmlrpc_call = b"""<?xml version="1.0"?>
     <methodCall>
       <methodName>examples.getStateName</methodName>
@@ -1228,8 +1227,8 @@ class HTTPRequestTests(unittest.TestCase, HTTPRequestFactoryMixin):
          </params>
       </methodCall>
     """
-    
-    def test_processInputs_xmlrpc(self):
+
+    def test_processInputs_xmlrpc_with_args(self):
         req = self._makeOne(
             stdin=BytesIO(self._xmlrpc_call),
             environ=dict(REQUEST_METHOD="POST", CONTENT_TYPE="text/xml"))

--- a/src/ZPublisher/tests/testHTTPRequest.py
+++ b/src/ZPublisher/tests/testHTTPRequest.py
@@ -14,11 +14,13 @@
 import sys
 import unittest
 from io import BytesIO
+from contextlib import contextmanager
 
 from six import PY2
 
 from AccessControl.tainted import should_be_tainted
 from zExceptions import NotFound
+from zope.component import getGlobalSiteManager
 from zope.component import provideAdapter
 from zope.i18n.interfaces import IUserPreferredLanguages
 from zope.i18n.interfaces.locales import ILocale
@@ -26,8 +28,10 @@ from zope.publisher.browser import BrowserLanguages
 from zope.publisher.interfaces.http import IHTTPRequest
 from zope.testing.cleanup import cleanUp
 from ZPublisher.HTTPRequest import search_type
+from ZPublisher.interfaces import IXmlrpcChecker
 from ZPublisher.tests.testBaseRequest import TestRequestViewsBase
 from ZPublisher.utils import basic_auth_encode
+from ZPublisher.xmlrpc import is_xmlrpc_response
 
 
 if sys.version_info >= (3, ):
@@ -1212,6 +1216,49 @@ class HTTPRequestTests(unittest.TestCase, HTTPRequestFactoryMixin):
 
         self.assertNotIn('secret', req.text())
         self.assertIn('password obscured', req.text())
+
+
+    _xmlrpc_call = b"""<?xml version="1.0"?>
+    <methodCall>
+      <methodName>examples.getStateName</methodName>
+      <params>
+         <param>
+            <value><i4>41</i4></value>
+            </param>
+         </params>
+      </methodCall>
+    """
+    
+    def test_processInputs_xmlrpc(self):
+        req = self._makeOne(
+            stdin=BytesIO(self._xmlrpc_call),
+            environ=dict(REQUEST_METHOD="POST", CONTENT_TYPE="text/xml"))
+        req.processInputs()
+        self.assertTrue(is_xmlrpc_response(req.response))
+        self.assertEqual(req.args, (41,))
+        self.assertEqual(req.other["PATH_INFO"], "/examples/getStateName")
+
+    def test_processInputs_xmlrpc_controlled_allowed(self):
+        req = self._makeOne(
+            stdin=BytesIO(self._xmlrpc_call),
+            environ=dict(REQUEST_METHOD="POST", CONTENT_TYPE="text/xml"))
+        with self._xmlrpc_control(lambda request: True):
+            req.processInputs()
+        self.assertTrue(is_xmlrpc_response(req.response))
+
+    def test_processInputs_xmlrpc_controlled_disallowed(self):
+        req = self._makeOne(
+            environ=dict(REQUEST_METHOD="POST", CONTENT_TYPE="text/xml"))
+        with self._xmlrpc_control(lambda request: False):
+            req.processInputs()
+        self.assertFalse(is_xmlrpc_response(req.response))
+
+    @contextmanager
+    def _xmlrpc_control(self, allow):
+        gsm = getGlobalSiteManager()
+        gsm.registerUtility(allow, IXmlrpcChecker)
+        yield
+        gsm.unregisterUtility(allow, IXmlrpcChecker)
 
 
 class TestHTTPRequestZope3Views(TestRequestViewsBase):


### PR DESCRIPTION
This PR addresses #620.
It allows to control the use of Zope's internal XML-RPC for POST requests with Content-Type `text/xml` via the registration of a `ZPublisher.interfaces.IXmlrpcChecker` utility. If such a utility is registered, it is called for those candidate requests to decide whether or not this should really be handled via the internal XML-RPC support. Nothing changes, if no such utility is registered.