### PR TITLE
Reuse ``zope.publisher.http.splitport`` instead of defining our own

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,9 @@ https://github.com/zopefoundation/Zope/blob/4.0a6/CHANGES.rst
   (`tempstorage#8 <https://github.com/zopefoundation/tempstorage/issues/8>`_)
   (`tempstorage#12 <https://github.com/zopefoundation/tempstorage/issues/12>`_)
 
+- Reuse ``zope.publisher.http.splitport`` instead of defining our own
+  (`#683 <https://github.com/zopefoundation/Zope/issues/683>`_)
+
 
 4.1.1 (2019-07-02)
 ------------------

--- a/src/Products/SiteAccess/VirtualHostMonster.py
+++ b/src/Products/SiteAccess/VirtualHostMonster.py
@@ -10,12 +10,12 @@ from App.special_dtml import DTMLFile
 from OFS.SimpleItem import Item
 from Persistence import Persistent
 from zExceptions import BadRequest
+from zope.publisher.http import splitport
 from ZPublisher.BaseRequest import quote
 from ZPublisher.BeforeTraverse import NameCaller
 from ZPublisher.BeforeTraverse import queryBeforeTraverse
 from ZPublisher.BeforeTraverse import registerBeforeTraverse
 from ZPublisher.BeforeTraverse import unregisterBeforeTraverse
-from ZPublisher.HTTPRequest import splitport
 
 
 class VirtualHostMonster(Persistent, Item, Implicit):
@@ -149,7 +149,9 @@ class VirtualHostMonster(Persistent, Item, Implicit):
                 stack.pop()
                 protocol = stack.pop()
                 host = stack.pop()
-                request.setServerURL(protocol, *splitport(host))
+                hostname, port = splitport(host)
+                port = (port and int(port)) or None
+                request.setServerURL(protocol, hostname, port)
                 path = list(stack)
 
             # Find and convert VirtualHostRoot directive

--- a/src/Products/SiteAccess/VirtualHostMonster.py
+++ b/src/Products/SiteAccess/VirtualHostMonster.py
@@ -150,7 +150,7 @@ class VirtualHostMonster(Persistent, Item, Implicit):
                 protocol = stack.pop()
                 host = stack.pop()
                 hostname, port = splitport(host)
-                port = (port and int(port)) or None
+                port = int(port) if port else None
                 request.setServerURL(protocol, hostname, port)
                 path = list(stack)
 

--- a/src/ZPublisher/HTTPRequest.py
+++ b/src/ZPublisher/HTTPRequest.py
@@ -40,6 +40,7 @@ from zope.interface import directlyProvidedBy
 from zope.interface import directlyProvides
 from zope.interface import implementer
 from zope.publisher.base import DebugFlags
+from zope.publisher.http import splitport
 from zope.publisher.interfaces.browser import IBrowserRequest
 from ZPublisher import xmlrpc
 from ZPublisher.BaseRequest import BaseRequest
@@ -105,27 +106,6 @@ trusted_proxies = []
 
 class NestedLoopExit(Exception):
     pass
-
-
-def splitport(url):
-    """Return (hostname, port) from a URL
-
-    If it does not return a port, return the URL unchanged.
-    This mimics the behavior of the `splitport` function which was
-    in Python and got deprecated in Python 3.8.
-    """
-    parsed = urlparse(url)
-    if (not parsed.scheme
-            and parsed.port is None
-            and parsed.hostname is None):
-        # urlparse does not like URLs without a protocol, so add one:
-        parsed = urlparse('http://{}'.format(url))
-    if parsed.port is None:
-        return url, None
-    hostname = parsed.hostname
-    if parsed.netloc.startswith('['):
-        hostname = "[{}]".format(hostname)
-    return hostname, parsed.port
 
 
 @implementer(IBrowserRequest)


### PR DESCRIPTION
Fixes #683 

The behavior of the zope.publisher version is slightly different, so for the VirtualHostMonster code it was not a full drop-in replacement.