### PR TITLE
Fix unrestrictedTraverse not handling unicode strings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,9 @@ https://github.com/zopefoundation/Zope/blob/4.0a6/CHANGES.rst
 
 - Update to current releases of the dependencies.
 
+- Fix unrestrictedTraverse not handling unicode strings under Python 2.
+  (`#715 <https://github.com/zopefoundation/Zope/issues/715>`_)
+
 
 4.1.2 (2019-09-04)
 ------------------

--- a/src/OFS/Traversable.py
+++ b/src/OFS/Traversable.py
@@ -13,6 +13,7 @@
 """This module implements a mix-in for traversable objects.
 """
 
+from six import string_types
 from six.moves.urllib.parse import quote
 
 from AccessControl.class_init import InitializeClass
@@ -172,8 +173,7 @@ class Traversable(object):
         if not path:
             return self
 
-        if isinstance(path, str):
-            # Unicode paths are not allowed
+        if isinstance(path, string_types):
             path = path.split('/')
         else:
             path = list(path)

--- a/src/OFS/tests/testTraverse.py
+++ b/src/OFS/tests/testTraverse.py
@@ -225,6 +225,11 @@ class TestTraverse(unittest.TestCase):
             self.folder1.unrestrictedTraverse(('', 'folder1', 'file')))
         self.assertTrue(self.folder1.unrestrictedTraverse(('', 'folder1')))
 
+    def testTraverseUnicodePath(self):
+        self.assertTrue('file' in self.folder1.objectIds())
+        self.assertTrue(
+            self.folder1.unrestrictedTraverse(u'/folder1/file'))
+
     def testTraverseURLNoSlash(self):
         self.assertTrue('file' in self.folder1.objectIds())
         self.assertTrue(self.folder1.unrestrictedTraverse('/folder1/file'))


### PR DESCRIPTION
... under Python 2.

This closes #715.

modified:   CHANGES.rst
modified:   src/OFS/Traversable.py
modified:   src/OFS/tests/testTraverse.py