### PR TITLE
Set ``REMOTE_USER`` in wsgi environ using Zope user authentication

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,8 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 - Fix ``OFS.Image.File.__str__`` for ``Pdata`` contents
   (`#711 <https://github.com/zopefoundation/Zope/issues/711>`_)
 
+- Set ``REMOTE_USER`` in wsgi environ using Zope user authentication
+
 - Improve documentation for Zope's error logging services.
 
 Backwards incompatible changes

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
   (`#711 <https://github.com/zopefoundation/Zope/issues/711>`_)
 
 - Set ``REMOTE_USER`` in wsgi environ using Zope user authentication
+  (`#713 <https://github.com/zopefoundation/Zope/pull/713>`_)
 
 - Improve documentation for Zope's error logging services.
 

--- a/src/ZPublisher/WSGIPublisher.py
+++ b/src/ZPublisher/WSGIPublisher.py
@@ -23,6 +23,7 @@ from six import reraise
 from six.moves._thread import allocate_lock
 
 import transaction
+from AccessControl.SecurityManagement import getSecurityManager
 from AccessControl.SecurityManagement import newSecurityManager
 from AccessControl.SecurityManagement import noSecurityManager
 from Acquisition import aq_acquire
@@ -330,6 +331,9 @@ def publish_module(environ, start_response,
                 with load_app(module_info) as new_mod_info:
                     with transaction_pubevents(request, response):
                         response = _publish(request, new_mod_info)
+                user = getSecurityManager().getUser()
+                if user is not None and user.getUserName() != 'Anonymous User':
+                    environ['REMOTE_USER'] = user.getUserName()
                 break
             except TransientError:
                 if request.supports_retry():

--- a/src/ZPublisher/tests/test_WSGIPublisher.py
+++ b/src/ZPublisher/tests/test_WSGIPublisher.py
@@ -20,6 +20,7 @@ import Testing.testbrowser
 import transaction
 from Testing.ZopeTestCase import FunctionalTestCase
 from Testing.ZopeTestCase import ZopeTestCase
+from Testing.ZopeTestCase import user_name
 from ZODB.POSException import ConflictError
 from zope.interface.common.interfaces import IException
 from zope.publisher.interfaces import INotFound
@@ -660,6 +661,21 @@ class TestPublishModule(ZopeTestCase):
         finally:
             # Clean up view registration
             unregisterExceptionView(IException)
+
+    def test_set_REMOTE_USER_environ(self):
+        environ = self._makeEnviron()
+        start_response = DummyCallable()
+        _response = DummyResponse()
+        _publish = DummyCallable()
+        _publish._result = _response
+        self.assertFalse('REMOTE_USER' in environ)
+        self._callFUT(environ, start_response, _publish)
+        self.assertEqual(environ['REMOTE_USER'], user_name)
+        # After logout there is no REMOTE_USER in environ
+        environ = self._makeEnviron()
+        self.logout()
+        self._callFUT(environ, start_response, _publish)
+        self.assertFalse('REMOTE_USER' in environ)
 
 
 class ExcViewCreatedTests(ZopeTestCase):


### PR DESCRIPTION
Set REMOTE_USER in wsgi publisher for next apps in wsgi pipeline. 
e.g. useful for have user in access logs, ...