### PR TITLE
Remove recommendation of tempstorage.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,13 @@ https://github.com/zopefoundation/Zope/blob/4.0a6/CHANGES.rst
 
 - Resurrect History ZMI tab and functionality
 
+- Removed commented out configuration for tempstorage (and server side 
+  sessions) as that was known not working for ages. This was removed so we do 
+  not lead unsuspecting developers to think that this is the right way to do 
+  session data. See
+  (`#679 <https://github.com/zopefoundation/Zope/issues/679>`_)
+  (`tempstorage#8 <https://github.com/zopefoundation/tempstorage/issues/8>`_)
+  (`tempstorage#12 <https://github.com/zopefoundation/tempstorage/issues/12>`_)
 
 4.1.1 (2019-07-02)
 ------------------

--- a/src/Zope2/utilities/skel/etc/zope.conf.in
+++ b/src/Zope2/utilities/skel/etc/zope.conf.in
@@ -1,3 +1,4 @@
+%define INSTANCE <<INSTANCE_HOME>>
 
 instancehome $INSTANCE
 

--- a/src/Zope2/utilities/skel/etc/zope.conf.in
+++ b/src/Zope2/utilities/skel/etc/zope.conf.in
@@ -1,4 +1,3 @@
-%define INSTANCE <<INSTANCE_HOME>>
 
 instancehome $INSTANCE
 
@@ -8,16 +7,6 @@ instancehome $INSTANCE
    </filestorage>
    mount-point /
 </zodb_db>
-
-# Uncomment this if you use Products.Sessions and Products.TemporaryFolder
-# <zodb_db temporary>
-#     <temporarystorage>
-#       name Temporary database (for sessions)
-#     </temporarystorage>
-#     mount-point /temp_folder
-#     container-class Products.TemporaryFolder.TemporaryContainer
-# </zodb_db>
-
 
 # Directive: locale
 #

--- a/versions.cfg
+++ b/versions.cfg
@@ -57,7 +57,6 @@ snowballstemmer = 1.9
 soupsieve = 1.9.2
 sphinx-rtd-theme = 0.4.3
 sphinxcontrib-websupport = 1.1.2
-tempstorage = 5.0
 toml = 0.10.0
 tox = 3.13.2
 tqdm = 4.32.2


### PR DESCRIPTION
This pull request tries to follow through on #679.

As a first suggestion I have just removed the recommendation of tempstorage from the generated config file. Since this is maybe impractical, an alternative suggestion could be to reformulate the commented out snippet like this:

```
# Uncomment this if you use Products.Sessions and Products.TemporaryFolder
# <zodb_db temporary>
#     <filestorage>
#       path $INSTANCE/var/Data.temporary.fs
#     </filestorage>
#     mount-point /temp_folder
#     container-class Products.TemporaryFolder.TemporaryContainer
# </zodb_db>
```

However, I do not pretend to understand the ramifications of this recommendation (nor have I tested it in depth), so I am putting it here as a discussion point.