### PR TITLE
Better application/json request support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ https://zope.readthedocs.io/en/2.13/CHANGES.html
 4.4.3 (unreleased)
 ------------------
 
+- Mark requests with ``Accept: application/json`` header as ``zope.publisher.interfaces.http.IJSONRequest`` requests.
 - Update dependencies to newest releases.
 - Improve solidity of the ``debugError`` method.
   (`#829 <https://github.com/zopefoundation/Zope/issues/829>`_)

--- a/src/ZPublisher/HTTPRequest.py
+++ b/src/ZPublisher/HTTPRequest.py
@@ -42,7 +42,7 @@ from zope.interface import directlyProvides
 from zope.interface import implementer
 from zope.publisher.base import DebugFlags
 from zope.publisher.http import splitport
-from zope.publisher.interfaces.browser import IBrowserRequest
+from zope.publisher.interfaces.http import IHTTPRequest
 from ZPublisher import xmlrpc
 from ZPublisher.BaseRequest import BaseRequest
 from ZPublisher.BaseRequest import quote
@@ -109,7 +109,7 @@ class NestedLoopExit(Exception):
     pass
 
 
-@implementer(IBrowserRequest)
+@implementer(IHTTPRequest)
 class HTTPRequest(BaseRequest):
     """ Model HTTP request data.
 

--- a/src/ZPublisher/WSGIPublisher.py
+++ b/src/ZPublisher/WSGIPublisher.py
@@ -35,6 +35,9 @@ from zope.component import queryMultiAdapter
 from zope.event import notify
 from zope.globalrequest import clearRequest
 from zope.globalrequest import setRequest
+from zope.interface import directlyProvides
+from zope.publisher.interfaces.browser import IBrowserRequest
+from zope.publisher.interfaces.http import IJSONRequest
 from zope.publisher.skinnable import setDefaultSkin
 from zope.security.management import endInteraction
 from zope.security.management import newInteraction
@@ -348,6 +351,11 @@ def publish_module(environ, start_response,
             else _request_factory(environ['wsgi.input'],
                                   environ,
                                   new_response))
+
+        if environ.get('HTTP_ACCEPT', None) == 'application/json':
+            directlyProvides(new_request, IJSONRequest)
+        else:
+            directlyProvides(new_request, IBrowserRequest)
 
         for i in range(getattr(new_request, 'retry_max_count', 3) + 1):
             request = new_request


### PR DESCRIPTION
Mark application/json reqeusts with IJSONRequest.

Very early draft for exploring ideas on supporting application/json requests and possibly other type of requests.
Those requests can than explicitly be adapted to.

Related PRs:
https://github.com/zopefoundation/Zope/pull/845
https://github.com/zopefoundation/zope.publisher/pull/53

References the discussion plone.rest and how it intercepts the traversing chain for JSON requests: https://community.plone.org/t/json-application-messaging-in-plone-core/12353