### PR TITLE
Improve solidity of the ``debugError`` method (4.x)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ https://zope.readthedocs.io/en/2.13/CHANGES.html
 ------------------
 
 - Update dependencies to newest releases.
+- Improve solidity of the ``debugError`` method.
+  (`#829 <https://github.com/zopefoundation/Zope/issues/829>`_)
 
 
 4.4.2 (2020-04-30)

--- a/src/ZPublisher/HTTPResponse.py
+++ b/src/ZPublisher/HTTPResponse.py
@@ -826,8 +826,11 @@ class HTTPResponse(HTTPBaseResponse):
     def debugError(self, entry):
         raise NotFound(self._error_html(
             "Debugging Notice",
-            ("Zope has encountered a problem publishing your object.<p>"
-             "\n" + entry + "</p>")))
+            (
+                "Zope has encountered a problem publishing your object. "
+                "<p>%r</p>" % entry
+            )
+        ))
 
     def badRequestError(self, name):
         self.setStatus(400)

--- a/src/ZPublisher/tests/testHTTPResponse.py
+++ b/src/ZPublisher/tests/testHTTPResponse.py
@@ -875,7 +875,7 @@ class HTTPResponseTests(unittest.TestCase):
         except NotFound as raised:
             self.assertEqual(response.status, 200)
             self.assertTrue("Zope has encountered a problem publishing "
-                            "your object.<p>\ntesting</p>" in str(raised))
+                            "your object. <p>'testing'</p>" in str(raised))
         else:
             self.fail("Didn't raise NotFound")
 


### PR DESCRIPTION
Backport of #830 to the 4.x branch