### PR TITLE
Pin more-itertools to less than 6.0.0. [2.13]

### DIFF
--- a/version_ranges.cfg
+++ b/version_ranges.cfg
@@ -99,6 +99,7 @@ mechanize = < 0.3.dev
 python-gettext = < 1.3.dev
 zope.testbrowser = < 3.12.dev
 mr.developer = < 1.35.dev
+more-itertools = < 6.0.0
 
 # pytz 2017.3 provokes a test failure in DateTime:
 # AssertionError: legacy timezone  Canada/East-Saskatchewan cannot be looked up


### PR DESCRIPTION
Version 6 and higher no longer work on Python 2.7, so you get a SyntaxError when running buildout.

(I am looking at Zope 2.13 because the Plone hotfix of this week should be merged in parts of Zope. But the Zope(2) package itself does not seem affected. Still, would be nice if the buildout can finish.)