### PR TITLE
Grep for `Python 2` and fix the places where it was used.

### DIFF
--- a/docs/zdgbook/ComponentsAndInterfaces.rst
+++ b/docs/zdgbook/ComponentsAndInterfaces.rst
@@ -135,7 +135,7 @@ Interfaces try to solve these problems by providing a way for you to
 describe how to use an object, and a mechanism for discovering that
 description.
 
-Creating Interfaces                                       
+Creating Interfaces
 ===================
 
 The first step to creating a component, as you've been shown, is to
@@ -247,12 +247,6 @@ interfaces and classes should never be confused.
 Querying an Interface
 =====================
 
-.. attention::
-
-  The following explanation is only valid for Python 3. If you still
-  use Python 2, please note, that both ``names`` and
-  ``namesAndDescriptions`` return a list, not a dict_view.
-
 Interfaces can be queried for information.  The simplest case is to
 ask an interface the names of all the various interface items it
 describes.  From the Python interpreter, for example, you can walk
@@ -302,7 +296,7 @@ For example::
   <zope.interface.interface.Method object at 0x7fc6875110f0>
   >>> m.getSignatureString()
   '(name)'
-  >>> m.getSignatureInfo()   
+  >>> m.getSignatureInfo()
   {'positional': ('name',), 'required': ('name',), 'optional': {},
    'varargs': None, 'kwargs': None}
 

--- a/docs/zdgbook/GettingStarted.rst
+++ b/docs/zdgbook/GettingStarted.rst
@@ -74,12 +74,6 @@ command to build the system.
 
 The initial build will take some time to complete.
 
-.. attention::
-
-  You will see some warnings or error messages on the console. These
-  cannot be fixed until Python 2 support is dropped. Just ignore
-  them for now.
-
 Creating the instance
 =====================
 

--- a/docs/zdgbook/ObjectPublishing.rst
+++ b/docs/zdgbook/ObjectPublishing.rst
@@ -944,7 +944,7 @@ module. However, the converter may impose restrictions.
 
 **Special cases**
 
-If you are still on Python 2 or your pages use a different encoding,
+If your pages use a different encoding,
 such as ``Windows-1252`` or ``ISO-8859-1``, which was the default
 encoding for HTML 4, you have to add the encoding, eg ``:cp1252``, for
 all argument type converts, such as follows::
@@ -1276,13 +1276,6 @@ Other Network Protocols
 
 XML-RPC
 -------
-
-.. note::
-
-  Code examples are valid for Python 3 only.
-
-  If you want to use Python 2, please refer to the
-  `offcial documentation <https://docs.python.org/2/library/xmlrpclib.html>`_
 
 **XML-RPC** is a light-weight remote procedure call (RPC) protocol
 that uses **XML** to encode its calls and **HTTP** as a transport

--- a/src/OFS/tests/testProperties.py
+++ b/src/OFS/tests/testProperties.py
@@ -15,8 +15,6 @@
 
 import unittest
 
-import six
-
 
 class TestPropertyManager(unittest.TestCase):
 
@@ -91,16 +89,11 @@ class TestPropertyManager(unittest.TestCase):
         pm = self._makeOne()
         pm._setProperty('test_lines', [], type='lines')
 
-        # text gets converted to bytes here as it's likely utf-8
-        # (or otherwise) encoded anyway (from use with Python 2)
         pm._updateProperty('test_lines', 'foo\nbar')
         self.assertEqual(pm.getProperty('test_lines'), (b'foo', b'bar'))
 
         pm._updateProperty('test_lines', b'bar\nbaz')
         self.assertEqual(pm.getProperty('test_lines'), (b'bar', b'baz'))
-
-        pm._updateProperty('test_lines', six.u('uni\ncode'))
-        self.assertEqual(pm.getProperty('test_lines'), (b'uni', b'code'))
 
 
 class TestPropertySheets(unittest.TestCase):
@@ -153,13 +146,8 @@ class TestPropertySheet(unittest.TestCase):
         ps = self._makeOne('foo')
         ps._setProperty('test_lines', [], type='lines')
 
-        # text gets converted to bytes here as it's likely utf-8
-        # (or otherwise) encoded anyway (from use with Python 2)
         ps._updateProperty('test_lines', 'foo\nbar')
         self.assertEqual(ps.getProperty('test_lines'), (b'foo', b'bar'))
 
         ps._updateProperty('test_lines', b'bar\nbaz')
         self.assertEqual(ps.getProperty('test_lines'), (b'bar', b'baz'))
-
-        ps._updateProperty('test_lines', six.u('uni\ncode'))
-        self.assertEqual(ps.getProperty('test_lines'), (b'uni', b'code'))

--- a/src/ZPublisher/tests/testHTTPResponse.py
+++ b/src/ZPublisher/tests/testHTTPResponse.py
@@ -1339,8 +1339,6 @@ class HTTPResponseTests(unittest.TestCase):
     def test_exception_500_text(self):
         message = u'ERROR \xe4 VALUE'
         exc = AttributeError(message)
-        # This gets called deep down in the zExceptions.ExceptionFormatter
-        # and produces different results in Python 2/3.
         expected = traceback.format_exception_only(
             exc.__class__, exc)[0].encode('utf-8')
         response = self._makeOne()


### PR DESCRIPTION
See #692.