### PR TITLE
Try to hide the docstring restriction a little less.

### DIFF
--- a/docs/zdgbook/Security.rst
+++ b/docs/zdgbook/Security.rst
@@ -38,8 +38,14 @@ determine whether to allow or deny access to a visitor for a
 particular object.  For example, when a user visits the root
 ``index_html`` object of your site via HTTP, the security policy is
 consulted by ``ZPublisher`` to determine whether the user has
-permission to view the ``index_html`` object itself.  For more
-information on this topic, see the chapter on :doc:`ObjectPublishing`.
+permission to view the ``index_html`` object itself.
+
+On top of that, publisher also defines other rules to determine which
+objects can be published. The most important of these is that Objects
+which are published must have a docstring.
+
+For more information on this topic, see the chapter on 
+:doc:`ObjectPublishing`.
 
 
 How The Security Policy Relates to Restricted Code

--- a/docs/zdgbook/Security.rst
+++ b/docs/zdgbook/Security.rst
@@ -40,9 +40,9 @@ particular object.  For example, when a user visits the root
 consulted by ``ZPublisher`` to determine whether the user has
 permission to view the ``index_html`` object itself.
 
-On top of that, publisher also defines other rules to determine which
-objects can be published. The most important of these is that Objects
-which are published must have a docstring.
+On top of that, the publisher also defines other rules to determine
+which objects can be published. The most important of these is that 
+objects which are published must have a docstring.
 
 For more information on this topic, see the chapter on 
 :doc:`ObjectPublishing`.
@@ -135,8 +135,8 @@ In short, the default Zope security policy ensures the following:
   user does not possess a role that has been granted the permission
   in question, access is denied.
 
-- not directly part of the security policy, but also important is the
-  rule, that objects can only be published if they have a doc string. 
+- objects can only be published if they have a doc string. This
+  restriction exists outside the security policy itself. 
 
 
 As we delve further into Zope security within this chapter, we'll see

--- a/docs/zdgbook/Security.rst
+++ b/docs/zdgbook/Security.rst
@@ -135,6 +135,10 @@ In short, the default Zope security policy ensures the following:
   user does not possess a role that has been granted the permission
   in question, access is denied.
 
+- not directly part of the security policy, but also important is the
+  rule, that objects can only be published if they have a doc string. 
+
+
 As we delve further into Zope security within this chapter, we'll see
 exactly what it means to associate security information with an
 object.


### PR DESCRIPTION
As discussed in #770, the "docstring restriction" when publishing objects is not really part of the security policy stuff. But it is at least related, so I decided to mention it in the security chapter in 2 places which are likely to be read.  