### PR TITLE
Improve on issue 717

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,15 @@ https://zope.readthedocs.io/en/2.13/CHANGES.html
 4.3.1 (unreleased)
 ------------------
 
+- Improve *engine* handling of
+  ``Products.PageTempates.engine.Program.cook``
+  to support TALES extensions/adaptations (such as those by
+  ``Products.TrustedExecutables``).
+  However, *engine* is still not honoured for templates
+  used directly from ``zope.pagetemplate`` (rather than ``Zope``);
+  for them, the previous behaviour is unchanged.
+  (`#717 <https://github.com/zopefoundation/Zope/issues/717>`_).
+
 - Fixed encoding issue of `displayname` WebDAV property
   (`#797 <https://github.com/zopefoundation/Zope/issues/797>`_)
 

--- a/src/Products/Five/browser/pagetemplatefile.py
+++ b/src/Products/Five/browser/pagetemplatefile.py
@@ -18,12 +18,12 @@ from os.path import basename
 
 from AccessControl import getSecurityManager
 from Acquisition import aq_get
+from Products.PageTemplates.expression import \
+    createTrustedZopeEngine as createChTrustedZopeEngine
 from Products.PageTemplates.Expressions import SecureModuleImporter
 from Products.PageTemplates.Expressions import \
-     createTrustedZopeEngine as createPtTrustedZopeEngine
+    createTrustedZopeEngine as createPtTrustedZopeEngine
 from Products.PageTemplates.PageTemplate import get_template_engine_type
-from Products.PageTemplates.expression import \
-     createTrustedZopeEngine as createChTrustedZopeEngine
 from zope.component import getMultiAdapter
 from zope.pagetemplate.engine import TrustedAppPT
 from zope.pagetemplate.pagetemplatefile import PageTemplateFile

--- a/src/Products/Five/browser/pagetemplatefile.py
+++ b/src/Products/Five/browser/pagetemplatefile.py
@@ -19,17 +19,25 @@ from os.path import basename
 from AccessControl import getSecurityManager
 from Acquisition import aq_get
 from Products.PageTemplates.Expressions import SecureModuleImporter
-from Products.PageTemplates.Expressions import createTrustedZopeEngine
+from Products.PageTemplates.Expressions import \
+     createTrustedZopeEngine as createPtTrustedZopeEngine
+from Products.PageTemplates.PageTemplate import get_template_engine_type
+from Products.PageTemplates.expression import \
+     createTrustedZopeEngine as createChTrustedZopeEngine
 from zope.component import getMultiAdapter
 from zope.pagetemplate.engine import TrustedAppPT
 from zope.pagetemplate.pagetemplatefile import PageTemplateFile
 
 
-_engine = createTrustedZopeEngine()
+_pt_engine = createPtTrustedZopeEngine()
+_ch_engine = createChTrustedZopeEngine()
 
 
 def getEngine():
-    return _engine
+    # we must delay the engine selection because the switch
+    #  from the `zope.pagetemplate` to the `chameleon` template engine
+    #  happens quite late (maybe after the import of this module)
+    return _pt_engine if get_template_engine_type() == "pt" else _ch_engine
 
 
 class ViewPageTemplateFile(TrustedAppPT, PageTemplateFile):

--- a/src/Products/PageTemplates/Expressions.py
+++ b/src/Products/PageTemplates/Expressions.py
@@ -14,6 +14,9 @@
 
 Page Template-specific implementation of TALES, with handlers
 for Python expressions, string literals, and paths.
+
+Used by the (old) ``zope.pagetemplate`` template engine and
+other components (such as ``Products.CMFCore``).
 """
 
 import logging
@@ -403,6 +406,7 @@ class UnicodeAwareStringExpr(StringExpr):
 
 
 def createZopeEngine(zpe=ZopePathExpr):
+    """untrusted TALES engine for `zope.pagetemplate` template engine."""
     e = ZopeEngine()
     e.iteratorFactory = PathIterator
     for pt in zpe._default_type_names:
@@ -418,7 +422,7 @@ def createZopeEngine(zpe=ZopePathExpr):
 
 
 def createTrustedZopeEngine():
-    # same as createZopeEngine, but use non-restricted Python
+    """trusted TALES engine for `zope.pagetemplate` template engine."""
     # expression evaluator
     e = createZopeEngine(TrustedZopePathExpr)
     e.types['python'] = PythonExpr

--- a/src/Products/PageTemplates/PageTemplate.py
+++ b/src/Products/PageTemplates/PageTemplate.py
@@ -22,18 +22,17 @@ from Acquisition import aq_inner
 from Acquisition import aq_parent
 from zope.component import queryUtility
 from zope.pagetemplate.interfaces import IPageTemplateEngine
+from zope.pagetemplate.pagetemplate import PageTemplateEngine
 from zope.pagetemplate.pagetemplate import PageTemplateTracebackSupplement
 from zope.pagetemplate.pagetemplate import PTRuntimeError
-from zope.pagetemplate.pagetemplate import PageTemplateEngine
 from zope.tales.expressions import SimpleModuleImporter
 
-from .Expressions import getEngine as getPtEngine, \
-     createZopeEngine as createPtZopeEngine, \
-     createTrustedZopeEngine as createPtTrustedZopeEngine
-
-from .expression import getEngine as getChEngine, \
-     createZopeEngine as createChZopeEngine, \
-     createTrustedZopeEngine as createChTrustedZopeEngine
+from .expression import createTrustedZopeEngine as createChTrustedZopeEngine
+from .expression import createZopeEngine as createChZopeEngine
+from .expression import getEngine as getChEngine
+from .Expressions import createTrustedZopeEngine as createPtTrustedZopeEngine
+from .Expressions import createZopeEngine as createPtZopeEngine
+from .Expressions import getEngine as getPtEngine
 
 
 class PageTemplate(ExtensionClass.Base,
@@ -160,6 +159,7 @@ def createZopeEngine():
     return createPtZopeEngine() if get_template_engine_type() == "pt" \
         else createChZopeEngine()
 
+
 def createTrustedZopeEngine():
     return createPtTrustedZopeEngine() if get_template_engine_type() == "pt" \
         else createChTrustedZopeEngine()
@@ -171,6 +171,6 @@ def createTrustedZopeEngine():
 _pt_engine = getPtEngine()
 _ch_engine = getChEngine()
 
+
 def getEngine():
     return _pt_engine if get_template_engine_type() == "pt" else _ch_engine
-

--- a/src/Products/PageTemplates/engine.py
+++ b/src/Products/PageTemplates/engine.py
@@ -17,7 +17,8 @@ from zope.interface import provider
 from zope.pagetemplate.interfaces import IPageTemplateEngine
 from zope.pagetemplate.interfaces import IPageTemplateProgram
 
-from .expression import ZopeEngine, createTrustedZopeEngine
+from .expression import ZopeEngine
+from .expression import createTrustedZopeEngine
 
 
 # Declare Chameleon's repeat dictionary public

--- a/src/Products/PageTemplates/expression.py
+++ b/src/Products/PageTemplates/expression.py
@@ -7,9 +7,9 @@ from ast import parse
 
 from chameleon.astutil import Static
 from chameleon.astutil import Symbol
+from chameleon.codegen import template
 from chameleon.tales import NotExpr
 from chameleon.tales import StringExpr
-from chameleon.codegen import template
 from six import class_types
 
 from AccessControl.ZopeGuards import guarded_apply
@@ -28,7 +28,8 @@ from zExceptions import Unauthorized
 from zope.traversing.adapters import traversePathElement
 from zope.traversing.interfaces import TraversalError
 
-from .Expressions import render, ZopeEngine
+from .Expressions import ZopeEngine
+from .Expressions import render
 
 
 _marker = object()
@@ -168,7 +169,6 @@ class UntrustedPythonExpr(expressions.PythonExpr):
             node.id = 'wrapped_repeat'
         else:
             node = super(UntrustedPythonExpr, self).rewrite(node)
-
         return node
 
     def parse(self, string):
@@ -192,13 +192,13 @@ def createZopeEngine(
         'exists': ExistsExpr,
         'path': PathExpr,
         'provider': ProviderExpr,
-        'nocall': NocallExpr,
-        }):
+        'nocall': NocallExpr}):
     """untrusted TALES engine for `chameleion` template engine."""
     e = ZopeEngine()
     for t, h in expression_types.items():
         e.registerType(t, h)
     return e
+
 
 def createTrustedZopeEngine(
     expression_types={
@@ -208,13 +208,13 @@ def createTrustedZopeEngine(
         'exists': ExistsExpr,
         'path': TrustedPathExpr,
         'provider': ProviderExpr,
-        'nocall': NocallExpr,
-    }):
+        'nocall': NocallExpr}):
     """trusted TALES engine for `chameleion` template engine."""
     return createZopeEngine(expression_types)
 
 
 _engine = createZopeEngine()
+
 
 def getEngine():
     return _engine


### PR DESCRIPTION
This addresses #717 and improved on the current state (sufficiently to allow `Products.TrustedExecutables` to support `chameleon`).

Unfortunately, it is not a complete solution. The reason: the `chameleon` integration is a mess. `chameleon`  requires a specialized TALES implementation, incompatible with a standard `zope` TALES implementation. The integration point is `zope.pagetemplate` but the integration itself is controlled by `Zope`. This PR causes `Zope`'s use of page templates to be aware of a potential template engine switch and use a corresponding TALES implementation. However, there are packages (e.g. `z3c.form`) which directly use `zope.pagetemplate` templates; they are unaware of a template engine switch and provide an inappropriate TALES implementation when a switch to `chameleon` has happened. This PR hacks in this situation: if the provided TALES implementation does not come from `Zope` (and therefore should be template engine switch aware), it is ignored and replaced by a trusted `chameleon` compatible TALES implementation which retained the previous behaviour in this case.

Maybe, an adapter "TALES implementation --> `chameleon` compatible TALES implementation" should be used instead of the above outlined fixed logic? This would allow packages directly using `zope.pagetemplate` to register their own adapters to achieve `chameleon` compatibility.

Ideally, however, `chameleon` should be able to work with a standard TALES implementation and not require something special.