### PR TITLE
Do not cache (implicit) request access to form data or cookies

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,9 @@ Fixes
 - Fixed logic error in exceptions handling during publishing. This error would
   prevent correct Unauthorized handling when exceptions debug mode was set.
 
+- Do not cache (implicit) request access to form data and cookies in ``other``
+  (`#630 <https://github.com/zopefoundation/Zope/issues/630>`_).
+
 
 4.0 (2019-05-10)
 ----------------

--- a/src/ZPublisher/HTTPRequest.py
+++ b/src/ZPublisher/HTTPRequest.py
@@ -145,10 +145,8 @@ class HTTPRequest(BaseRequest):
       - Environment variables
 
         These variables include input headers, server data, and other
-        request-related data.  The variable names are as <a
-        href="http://hoohoo.ncsa.uiuc.edu/cgi/env.html">specified</a>
-        in the <a
-        href="http://hoohoo.ncsa.uiuc.edu/cgi/interface.html">CGI
+        request-related data.  The variable names are as specified
+        in the <a href="https://tools.ietf.org/html/rfc3875">CGI
         specification</a>
 
       - Form data

--- a/src/ZPublisher/HTTPRequest.py
+++ b/src/ZPublisher/HTTPRequest.py
@@ -1371,26 +1371,30 @@ class HTTPRequest(BaseRequest):
         if returnTaints:
             v = self.taintedform.get(key, _marker)
             if v is not _marker:
-                other[key] = v
+                # Issue 630
+                # other[key] = v
                 return v
 
         # Untrusted data *after* trusted data
         v = self.form.get(key, _marker)
         if v is not _marker:
-            other[key] = v
+            # Issue 630
+            # other[key] = v
             return v
 
         # Return tainted data first (marked as suspect)
         if returnTaints:
             v = self.taintedcookies.get(key, _marker)
             if v is not _marker:
-                other[key] = v
+                # Issue 630
+                # other[key] = v
                 return v
 
         # Untrusted data *after* trusted data
         v = self.cookies.get(key, _marker)
         if v is not _marker:
-            other[key] = v
+            # Issue 630
+            # other[key] = v
             return v
 
         return default

--- a/src/ZPublisher/HTTPRequest.py
+++ b/src/ZPublisher/HTTPRequest.py
@@ -1371,30 +1371,22 @@ class HTTPRequest(BaseRequest):
         if returnTaints:
             v = self.taintedform.get(key, _marker)
             if v is not _marker:
-                # Issue 630
-                # other[key] = v
                 return v
 
         # Untrusted data *after* trusted data
         v = self.form.get(key, _marker)
         if v is not _marker:
-            # Issue 630
-            # other[key] = v
             return v
 
         # Return tainted data first (marked as suspect)
         if returnTaints:
             v = self.taintedcookies.get(key, _marker)
             if v is not _marker:
-                # Issue 630
-                # other[key] = v
                 return v
 
         # Untrusted data *after* trusted data
         v = self.cookies.get(key, _marker)
         if v is not _marker:
-            # Issue 630
-            # other[key] = v
             return v
 
         return default


### PR DESCRIPTION
This PR fixes #630 by not caching the result of an implicit request lookup (in the form `request.get` or `request[...]` in contrast to `request.{form|cookies}{.get,[...]}`) in `other`.

There is a minor backward incompatibility affecting applications which might rely on finding form data/cookies in `other` after the first access.