### PR TITLE
Remove further tempstorage dependencies.

### DIFF
--- a/requirements-rtd.txt
+++ b/requirements-rtd.txt
@@ -1,4 +1,3 @@
 repoze.sphinx.autointerface
 Zope
 ZConfig==3.5.0
-tempstorage

--- a/requirements-rtd.txt
+++ b/requirements-rtd.txt
@@ -1,3 +1,4 @@
 repoze.sphinx.autointerface
 Zope
 ZConfig==3.5.0
+tempstorage

--- a/setup.py
+++ b/setup.py
@@ -131,7 +131,6 @@ setup(
             'Sphinx',
             'sphinx_rtd_theme',
             'repoze.sphinx.autointerface',
-            'tempstorage',
         ],
     },
     entry_points={


### PR DESCRIPTION
This tries to fix #668 by removing further `tempstorage` dependencies.

I am pretty sure that just removing `tempstorage` from the `[docs]` section of extras require is pretty safe as I can't find any mention of `tempstorage` in the documentation. I am a bit more hesitant about the requirements.rtd.txt - but am pretty sure that this is also not required.

Feedback welcome.