### PR TITLE
ZMI: permission table compressed for safari

### DIFF
--- a/src/OFS/dtml/properties.dtml
+++ b/src/OFS/dtml/properties.dtml
@@ -162,12 +162,12 @@
 	</form>
 
 	<dtml-if property_extensible_schema__>
-		<form action="<dtml-var "REQUEST.URL1" html_quote>/manage_addProperty" method="post" class="form-inline">
+		<form action="<dtml-var "REQUEST.URL1" html_quote>/manage_addProperty" method="post">
 			<p class="form-help mt-5">
 				To add a new property, enter a name, type and value for the new
 				property and click the <em>Add</em>-button.
 			</p>
-			<div class="form-group zmi-controls mt-2">
+			<div class="form-group form-inline zmi-controls mt-2">
 				<input type="text" placeholder="Name" title="Name" class="form-control" name="id:<dtml-var "REQUEST.charset.lower()=='utf-8' and 'UTF-8:' or ''">string" value="" />
 				<select name="type" title="Data Type"placeholder="Type" class="form-control">
 					<option>boolean</option>

--- a/src/zmi/styles/resources/zmi_base.css
+++ b/src/zmi/styles/resources/zmi_base.css
@@ -380,13 +380,17 @@ form.zmi-upload {
 	overflow: hidden;
 	display: inline-block;
 	text-align: center;
+	object-fit: contain;
 }
-
+.zmi .compress th.zmi-rolename > div > span {
+	text-align: left;
+}
 @media (max-width: 768px) {
 	.zmi th.blank > div > span {
 		width: 110px;
 		overflow: hidden;
 		display: inline-block;
+		text-align: left;
 	}
 	.zmi .zmi-table-head th {
 		border:none;

--- a/src/zmi/styles/resources/zmi_base.js
+++ b/src/zmi/styles/resources/zmi_base.js
@@ -6,7 +6,9 @@
 function isURL(str) {
 	return /^(?:\w+:)?\/\/\S*$/.test(str);
 };
-
+function isSafari() {
+	return /^((?!chrome).)*safari/i.test(navigator.userAgent);
+}
 
 // NAVBAR-FUNCTIONS
 
@@ -229,7 +231,7 @@ $(function() {
 	// COMPRESS USER PERMISSIONS TABLE SIZE
 	if ($('body.zmi-manage_access').length !== 0) {
 		function resize_permissions_table() {
-			if ( $('#table-permissions').width() > $(window).width() ) {
+			if ( $('#table-permissions').width() > $(window).width() || isSafari() ) {
 				$('#table-permissions').addClass('compress');
 			}
 		}


### PR DESCRIPTION
Hi @dataflake, 
these changes in addition to
https://github.com/zopefoundation/Zope/pull/731
It fixes a floating problem wide screens with src/OFS/dtml/properties.dtml, the table title text alignment of the permissions table and pushes the safari to the compressed view (safari has an known issues with browser window width)
 
Cheers
f