### PR TITLE
Zope-801 Fixes issue where GET on a binary WebDAV resource returned

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,9 @@ Bug fixes
 - Fixed encoding issue of `displayname` WebDAV property 
   (`#797 <https://github.com/zopefoundation/Zope/issues/797>`_)
 
+- Fixed issue where GET on a binary WebDAV resource returned improper
+  data (empty string instead of the binary data)
+  (`#797 <https://github.com/zopefoundation/Zope/issues/801>`_)
 
 Other changes
 +++++++++++++

--- a/src/webdav/Resource.py
+++ b/src/webdav/Resource.py
@@ -677,7 +677,12 @@ class Resource(Base, LockableItem):
     def manage_DAVget(self):
         """Gets the document source"""
         # The default implementation calls PrincipiaSearchSource
-        return self.PrincipiaSearchSource()
+        print('DAV')
+        import pdb; pdb.set_trace()
+        try:
+            return bytes(self)
+        except TypeError:
+            return self.PrincipiaSearchSource()
 
     @security.protected(webdav_access)
     def listDAVObjects(self):

--- a/src/webdav/Resource.py
+++ b/src/webdav/Resource.py
@@ -677,8 +677,6 @@ class Resource(Base, LockableItem):
     def manage_DAVget(self):
         """Gets the document source"""
         # The default implementation calls PrincipiaSearchSource
-        print('DAV')
-        import pdb; pdb.set_trace()
         try:
             return bytes(self)
         except TypeError:


### PR DESCRIPTION
Fixes #801 by using the `bytes()` result for a `GET` operation rather than `PrincipaSearchSource`.
Zope 5 passes the pyfilesystem2 and webdavfs test suite with 80 tests completely with this fix. 