### PR TITLE
Mark Zope Book as outdated.

### DIFF
--- a/docs/zopebook/Acquisition.rst
+++ b/docs/zopebook/Acquisition.rst
@@ -1,6 +1,8 @@
 Acquisition
 ###########
 
+.. include:: includes/zope2_notice.rst
+
 Acquisition is the technology that allows dynamic behavior to be
 shared between Zope objects via *containment*.
 

--- a/docs/zopebook/AdvDTML.rst
+++ b/docs/zopebook/AdvDTML.rst
@@ -1,6 +1,8 @@
 Advanced DTML
 =============
 
+.. include:: includes/zope2_notice.rst
+
 DTML is the kind of language that appears to "do what you mean."
 That is good when it does what you actually want it to do, but when
 it does something you don't want to do, well, it's no fun at all.

--- a/docs/zopebook/AdvZPT.rst
+++ b/docs/zopebook/AdvZPT.rst
@@ -1,6 +1,8 @@
 Advanced Page Templates
 =======================
 
+.. include:: includes/zope2_notice.rst
+
 In the chapter entitled `Using Zope Page Templates <ZPT.html>`_ you
 learned the basic features of Page Templates. In this chapter
 you'll learn about advanced techniques including new types of

--- a/docs/zopebook/AppendixA.rst
+++ b/docs/zopebook/AppendixA.rst
@@ -2,6 +2,8 @@
 Appendix A: DTML Reference
 ##########################
 
+.. include:: includes/zope2_notice.rst
+
 DTML is the *Document Template Markup Language*, a handy presentation and
 templating language that comes with Zope. This Appendix is a reference to all
 of DTMLs markup tags and how they work.

--- a/docs/zopebook/AppendixB.rst
+++ b/docs/zopebook/AppendixB.rst
@@ -1,6 +1,8 @@
 Appendix B: API Reference
 #########################
 
+.. include:: includes/zope2_notice.rst
+
 Introduction
 ============
 

--- a/docs/zopebook/AppendixC.rst
+++ b/docs/zopebook/AppendixC.rst
@@ -1,6 +1,8 @@
 Appendix C: Zope Page Templates Reference
 #########################################
 
+.. include:: includes/zope2_notice.rst
+
 Zope Page Templates are an HTML/XML generation tool. This appendix is a
 reference to Zope Page Templates standards: Template Attribute Language (TAL),
 TAL Expression Syntax (TALES), and Macro Expansion TAL (METAL). It also

--- a/docs/zopebook/AppendixD.rst
+++ b/docs/zopebook/AppendixD.rst
@@ -1,6 +1,8 @@
 Appendix D: Zope Resources
 ##########################
 
+.. include:: includes/zope2_notice.rst
+
 At the time of this writing there is a multitude of sources for Zope
 information on the Internet and in print. We've collected a number of the most
 important links which you can use to find out more about Zope.

--- a/docs/zopebook/AppendixE.rst
+++ b/docs/zopebook/AppendixE.rst
@@ -1,6 +1,8 @@
 Appendix E: DTML Name Lookup Rules
 ##################################
 
+.. include:: includes/zope2_notice.rst
+
 These are the rules which DTML uses to resolve names mentioned in `name=` and
 `expr=` tags. The rules are in order from first to last in the search path.
 

--- a/docs/zopebook/BasicObject.rst
+++ b/docs/zopebook/BasicObject.rst
@@ -1,6 +1,8 @@
 Using Basic Zope Objects
 ########################
 
+.. include:: includes/zope2_notice.rst
+
 When building a web application with Zope, you construct the application
 with *objects*.  The most fundamental Zope objects are explained in this
 chapter.

--- a/docs/zopebook/BasicScripting.rst
+++ b/docs/zopebook/BasicScripting.rst
@@ -1,6 +1,8 @@
 Basic Zope Scripting
 ####################
 
+.. include:: includes/zope2_notice.rst
+
 So far, you've learned about some basic Zope objects and how to manage them
 through the *Zope Management Interface*. This chapter shows you how to manage
 Zope objects programmatically.

--- a/docs/zopebook/Contributions.rst
+++ b/docs/zopebook/Contributions.rst
@@ -1,6 +1,8 @@
 Contributions
 =============
 
+.. include:: includes/zope2_notice.rst
+
 Contributors to this book include Amos Latteier, Michel Pelletier,
 Chris McDonough, Evan Simpson, Tom Deprez, Paul Everitt, Bakhtiar
 A. Hamid, Geir Baekholt, Thomas Reulbach, Paul Winkler, Peter Sabaini,

--- a/docs/zopebook/DTML.rst
+++ b/docs/zopebook/DTML.rst
@@ -1,6 +1,8 @@
 Basic DTML
 ==========
 
+.. include:: includes/zope2_notice.rst
+
 
 .. note::
     DTML has been the primary markup language within Zope for a long time.  However

--- a/docs/zopebook/ExternalTools.rst
+++ b/docs/zopebook/ExternalTools.rst
@@ -1,6 +1,8 @@
 Managing Zope Objects Using External Tools
 ##########################################
 
+.. include:: includes/zope2_notice.rst
+
 So far, you've been working with Zope objects in your web browser via the Zope
 Management Interface. This chapter details how to use common non-browser-based
 common to access and modify your Zope content.

--- a/docs/zopebook/InstallingZope.rst
+++ b/docs/zopebook/InstallingZope.rst
@@ -1,6 +1,8 @@
 Installing and Starting Zope
 ============================
 
+.. include:: includes/zope2_notice.rst
+
 By the end of this chapter, you should be able to install and start
 Zope.  It is fairly easy to install Zope on most platforms, and it
 typically takes no longer than ten minutes to complete an installation.

--- a/docs/zopebook/IntroducingZope.rst
+++ b/docs/zopebook/IntroducingZope.rst
@@ -1,6 +1,8 @@
 Introducing Zope
 ================
 
+.. include:: includes/zope2_notice.rst
+
 Zope is family of related Python packages focussed on web technologies. The
 first version of Zope has originated from a company called
 `Zope Corporation <http://www.zope.com/>`_.

--- a/docs/zopebook/MaintainingZope.rst
+++ b/docs/zopebook/MaintainingZope.rst
@@ -1,6 +1,8 @@
 Maintaining Zope
 ################
 
+.. include:: includes/zope2_notice.rst
+
 Keeping a Zope site running smoothly involves a number of administrative tasks.
 This chapter covers some of these tasks, such as:
 

--- a/docs/zopebook/ObjectOrientation.rst
+++ b/docs/zopebook/ObjectOrientation.rst
@@ -1,6 +1,8 @@
 Object Orientation
 ==================
 
+.. include:: includes/zope2_notice.rst
+
 To make the best use of Zope, you will need a grasp on the concept of *object
 orientation*, which is a software development pattern used in many programming
 languages (C++, Java, Python and others) and computer systems that simulate

--- a/docs/zopebook/Preface.rst
+++ b/docs/zopebook/Preface.rst
@@ -1,6 +1,8 @@
 Preface
 =======
 
+.. include:: includes/zope2_notice.rst
+
 Welcome to *The Zope Book*.  This book is designed to introduce you
 to ``Zope2``, an open-source web application server.
 

--- a/docs/zopebook/RelationalDatabases.rst
+++ b/docs/zopebook/RelationalDatabases.rst
@@ -1,6 +1,8 @@
 Relational Database Connectivity
 ================================
 
+.. include:: includes/zope2_notice.rst
+
 
 .. note::
 

--- a/docs/zopebook/ScriptingZope.rst
+++ b/docs/zopebook/ScriptingZope.rst
@@ -1,6 +1,8 @@
 Advanced Zope Scripting
 =======================
 
+.. include:: includes/zope2_notice.rst
+
 In the chapter entitled "Basic Zope Scripting", you have seen
 how to manage Zope objects programmatically.  In this chapter,
 we will explore this topic some more.  Subjects discussed

--- a/docs/zopebook/SearchingZCatalog.rst
+++ b/docs/zopebook/SearchingZCatalog.rst
@@ -1,6 +1,8 @@
 Searching and Categorizing Content
 ==================================
 
+.. include:: includes/zope2_notice.rst
+
 The ZCatalog is Zope's built in search engine. It allows you to
 categorize and search all kinds of Zope objects. You can also use it
 to search external data such as relational data, files, and remote

--- a/docs/zopebook/Security.rst
+++ b/docs/zopebook/Security.rst
@@ -1,6 +1,8 @@
 Users and Security
 ==================
 
+.. include:: includes/zope2_notice.rst
+
 Introduction to Zope Security
 -----------------------------
 

--- a/docs/zopebook/Sessions.rst
+++ b/docs/zopebook/Sessions.rst
@@ -1,6 +1,8 @@
 Session Management
 ##################
 
+.. include:: includes/zope2_notice.rst
+
 This chapter describes Zope's built-in Session Management.
 
 Terminology

--- a/docs/zopebook/SimpleExamples.rst
+++ b/docs/zopebook/SimpleExamples.rst
@@ -1,6 +1,8 @@
 Creating Basic Zope Applications
 ================================
 
+.. include:: includes/zope2_notice.rst
+
 .. todo:
    
    - add new screen shots

--- a/docs/zopebook/UsingZope.rst
+++ b/docs/zopebook/UsingZope.rst
@@ -1,6 +1,8 @@
 Using the Zope Management Interface
 ===================================
 
+.. include:: includes/zope2_notice.rst
+
 Introduction
 ------------
 

--- a/docs/zopebook/VirtualHosting.rst
+++ b/docs/zopebook/VirtualHosting.rst
@@ -1,6 +1,8 @@
 Virtual Hosting Services
 ========================
 
+.. include:: includes/zope2_notice.rst
+
 Zope comes with one object that help you do virtual hosting:
 *Virtual Host Monster*. Virtual hosting is a way to
 serve many websites with one Zope server.

--- a/docs/zopebook/ZEO.rst
+++ b/docs/zopebook/ZEO.rst
@@ -1,6 +1,8 @@
 Scalability and ZEO
 ###################
 
+.. include:: includes/zope2_notice.rst
+
 When a web application receives more requests than it can handle over a short
 period of time, it can become unresponsive. In the worst case, too many
 concurrent requests to a web application can cause the software which services

--- a/docs/zopebook/ZPT.rst
+++ b/docs/zopebook/ZPT.rst
@@ -1,6 +1,8 @@
 Using Zope Page Templates
 =========================
 
+.. include:: includes/zope2_notice.rst
+
 *Page Templates* are a web page generation tool.  They help programmers and
 designers collaborate in producing dynamic web pages for Zope web
 applications.  Designers can use them to maintain pages without having to

--- a/docs/zopebook/ZopeArchitecture.rst
+++ b/docs/zopebook/ZopeArchitecture.rst
@@ -2,6 +2,8 @@
 Zope Concepts and Architecture
 ##############################
 
+.. include:: includes/zope2_notice.rst
+
 Fundamental Zope Concepts
 =========================
 

--- a/docs/zopebook/ZopeServices.rst
+++ b/docs/zopebook/ZopeServices.rst
@@ -1,6 +1,8 @@
 Zope Services
 =============
 
+.. include:: includes/zope2_notice.rst
+
 Some Zope objects are *service* objects.  *Service* objects provide
 various kinds of support to your "domain-specific" content, logic,
 and presentation objects.  They help solve fundamental problems that

--- a/docs/zopebook/includes/zope2_notice.rst
+++ b/docs/zopebook/includes/zope2_notice.rst
@@ -1,0 +1,3 @@
+.. attention::
+
+  This document was written for Zope 2.

--- a/docs/zopebook/index.rst
+++ b/docs/zopebook/index.rst
@@ -1,6 +1,8 @@
 The Zope Book
 =============
 
+.. include:: includes/zope2_notice.rst
+
 Welcome to *The Zope Book*.  This book is designed to introduce you
 to `Zope`, an open-source web application server.
 


### PR DESCRIPTION
The "Zope Book" is based on Zope 2 and has to be updated to Zope 4.

This will take a very long time.

In the mean time at least a hint is shown, that the book refers to
Zope 2.

cf https://github.com/zopefoundation/Zope/issues/671