### PR TITLE
Fix broken deprecated import when ZServer is not installed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,9 @@ https://github.com/zopefoundation/Zope/blob/4.0a6/CHANGES.rst
 4.1.3 (unreleased)
 ------------------
 
+- Fix broken deprecated import when ZServer is not installed
+  (`#714 <https://github.com/zopefoundation/Zope/issues/714>`_)
+
 - Improve ZMI Security Tab usability for high numbers of roles
   (`#730 <https://github.com/zopefoundation/Zope/issues/730>`_)
 

--- a/src/OFS/interfaces.py
+++ b/src/OFS/interfaces.py
@@ -29,6 +29,8 @@ from zope.schema import Bool
 from zope.schema import NativeStringLine
 from zope.schema import Tuple
 
+from . import bbb
+
 
 class IOrderedContainer(Interface):
 
@@ -1056,7 +1058,14 @@ class IObjectClonedEvent(IObjectEvent):
 
 
 # BBB Zope 5.0
-deprecated(
-    'Please import from webdav.interfaces.',
-    IFTPAccess='webdav.interfaces:IFTPAccess',
-)
+if bbb.HAS_ZSERVER:
+    # This import can only be resolved if ZServer is installed
+    deprecated(
+        'Please import from webdav.interfaces.',
+        IFTPAccess='webdav.interfaces:IFTPAccess',
+    )
+else:
+    deprecated(
+        'You must install the ZServer package to import IFTPAccess.',
+        IFTPAccess='zope.interface:Interface',
+    )


### PR DESCRIPTION
Workaround to fix #714 