### PR TITLE
Increase test coverage and extend the fix for #829 also for the WSGI

### DIFF
--- a/src/ZPublisher/HTTPResponse.py
+++ b/src/ZPublisher/HTTPResponse.py
@@ -782,7 +782,7 @@ class HTTPResponse(HTTPBaseResponse):
             "Debugging Notice",
             (
                 "Zope has encountered a problem publishing your object. "
-                "<p>%r</p>" % entry
+                "<p>%s</p>" % repr(entry)
             )
         ))
 
@@ -950,8 +950,9 @@ class WSGIResponse(HTTPBaseResponse):
         exc = NotFound(entry)
         exc.title = 'Debugging Notice'
         exc.detail = (
-            'Zope has encountered a problem publishing your object.<p>'
-            '\n%s</p>' % entry)
+            "Zope has encountered a problem publishing your object. "
+            "<p>%s</p>" % repr(entry)
+        )
         raise exc
 
     def badRequestError(self, name):

--- a/src/ZPublisher/tests/testHTTPResponse.py
+++ b/src/ZPublisher/tests/testHTTPResponse.py
@@ -872,8 +872,30 @@ class HTTPResponseTests(unittest.TestCase):
             response.debugError('testing')
         except NotFound as raised:
             self.assertEqual(response.status, 200)
-            self.assertTrue("Zope has encountered a problem publishing "
-                            "your object. <p>'testing'</p>" in str(raised))
+            self.assertIn(
+                "Zope has encountered a problem publishing your object. <p>'testing'</p>",  # noqa: E501
+                str(raised),
+            )
+        else:
+            self.fail("Didn't raise NotFound")
+        try:
+            response.debugError(("testing",))
+        except NotFound as raised:
+            self.assertEqual(response.status, 200)
+            self.assertIn(
+                "Zope has encountered a problem publishing your object. <p>(\'testing\',)</p>",  # noqa: E501
+                str(raised),
+            )
+        else:
+            self.fail("Didn't raise NotFound")
+        try:
+            response.debugError(("foo", "bar"))
+        except NotFound as raised:
+            self.assertEqual(response.status, 200)
+            self.assertIn(
+                "Zope has encountered a problem publishing your object. <p>(\'foo\', \'bar\')</p>",  # noqa: E501
+                str(raised),
+            )
         else:
             self.fail("Didn't raise NotFound")
 

--- a/src/ZPublisher/tests/test_WSGIPublisher.py
+++ b/src/ZPublisher/tests/test_WSGIPublisher.py
@@ -19,6 +19,7 @@ import transaction
 from Testing.ZopeTestCase import FunctionalTestCase
 from Testing.ZopeTestCase import ZopeTestCase
 from Testing.ZopeTestCase import user_name
+from zExceptions import NotFound
 from ZODB.POSException import ConflictError
 from zope.interface.common.interfaces import IException
 from zope.publisher.interfaces import INotFound
@@ -171,6 +172,39 @@ class WSGIResponseTests(unittest.TestCase):
         with self.assertRaises(Unauthorized):
             response.exception(info=(Unauthorized, Unauthorized('fail'), None))
         self.assertEqual(_unauthorized._called_with, ((), {}))
+
+    def test_debugError(self):
+        response = self._makeOne()
+        try:
+            response.debugError('testing')
+        except NotFound as raised:
+            self.assertEqual(response.status, 404)
+            self.assertIn(
+                "Zope has encountered a problem publishing your object. <p>'testing'</p>",  # noqa: E501
+                raised.detail,
+            )
+        else:
+            self.fail("Didn't raise NotFound")
+        try:
+            response.debugError(("testing",))
+        except NotFound as raised:
+            self.assertEqual(response.status, 404)
+            self.assertIn(
+                "Zope has encountered a problem publishing your object. <p>(\'testing\',)</p>",  # noqa: E501
+                raised.detail,
+            )
+        else:
+            self.fail("Didn't raise NotFound")
+        try:
+            response.debugError(("foo", "bar"))
+        except NotFound as raised:
+            self.assertEqual(response.status, 404)
+            self.assertIn(
+                "Zope has encountered a problem publishing your object. <p>(\'foo\', \'bar\')</p>",  # noqa: E501
+                raised.detail,
+            )
+        else:
+            self.fail("Didn't raise NotFound")
 
 
 class TestPublish(unittest.TestCase):


### PR DESCRIPTION
Refs. #829

Also takes care of the `WSGIResponse.debugError` method that was not tested at all.