### PR TITLE
Bring request lookup order related documentation in line with the act…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,11 @@ Fixes
 - Fixed logic error in exceptions handling during publishing. This error would
   prevent correct Unauthorized handling when exceptions debug mode was set.
 
+- Bring request lookup order related documentation in line with the
+  actual implementation
+  (`#629 <https://github.com/zopefoundation/Zope/issues/629>`_).
+  Minor cleanup of ``HTTPRequest.get``.
+
 
 4.0 (2019-05-10)
 ----------------

--- a/docs/zopebook/AdvDTML.rst
+++ b/docs/zopebook/AdvDTML.rst
@@ -260,22 +260,24 @@ of places for variables, so too the request looks up variables
 in a number of places. When the request looks for a variable it
 consults these sources in order:
 
-1. The CGI environment. The `Common Gateway Interface
+1. Variables explicitly set on the request.
+
+2. Special variables. The REQUEST namespace provides you
+   with special information, such as the URL of
+   the current object and all of its parents.
+
+3. The CGI environment. The `Common Gateway Interface
    <http://www.w3.org/CGI/>`_, or CGI interface defines
    a standard set of environment variables to be used by
    dynamic web scripts.  These variables are provided by Zope
    in the REQUEST namespace.
 
-2. Form data. If the current request is a form action, then
+4. Form data. If the current request is a form action, then
    any form input data that was submitted with the request can
    be found in the REQUEST object.
 
-3. Cookies. If the client of the current request has any cookies
+5. Cookies. If the client of the current request has any cookies
    these can be found in the current REQUEST object.
-
-4. Additional variables. The REQUEST namespace provides you
-   with lots of other useful information, such as the URL of
-   the current object and all of its parents.
 
 The request namespace is very useful in Zope since it is the
 primary way that clients (in this case, web browsers)

--- a/src/ZPublisher/HTTPRequest.py
+++ b/src/ZPublisher/HTTPRequest.py
@@ -1277,15 +1277,29 @@ class HTTPRequest(BaseRequest):
             ):
         """Get a variable value
 
-        Return a value for the required variable name.
-        The value will be looked up from one of the request data
-        categories. The search order is environment variables,
-        other variables, form data, and then cookies.
+        Return a value for the variable key, or default if not found.
+
+        If key is "REQUEST", return the request.
+        Otherwise, the value will be looked up from one of the request data
+        categories. The search order is:
+        other (the target for explicitly set variables),
+        the special URL and BASE variables,
+        environment variables,
+        common variables (defined by the request class),
+        lazy variables (set with set_lazy),
+        form data and cookies.
+
+        If returnTaints has a true value, then the access to
+        form and cookie variables returns values with special
+        protection against embedded HTML fragments to counter
+        some cross site scripting attacks.
         """
+
+        if key == 'REQUEST':
+            return self
+
         other = self.other
         if key in other:
-            if key == 'REQUEST':
-                return self
             return other[key]
 
         if key[:1] == 'U':
@@ -1312,9 +1326,6 @@ class HTTPRequest(BaseRequest):
             if key in environ and (key not in hide_key):
                 return environ[key]
             return ''
-
-        if key == 'REQUEST':
-            return self
 
         if key[:1] == 'B':
             match = BASEmatch(key)


### PR DESCRIPTION
…ual code (#629); minor refactorization/cleanup of `HTTPRequest.get`

The cleanup moves the (duplicated) special handling of the lookup of `REQUEST` to the top of `get` to match the new documentation.

There is still an apparent mismatch between documentation and code related to the order of URL/BASE and environment lookup - but this is apparent only as only CGI names and names starting with `HTTP_` are looked up in the environment and therefore, there is not overlap.