### PR TITLE
close opened db during shutdown

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 5.0a1 (unreleased)
 ------------------
 
+- Close opened db during shutdown (as ZServer is already doing).
+
 - Updated Zope documentation sources for Zope 5
   (`#659 <https://github.com/zopefoundation/Zope/issues/659>`_)
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 ------------------
 
 - Close opened db during shutdown (as ZServer is already doing).
+  (`#740 <https://github.com/zopefoundation/Zope/issues/740>`_)
 
 - Updated Zope documentation sources for Zope 5
   (`#659 <https://github.com/zopefoundation/Zope/issues/659>`_)

--- a/src/Zope2/Startup/serve.py
+++ b/src/Zope2/Startup/serve.py
@@ -18,6 +18,7 @@ import optparse
 import os
 import re
 import sys
+import Zope2
 from logging.config import fileConfig
 
 from paste.deploy import loadapp
@@ -209,6 +210,8 @@ and then use %(http_port)s in your config files.
                     msg = ''
                 self.out('Exiting%s (-v to see traceback)' % msg)
             finally:
+                for db in Zope2.opened:
+                    db.close()
                 self.unlinkPidFile()
 
         serve()

--- a/src/Zope2/Startup/serve.py
+++ b/src/Zope2/Startup/serve.py
@@ -18,13 +18,13 @@ import optparse
 import os
 import re
 import sys
-import Zope2
 from logging.config import fileConfig
 
 from paste.deploy import loadapp
 from paste.deploy import loadserver
 from six.moves import configparser
 
+import Zope2
 from App.config import getConfiguration
 
 


### PR DESCRIPTION
Close opened database connections during shutdown. 

That's important at least with Relstorage, where ZODB cache is saved persistently on filesystem within db closing, with a great improvement on startup.

Here where ZServer do something like this: https://github.com/zopefoundation/ZServer/blob/master/src/ZServer/Zope2/Startup/starter.py#L112