### PR TITLE
Add missing Paste dependency.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -55,8 +55,8 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 
 - Improve documentation for Zope's error logging services.
 
-- Add ``Paste`` as install dependency, otherwise it won't start when installed
-  with `pip` and the `constraints.txt` file.
+- Add ``Paste`` as ``extras_require`` dependency to pull in ``Paste`` when 
+  installing with `pip` and `constraints.txt` to prevent startup errors.
   (`#734 <https://github.com/zopefoundation/Zope/issues/734>`_)
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -57,6 +57,7 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 
 - Add ``Paste`` as ``extras_require`` dependency to pull in ``Paste`` when 
   installing with `pip` and `constraints.txt` to prevent startup errors.
+  This requires adding the ``[wsgi]`` extra in the egg specification.
   (`#734 <https://github.com/zopefoundation/Zope/issues/734>`_)
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -51,6 +51,11 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 
 - Improve documentation for Zope's error logging services.
 
+- Add ``Paste`` as install dependency, otherwise it won't start when installed
+  with `pip` and the `constraints.txt` file.
+  (`#734 <https://github.com/zopefoundation/Zope/issues/734>`_)
+
+
 Backwards incompatible changes
 ++++++++++++++++++++++++++++++
 

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -45,8 +45,7 @@ eggs =
 recipe = zc.recipe.egg
 interpreter = zopepy
 eggs =
-    Paste
-    Zope
+    Zope[wsgi]
     zodbupdate
 
 

--- a/docs/INSTALL.rst
+++ b/docs/INSTALL.rst
@@ -166,8 +166,8 @@ version you find on https://zopefoundation.github.io/Zope/:
   $ python3.7 -m venv zope
   $ cd zope
   $ bin/pip install -U pip
-  $ bin/pip install Zope==4.1 \
-    -c https://zopefoundation.github.io/Zope/releases/4.1/constraints.txt
+  $ bin/pip install Zope[wsgi]==4.1.2 \
+    -c https://zopefoundation.github.io/Zope/releases/4.1.2/constraints.txt
 
 You can also install Zope using a single requirements file. Note that this
 installation method might install packages that are not actually needed (i. e.

--- a/docs/INSTALL.rst
+++ b/docs/INSTALL.rst
@@ -166,8 +166,8 @@ version you find on https://zopefoundation.github.io/Zope/:
   $ python3.7 -m venv zope
   $ cd zope
   $ bin/pip install -U pip
-  $ bin/pip install Zope[wsgi]==4.1.2 \
-    -c https://zopefoundation.github.io/Zope/releases/4.1.2/constraints.txt
+  $ bin/pip install Zope[wsgi]==4.1.3 \
+    -c https://zopefoundation.github.io/Zope/releases/4.1.3/constraints.txt
 
 You can also install Zope using a single requirements file. Note that this
 installation method might install packages that are not actually needed (i. e.
@@ -176,7 +176,7 @@ more than are listed in the ``install_requires`` section of ``setup.py``):
 .. code-block:: console
 
     $ bin/pip install \
-    -r https://zopefoundation.github.io/Zope/releases/4.1.2/requirements-full.txt
+    -r https://zopefoundation.github.io/Zope/releases/4.1.3/requirements-full.txt
 
 
 Building the documentation with ``Sphinx``

--- a/docs/INSTALL.rst
+++ b/docs/INSTALL.rst
@@ -176,7 +176,7 @@ more than are listed in the ``install_requires`` section of ``setup.py``):
 .. code-block:: console
 
     $ bin/pip install \
-    -r https://zopefoundation.github.io/Zope/releases/4.1/requirements-full.txt
+    -r https://zopefoundation.github.io/Zope/releases/4.1.2/requirements-full.txt
 
 
 Building the documentation with ``Sphinx``

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ setup(
         'DocumentTemplate >= 3.0b9',
         'ExtensionClass',
         'MultiMapping',
+        'Paste',
         'PasteDeploy',
         'Persistence',
         'RestrictedPython',

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,6 @@ setup(
         'DocumentTemplate >= 3.0b9',
         'ExtensionClass',
         'MultiMapping',
-        'Paste',
         'PasteDeploy',
         'Persistence',
         'RestrictedPython',
@@ -130,6 +129,9 @@ setup(
             'Sphinx',
             'sphinx_rtd_theme',
             'repoze.sphinx.autointerface',
+        ],
+        'wsgi': [
+            'Paste',
         ],
     },
     entry_points={


### PR DESCRIPTION
Otherwise Zope won't start up when installed with `pip` and the `constraints.txt` file.

When accepted this PR should also be ported to the 4.x branch.

Relates to #734.