### PR TITLE
Revive the removed History tab

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ https://github.com/zopefoundation/Zope/blob/4.0a6/CHANGES.rst
 
 - Update to current releases of the dependencies.
 
+- Resurrect History ZMI tab and functionality
+
 
 4.1.1 (2019-07-02)
 ------------------

--- a/src/OFS/History.py
+++ b/src/OFS/History.py
@@ -1,0 +1,266 @@
+##############################################################################
+#
+# Copyright (c) 2002 Zope Foundation and Contributors.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE
+#
+##############################################################################
+"""Object Histories
+"""
+
+try:
+    from html import escape
+except ImportError:
+    from cgi import escape
+import difflib
+from struct import pack
+from struct import unpack
+
+from AccessControl.class_init import InitializeClass
+from AccessControl.SecurityInfo import ClassSecurityInfo
+from Acquisition import Implicit
+from Acquisition import aq_base
+from App.special_dtml import DTMLFile
+from DateTime.DateTime import DateTime
+from ExtensionClass import Base
+from zExceptions import Redirect
+
+
+view_history = 'View History'
+
+
+class TemporalParadox(Exception):
+    pass
+
+
+class HistorySelectionError(Exception):
+    pass
+
+
+class HystoryJar:
+    """A ZODB Connection-like object that provides access to data
+    but prevents history from being changed."""
+
+    def __init__(self, base):
+        self.__base__ = base
+
+    def __getattr__(self, name):
+        return getattr(self.__base__, name)
+
+    def commit(self, object, transaction):
+        if object._p_changed:
+            raise TemporalParadox("You can't change history!")
+
+    def abort(*args, **kw):
+        pass
+
+    tpc_begin = tpc_finish = abort
+
+
+def historicalRevision(self, serial):
+    state = self._p_jar.oldstate(self, serial)
+    rev = self.__class__.__basicnew__()
+    rev._p_jar = HystoryJar(self._p_jar)
+    rev._p_oid = self._p_oid
+    rev._p_serial = serial
+    rev.__setstate__(state)
+    rev._p_changed = 0
+    return rev
+
+
+class Historian(Implicit):
+    """An Historian's job is to find hysterical revisions of
+    objects, given a time."""
+
+    def __getitem__(self, key):
+        self = self.aq_parent
+
+        serial = pack(*('>HHHH',) + tuple(map(int, key.split('.'))))
+
+        if serial == self._p_serial:
+            return self
+
+        rev = historicalRevision(self, serial)
+
+        return rev.__of__(self.aq_parent)
+
+    def manage_workspace(self, REQUEST):
+        """ We aren't real, so we delegate to that that spawned us! """
+        raise Redirect('/%s/manage_change_history_page' % REQUEST['URL2'])
+
+
+class Historical(Base):
+    """Mix-in class to provide a veiw that shows hystorical changes
+    The display is similar to that used for undo, except that the transactions
+    are limited to those that effect the displayed object and that the
+    interface doesn't provide an undo capability.
+    This interface is generally *only* interesting for objects, such
+    as methods, and documents, that are self-contained, meaning that
+    they don't have persistent sub-objects.
+    """
+    security = ClassSecurityInfo()
+    HistoricalRevisions = Historian()
+
+    manage_options = (
+        {'label': 'History', 'action': 'manage_change_history_page'},
+    )
+
+    security.declareProtected(view_history,  # NOQA: D001
+                              'manage_change_history_page')
+
+    manage_change_history_page = DTMLFile(
+        'dtml/history', globals(),
+        HistoryBatchSize=20,
+        first_transaction=0, last_transaction=20)
+
+    @security.protected(view_history)
+    def manage_change_history(self):
+        first = 0
+        last = 20
+        request = getattr(self, 'REQUEST', None)
+        if request is not None:
+            first = request.get('first_transaction', first)
+            last = request.get('last_transaction', last)
+
+        r = self._p_jar.db().history(self._p_oid, size=last)
+        if r is None:
+            # storage doesn't support history
+            return ()
+        r = r[first:]
+
+        for d in r:
+            d['time'] = DateTime(d['time'])
+            d['key'] = '.'.join(map(str, unpack('>HHHH', d['tid'])))
+
+        return r
+
+    def manage_beforeHistoryCopy(self):
+        pass
+
+    def manage_historyCopy(self, keys=[], RESPONSE=None, URL1=None):
+        """ Copy a selected revision to the present """
+        if not keys:
+            raise HistorySelectionError('No historical revision selected.')
+
+        if len(keys) > 1:
+            raise HistorySelectionError(
+                'Only one historical revision can be copied to the present.')
+
+        key = keys[0]
+        serial = pack(*('>HHHH',) + tuple(map(int, key.split('.'))))
+
+        if serial != self._p_serial:
+            self.manage_beforeHistoryCopy()
+            state = self._p_jar.oldstate(self, serial)
+            base = aq_base(self)
+            base._p_activate()  # make sure we're not a ghost
+            base.__setstate__(state)  # change the state
+            base._p_changed = True  # marke object as dirty
+            self.manage_afterHistoryCopy()
+
+        if RESPONSE is not None and URL1 is not None:
+            RESPONSE.redirect('%s/manage_workspace' % URL1)
+
+    def manage_afterHistoryCopy(self):
+        pass
+
+    _manage_historyComparePage = DTMLFile(
+        'dtml/historyCompare', globals(), management_view='History')
+
+    @security.protected(view_history)
+    def manage_historyCompare(self, rev1, rev2, REQUEST,
+                              historyComparisonResults=''):
+        dt1 = DateTime(rev1._p_mtime)
+        dt2 = DateTime(rev2._p_mtime)
+        return self._manage_historyComparePage(
+            self, REQUEST,
+            dt1=dt1, dt2=dt2,
+            historyComparisonResults=historyComparisonResults)
+
+    @security.protected(view_history)
+    def manage_historicalComparison(self, REQUEST, keys=[]):
+        """ Compare two selected revisions """
+        if not keys:
+            raise HistorySelectionError('No historical revision selected.')
+        if len(keys) > 2:
+            raise HistorySelectionError(
+                'Only two historical revision can be compared.')
+
+        serial = pack(*('>HHHH',) + tuple(map(int, keys[-1].split('.'))))
+        rev1 = historicalRevision(self, serial)
+
+        if len(keys) == 2:
+            serial = pack(*('>HHHH',) + tuple(map(int, keys[0].split('.'))))
+            rev2 = historicalRevision(self, serial)
+        else:
+            rev2 = self
+
+        return self.manage_historyCompare(rev1, rev2, REQUEST)
+
+
+InitializeClass(Historical)
+
+
+def dump(tag, x, lo, hi, r):
+    r1 = []
+    r2 = []
+    for i in range(lo, hi):
+        r1.append(tag)
+        r2.append(x[i])
+
+    r.append('<tr>\n'
+             '<td><pre>\n%s\n</pre></td>\n'
+             '<td><pre>\n%s\n</pre></td>\n'
+             '</tr>\n'
+             % ('\n'.join(r1), escape('\n'.join(r2))))
+
+
+def replace(x, xlo, xhi, y, ylo, yhi, r):
+
+    rx1 = []
+    rx2 = []
+    for i in range(xlo, xhi):
+        rx1.append('-')
+        rx2.append(x[i])
+
+    ry1 = []
+    ry2 = []
+    for i in range(ylo, yhi):
+        ry1.append('+')
+        ry2.append(y[i])
+
+    r.append('<tr>\n'
+             '<td><pre>\n%s\n%s\n</pre></td>\n'
+             '<td><pre>\n%s\n%s\n</pre></td>\n'
+             '</tr>\n'
+             % ('\n'.join(rx1), '\n'.join(ry1),
+                escape('\n'.join(rx2)), escape('\n'.join(ry2))))
+
+
+def html_diff(s1, s2):
+    a = s1.split('\n')
+    b = s2.split('\n')
+    cruncher = difflib.SequenceMatcher()
+    cruncher.set_seqs(a, b)
+    r = ['<table border=1>']
+
+    for tag, alo, ahi, blo, bhi in cruncher.get_opcodes():
+        if tag == 'replace':
+            replace(a, alo, ahi, b, blo, bhi, r)
+        elif tag == 'delete':
+            dump('-', a, alo, ahi, r)
+        elif tag == 'insert':
+            dump('+', b, blo, bhi, r)
+        elif tag == 'equal':
+            dump(' ', a, alo, ahi, r)
+        else:
+            raise ValueError('unknown tag %s' % str(tag))
+
+    r.append('</table>')
+
+    return '\n'.join(r)

--- a/src/OFS/dtml/history.dtml
+++ b/src/OFS/dtml/history.dtml
@@ -1,0 +1,99 @@
+<dtml-var manage_page_header>
+<dtml-var manage_tabs>
+
+<main class="container-fluid">
+
+  <h3>Historical revisions</h3>
+
+  <p class="form-help mb-4">
+    Use this form to view the historical revisions for the object, compare
+    changes or return the object to a previous state.
+    <br/>
+    Please note that ZODB packing will remove all but the current revision.
+  </p>
+
+  <dtml-if manage_change_history>
+
+    <form action="<dtml-var "REQUEST.URL1" html_quote>" method="POST">
+
+      <table width="100%" cellspacing="0" cellpadding="2" border="0">
+  
+        <tr class="list-header">
+           <td width="50%" align="left" valign="top">
+             <div class="list-nav">
+               <dtml-if first_transaction>       
+                 <dtml-with expr="_(next=first_transaction*2-last_transaction)">
+                   <a href="<dtml-var "REQUEST.URL" html_quote>?first_transaction:int=&dtml.-next;&last_transaction:int=&dtml.-first_transaction;&HistoryBatchSize:int=&dtml.-HistoryBatchSize;">&lt; Later Revisions</a>
+                 </dtml-with>
+               <dtml-else>
+                 &nbsp;
+               </dtml-if>
+             </div>
+           </td>
+           <td width="50%" align="right" valign="top">
+             <div class="list-nav">
+               <dtml-if expr="_.len(manage_change_history) == HistoryBatchSize"> 
+                 <dtml-with expr="_(last=last_transaction+HistoryBatchSize)">
+                   <a href="<dtml-var "REQUEST.URL" html_quote>?first_transaction:int=&dtml.-last_transaction;&last_transaction:int=&dtml.-last;&HistoryBatchSize:int=&dtml.-HistoryBatchSize;">Earlier Revisions &gt;</a>
+                 </dtml-with>
+               <dtml-else>
+                 &nbsp;
+               </dtml-if>
+             </div>
+           </td>
+         </tr>
+
+       </table>
+  
+
+      <table class="table table-striped table-hover table-sm">
+
+        <tr class="zmi-table-head">
+          <th>&nbsp;</th>
+          <th>Timestamp</th>
+          <th>User</th>
+          <th>Description</th>
+        </tr>
+  
+        <dtml-in manage_change_history mapping>
+          <tr>
+            <td class="zmi-object-check text-right">
+              <input type="checkbox" value="&dtml-key;" name="keys:list">
+            </td>
+            <td class="zmi-object-id">
+              <a href="&dtml-absolute_url;/HistoricalRevisions/&dtml-key;/manage_workspace">
+                <dtml-var time fmt="%Y-%m-%d %H:%M">
+              </a>
+            </td>
+            <td class="zmi-object-id">
+              <dtml-var user_name missing="n/a">
+            </td>
+            <td class="zmi-object-id">
+              <dtml-var description html_quote newline_to_br>
+              <dtml-if revision>
+                <br/>revision: <em>&dtml-revision;</em>
+               </dtml-if>
+            </td>
+          </tr>
+        </dtml-in>
+
+      </table>
+
+      <div class="zmi-controls form-group form-inline">
+        <input class="btn btn-primary" type="submit"
+               name="manage_historyCopy:method"
+               value="Copy to present"/>&nbsp;
+        <input class="btn btn-primary" type="submit"
+               name="manage_historicalComparison:method"
+               value="Compare"/>
+      </div>
+  
+    </form>
+  
+  <dtml-else>
+    <p class="form-help">No change history is available for this object.</p>
+  </dtml-if>
+
+</main>
+
+<dtml-var manage_page_footer>

--- a/src/OFS/tests/testHistory.py
+++ b/src/OFS/tests/testHistory.py
@@ -1,0 +1,97 @@
+import os
+import shutil
+import tempfile
+import time
+import unittest
+
+import transaction
+import ZODB
+import Zope2
+from OFS.Application import Application
+from OFS.History import Historical
+from OFS.SimpleItem import SimpleItem
+from ZODB.FileStorage import FileStorage
+
+
+Zope2.startup_wsgi()
+
+
+class HistoryItem(SimpleItem, Historical):
+    pass
+
+
+class HistoryTests(unittest.TestCase):
+
+    def setUp(self):
+        # set up a zodb
+        # we can't use DemoStorage here 'cos it doesn't support History
+        self.dir = tempfile.mkdtemp()
+        fs_path = os.path.join(self.dir, 'testHistory.fs')
+        self.s = FileStorage(fs_path, create=True)
+        self.connection = ZODB.DB(self.s).open()
+        r = self.connection.root()
+        a = Application()
+        r['Application'] = a
+        self.root = a
+        # create a python script
+        a['test'] = HistoryItem()
+        self.hi = hi = a.test
+        # commit some changes
+        hi.title = 'First title'
+        t = transaction.get()
+        # undo note made by Application instantiation above.
+        t.description = None
+        t.note(u'Change 1')
+        t.commit()
+        time.sleep(0.02)  # wait at least one Windows clock tick
+        hi.title = 'Second title'
+        t = transaction.get()
+        t.note(u'Change 2')
+        t.commit()
+        time.sleep(0.02)  # wait at least one Windows clock tick
+        hi.title = 'Third title'
+        t = transaction.get()
+        t.note(u'Change 3')
+        t.commit()
+
+    def tearDown(self):
+        # get rid of ZODB
+        transaction.abort()
+        self.connection.close()
+        self.s.close()
+        del self.root
+        del self.connection
+        del self.s
+        shutil.rmtree(self.dir)
+
+    def test_manage_change_history(self):
+        r = self.hi.manage_change_history()
+        self.assertEqual(len(r), 3)  # three transactions
+        for i in range(3):
+            entry = r[i]
+            # check no new keys show up without testing
+            self.assertEqual(len(entry.keys()), 6)
+            # the transactions are in newest-first order
+            self.assertEqual(entry['description'], 'Change %i' % (3 - i))
+            self.assertTrue('key' in entry)
+            # lets not assume the size will stay the same forever
+            self.assertTrue('size' in entry)
+            self.assertTrue('tid' in entry)
+            self.assertTrue('time' in entry)
+            if i:
+                # check times are increasing
+                self.assertTrue(entry['time'] < r[i - 1]['time'])
+            self.assertEqual(entry['user_name'], '')
+
+    def test_manage_historyCopy(self):
+        # we assume this works 'cos it's tested above
+        r = self.hi.manage_change_history()
+        # now we do the copy
+        self.hi.manage_historyCopy(keys=[r[2]['key']])
+        # do a commit, just like ZPublisher would
+        transaction.commit()
+        # check the body is as it should be, we assume
+        # (hopefully not foolishly)
+        # that all other attributes will behave the same
+        self.assertEqual(self.hi.title,
+                         'First title')


### PR DESCRIPTION
During Hanno's brutal cleanup he ripped out the ZMI History tab and functionality behind it. I would like to reintegrate it because it it very useful for those who edit scripts in the ZODB. Matter of fact, this functionality is critical for a customer of mine.

The code in this PR represents the last available revisions. It has been cleaned up to be Python 3-compatible, PEP-8 compliant, and the ZMI History template has been updated to look appealing on Zope 4.
