### PR TITLE
Fix ``__getattr__`` signature in ``UnauthorizedBinding``

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 
 5.0a1 (unreleased)
 ------------------
+- Fix ``__getattr__`` signature in ``UnauthorizedBinding``
+  (`#703 <https://github.com/zopefoundation/Zope/issues/703>`_)
 
 - Remove more Python 2 support code
   (`#692 <https://github.com/zopefoundation/Zope/issues/692>`_)

--- a/src/Shared/DC/Scripts/Bindings.py
+++ b/src/Shared/DC/Scripts/Bindings.py
@@ -187,7 +187,7 @@ class UnauthorizedBinding(object):
     def __repr__(self):
         return '<UnauthorizedBinding: %s>' % self._name
 
-    def __getattr__(self, name, default=None):
+    def __getattr__(self, name):
         # Make *extra* sure that the wrapper isn't used to access
         # __call__, etc.
         if name.startswith('__'):
@@ -200,7 +200,7 @@ class UnauthorizedBinding(object):
 
             self.__you_lose()
 
-        return guarded_getattr(self._wrapped, name, default)
+        return guarded_getattr(self._wrapped, name)
 
     def __you_lose(self):
         name = self.__dict__['_name']


### PR DESCRIPTION
Fixes #703 

Only "drawback" is that none of that code is tested. But the issue is obvious and correctly identified by Dieter.

This PR is against `master`/Zope 5. I can do a backport to `4.x` if it is accepted.