### PR TITLE
Switch to use f-strings.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Configuration file for the Sphinx documentation builder.
 #

--- a/docs/zdgbook/examples/PollImplementation.py
+++ b/docs/zdgbook/examples/PollImplementation.py
@@ -1,7 +1,7 @@
 from Poll import Poll
 
 
-class PollImplementation(object):
+class PollImplementation:
     """
     A multiple choice poll, implements the Poll interface.
 

--- a/src/App/ApplicationManager.py
+++ b/src/App/ApplicationManager.py
@@ -181,7 +181,7 @@ class ApplicationManager(Persistent, Tabs, Traversable, Implicit):
         h = h and ('%d hour%s' % (h, (h != 1 and 's' or ''))) or ''
         m = m and ('%d min' % m) or ''
         s = '%d sec' % s
-        return '%s %s %s %s' % (d, h, m, s)
+        return f'{d} {h} {m} {s}'
 
     def sys_version(self):
         return sys.version
@@ -254,8 +254,7 @@ class AltDatabaseManager(Traversable, UndoSupport):
 
         if REQUEST is not None:
             msg = 'ZODB in-memory caches minimized.'
-            url = '%s/manage_main?manage_tabs_message=%s' % (REQUEST['URL1'],
-                                                             msg)
+            url = f'{REQUEST["URL1"]}/manage_main?manage_tabs_message={msg}'
             REQUEST.RESPONSE.redirect(url)
 
     @requestmethod('POST')
@@ -276,8 +275,7 @@ class AltDatabaseManager(Traversable, UndoSupport):
             msg = 'Invalid days value %s' % str(days)
 
         if REQUEST is not None:
-            url = '%s/manage_main?manage_tabs_message=%s' % (REQUEST['URL1'],
-                                                             msg)
+            url = f'{REQUEST["URL1"]}/manage_main?manage_tabs_message={msg}'
             REQUEST['RESPONSE'].redirect(url)
 
         return t

--- a/src/App/DavLockManager.py
+++ b/src/App/DavLockManager.py
@@ -90,7 +90,7 @@ class DavLockManager(Item, Implicit):
         addresult = result.append
         for id, ob in items:
             if path:
-                p = '%s/%s' % (path, id)
+                p = f'{path}/{id}'
             else:
                 p = id
 

--- a/src/App/Extensions.py
+++ b/src/App/Extensions.py
@@ -55,7 +55,7 @@ def _getPath(home, prefix, name, suffixes):
 
     for suffix in suffixes:
         if suffix:
-            fqn = "%s.%s" % (fn, suffix)
+            fqn = f"{fn}.{suffix}"
         else:
             fqn = fn
         if os.path.exists(fqn):
@@ -138,7 +138,7 @@ def getPath(prefix, name, checkProduct=1, suffixes=('',), cfg=None):
 
             for suffix in suffixes:
                 if suffix:
-                    fn = "%s.%s" % (prefix, suffix)
+                    fn = f"{prefix}.{suffix}"
                 else:
                     fn = prefix
                 if os.path.exists(fn):

--- a/src/App/Management.py
+++ b/src/App/Management.py
@@ -81,7 +81,7 @@ class Tabs(Base):
                 'You are not authorized to view this object.')
 
         if m.find('/'):
-            return REQUEST.RESPONSE.redirect("%s/%s" % (REQUEST['URL1'], m))
+            return REQUEST.RESPONSE.redirect(f"{REQUEST['URL1']}/{m}")
 
         return getattr(self, m)(self, REQUEST)
 
@@ -99,11 +99,11 @@ class Tabs(Base):
             return
         last = steps.pop()
         for step in steps:
-            script = '%s/%s' % (script, step)
+            script = f'{script}/{step}'
             yield {'url': linkpat.format(html.escape(script, True)),
                    'title': html.escape(unquote(step)),
                    'last': False}
-        script = '%s/%s' % (script, last)
+        script = f'{script}/{last}'
         yield {'url': linkpat.format(html.escape(script, True)),
                'title': html.escape(unquote(last)),
                'last': True}
@@ -127,8 +127,8 @@ class Tabs(Base):
         last = path[-1]
         del path[-1]
         for p in path:
-            script = "%s/%s" % (script, quote(p))
-            out.append('<a href="%s/manage_workspace">%s</a>' % (script, p))
+            script = f"{script}/{quote(p)}"
+            out.append(f'<a href="{script}/manage_workspace">{p}</a>')
         out.append(last)
         return '/'.join(out)
 

--- a/src/App/ProductContext.py
+++ b/src/App/ProductContext.py
@@ -172,7 +172,7 @@ class ProductContext:
             # 'action': The action in the add drop down in the ZMI. This is
             #           currently also required by the _verifyObjectPaste
             #           method of CopyContainers like Folders.
-            'action': ('manage_addProduct/%s/%s' % (pid, name)),
+            'action': (f'manage_addProduct/{pid}/{name}'),
             # 'product': product id
             'product': pid,
             # 'permission': Guards the add action.

--- a/src/App/Undo.py
+++ b/src/App/Undo.py
@@ -90,9 +90,9 @@ class UndoSupport(Tabs, Implicit):
                 desc = ' '.join(desc[1:])
                 if len(desc) > 60:
                     desc = desc[:56] + ' ...'
-                tid = "%s %s %s %s" % (encode64(tid), t, d1, desc)
+                tid = f"{encode64(tid)} {t} {d1} {desc}"
             else:
-                tid = "%s %s" % (encode64(tid), t)
+                tid = f"{encode64(tid)} {t}"
             d['id'] = tid
 
         return r

--- a/src/App/version_txt.py
+++ b/src/App/version_txt.py
@@ -61,7 +61,7 @@ def _prep_version_data():
         v = sys.version_info
         pyver = "python %d.%d.%d, %s" % (v[0], v[1], v[2], sys.platform)
         dist = pkg_resources.get_distribution('Zope')
-        _version_string = "%s, %s" % (dist.version, pyver)
+        _version_string = f"{dist.version}, {pyver}"
         _zope_version = _parse_version_data(dist.version)
 
 
@@ -72,7 +72,7 @@ def _parse_version_data(version_string):
     rel = tuple(int(i) for i in version_dict['release'].split('.'))
     micro = rel[2] if len(rel) >= 3 else 0
     if version_dict['pre']:
-        micro = '%s%s' % (micro, version_dict['pre'])
+        micro = f'{micro}{version_dict["pre"]}'
 
     return ZopeVersion(
         rel[0] if len(rel) >= 1 else 0,

--- a/src/OFS/Application.py
+++ b/src/OFS/Application.py
@@ -101,7 +101,7 @@ class Application(ApplicationDefaultPermissions, Folder.Folder, FindSupport):
         # available as url.
         if destination.find('//') >= 0:
             raise RedirectException(destination)
-        raise RedirectException("%s/%s" % (URL1, destination))
+        raise RedirectException(f"{URL1}/{destination}")
 
     ZopeRedirect = Redirect
 
@@ -131,7 +131,7 @@ class Application(ApplicationDefaultPermissions, Folder.Folder, FindSupport):
         # Waaa. unrestrictedTraverse calls us with a fake REQUEST.
         # There is probably a better fix for this.
         try:
-            REQUEST.RESPONSE.notFoundError("%s\n%s" % (name, method))
+            REQUEST.RESPONSE.notFoundError(f"{name}\n{method}")
         except AttributeError:
             raise KeyError(name)
 
@@ -149,11 +149,9 @@ class Application(ApplicationDefaultPermissions, Folder.Folder, FindSupport):
         if major:
             return zversion.major
         else:
-            version = '%s.%s.%s' % (zversion.major,
-                                    zversion.minor,
-                                    zversion.micro)
+            version = f'{zversion.major}.{zversion.minor}.{zversion.micro}'
             if zversion.status:
-                version += '.%s%s' % (zversion.status, zversion.release)
+                version += f'.{zversion.status}{zversion.release}'
 
             return version
 

--- a/src/OFS/CopySupport.py
+++ b/src/OFS/CopySupport.py
@@ -160,7 +160,7 @@ class CopyContainer(Base):
         while 1:
             if self._getOb(id, None) is None:
                 return id
-            id = 'copy%s_of_%s' % (n and n + 1 or '', orig_id)
+            id = 'copy{}_of_{}'.format(n and n + 1 or '', orig_id)
             n = n + 1
 
     def _pasteObjects(self, cp, cb_maxsize=0):

--- a/src/OFS/DTMLDocument.py
+++ b/src/OFS/DTMLDocument.py
@@ -149,6 +149,6 @@ def addDTMLDocument(self, id, title='', file='', REQUEST=None, submit=None):
         except Exception:
             u = REQUEST['URL1']
         if submit == "Add and Edit":
-            u = "%s/%s" % (u, quote(id))
+            u = f"{u}/{quote(id)}"
         REQUEST.RESPONSE.redirect(u + '/manage_main')
     return ''

--- a/src/OFS/DTMLMethod.py
+++ b/src/OFS/DTMLMethod.py
@@ -475,6 +475,6 @@ def addDTMLMethod(self, id, title='', file='', REQUEST=None, submit=None):
         except Exception:
             u = REQUEST['URL1']
         if submit == "Add and Edit":
-            u = "%s/%s" % (u, quote(id))
+            u = f"{u}/{quote(id)}"
         REQUEST.RESPONSE.redirect(u + '/manage_main')
     return ''

--- a/src/OFS/FindSupport.py
+++ b/src/OFS/FindSupport.py
@@ -115,7 +115,7 @@ class FindSupport(Base):
 
         for id, ob in items:
             if pre:
-                p = "%s/%s" % (pre, id)
+                p = f"{pre}/{id}"
             else:
                 p = id
 

--- a/src/OFS/Image.py
+++ b/src/OFS/Image.py
@@ -316,7 +316,7 @@ class File(
                     )
                     RESPONSE.setHeader(
                         'Content-Type',
-                        'multipart/%sbyteranges; boundary=%s' % (
+                        'multipart/{}byteranges; boundary={}'.format(
                             draftprefix,
                             boundary,
                         )
@@ -975,25 +975,25 @@ class Image(File):
 
         if alt is None:
             alt = getattr(self, 'alt', '')
-        result = '%s alt="%s"' % (result, html.escape(alt, True))
+        result = '{} alt="{}"'.format(result, html.escape(alt, True))
 
         if title is None:
             title = getattr(self, 'title', '')
-        result = '%s title="%s"' % (result, html.escape(title, True))
+        result = '{} title="{}"'.format(result, html.escape(title, True))
 
         if height:
-            result = '%s height="%s"' % (result, height)
+            result = f'{result} height="{height}"'
 
         if width:
-            result = '%s width="%s"' % (result, width)
+            result = f'{result} width="{width}"'
 
         if css_class is not None:
-            result = '%s class="%s"' % (result, css_class)
+            result = f'{result} class="{css_class}"'
 
         for key in list(args.keys()):
             value = args.get(key)
             if value:
-                result = '%s %s="%s"' % (result, key, value)
+                result = f'{result} {key}="{value}"'
 
         return '%s />' % result
 

--- a/src/OFS/LockItem.py
+++ b/src/OFS/LockItem.py
@@ -107,7 +107,7 @@ class LockItem(Persistent):
     def getCreatorPath(self):
         db, name = self._creator
         path = '/'.join(db)
-        return "/%s/%s" % (path, name)
+        return f"/{path}/{name}"
 
     @security.public
     def getOwner(self):

--- a/src/OFS/ObjectManager.py
+++ b/src/OFS/ObjectManager.py
@@ -612,20 +612,17 @@ class ObjectManager(
             if RESPONSE is not None:
                 RESPONSE.setHeader('Content-type', 'application/data')
                 RESPONSE.setHeader('Content-Disposition',
-                                   'inline;filename=%s.%s' % (id, suffix))
+                                   f'inline;filename={id}.{suffix}')
             return result
 
-        f = os.path.join(CONFIG.clienthome, '%s.%s' % (id, suffix))
+        f = os.path.join(CONFIG.clienthome, f'{id}.{suffix}')
         with open(f, 'w+b') as fd:
             ob._p_jar.exportFile(ob._p_oid, fd)
 
         if REQUEST is not None:
             return self.manage_main(
                 self, REQUEST,
-                manage_tabs_message='"%s" successfully exported to "%s"' % (
-                    id,
-                    f
-                ),
+                manage_tabs_message=f'"{id}" successfully exported to "{f}"',
                 title='Object exported'
             )
 

--- a/src/OFS/PropertySheets.py
+++ b/src/OFS/PropertySheets.py
@@ -132,7 +132,7 @@ class PropertySheet(Traversable, Persistent, Implicit, DAVPropertySheetMixin):
 
         if id in self.__reserved_ids:
             raise ValueError(
-                "'%s' is a reserved Id (forbidden Ids are: %s) " % (
+                "'{}' is a reserved Id (forbidden Ids are: {}) ".format(
                     id, self.__reserved_ids))
 
         self.id = id

--- a/src/OFS/SimpleItem.py
+++ b/src/OFS/SimpleItem.py
@@ -183,7 +183,7 @@ class Item(
                 id = id.decode(default_encoding)
             if isinstance(title, bytes):
                 title = title.decode(default_encoding)
-        return title and ("%s (%s)" % (title, id)) or id
+        return title and f"{title} ({id})" or id
 
     def this(self):
         # Handy way to talk to ourselves in document templates.
@@ -347,7 +347,7 @@ class Item_w__name__(Item):
         If the title is not blank, then the id is included in parens.
         """
         t = self.title
-        return t and ("%s (%s)" % (t, self.__name__)) or self.__name__
+        return t and f"{t} ({self.__name__})" or self.__name__
 
     def _setId(self, id):
         self.__name__ = id

--- a/src/OFS/absoluteurl.py
+++ b/src/OFS/absoluteurl.py
@@ -76,11 +76,11 @@ class AbsoluteURL(BrowserView):
             raise TypeError(_insufficientContext)
 
         if name:
+            url = "{}/{}".format(
+                base[-1]['url'],
+                quote(name.encode('utf-8'), _safe))
             base += ({'name': name,
-                      'url': ("%s/%s" % (base[-1]['url'],
-                                         quote(name.encode('utf-8'), _safe)))
-                      }, )
-
+                      'url': url}, )
         return base
 
 
@@ -108,8 +108,8 @@ class OFSTraversableAbsoluteURL(BrowserView):
 
         view = getMultiAdapter((container, request), IAbsoluteURL)
         base = tuple(view.breadcrumbs())
-        base += (
-            {'name': name, 'url': ("%s/%s" % (base[-1]['url'], name))},)
+        base += ({'name': name,
+                  'url': "{}/{}".format(base[-1]['url'], name)},)
 
         return base
 

--- a/src/OFS/role.py
+++ b/src/OFS/role.py
@@ -126,7 +126,7 @@ class RoleManager(BaseRoleManager):
             for role in valid_roles:
                 role_name = role
                 role_hash = _string_hash(role_name)
-                if have("permission_%srole_%s" % (permission_hash, role_hash)):
+                if have(f"permission_{permission_hash}role_{role_hash}"):
                     roles.append(role)
             name, value = permissions[ip][:2]
             try:

--- a/src/OFS/tests/testApplication.py
+++ b/src/OFS/tests/testApplication.py
@@ -132,7 +132,7 @@ class ApplicationPublishTests(FunctionalTestCase):
         # These are all aliases.
         for name in ('Redirect', 'ZopeRedirect'):
             response = self.publish(
-                '/{}?destination=http://google.nl'.format(name))
+                f'/{name}?destination=http://google.nl')
             # This should *not* return a 302 Redirect.
             self.assertEqual(response.status, 404)
 

--- a/src/OFS/tests/testCopySupportEvents.py
+++ b/src/OFS/tests/testCopySupportEvents.py
@@ -186,7 +186,7 @@ class TestCopySupportSublocation(EventTest):
         #      relied on between objects.
         if not set(first) == set(second):
             raise self.failureException(
-                msg or '%r != %r' % (first, second))
+                msg or f'{first!r} != {second!r}')
 
     def test_1_Clone(self):
         # Test clone

--- a/src/OFS/tests/testRanges.py
+++ b/src/OFS/tests/testRanges.py
@@ -310,7 +310,7 @@ class TestRequestRange(unittest.TestCase):
         length = len(self.data)
         start, end = length - 100, length + 100
         self.expectMultipleRanges(
-            '3-700,%s-%s' % (start, end),
+            f'3-700,{start}-{end}',
             [(3, 701), (len(self.data) - 100, len(self.data))])
 
     # If-Range headers

--- a/src/OFS/tests/test_event.py
+++ b/src/OFS/tests/test_event.py
@@ -57,7 +57,7 @@ class NotifyBase(DontComplain):
     manage_beforeDelete.__five_method__ = True  # Shut up deprecation warnings
 
     def manage_afterClone(self, item):
-        print('old manage_afterClone {} {}'.format(self.getId(), item.getId()))
+        print(f'old manage_afterClone {self.getId()} {item.getId()}')
         super().manage_afterClone(item)
     manage_afterClone.__five_method__ = True  # Shut up deprecation warnings
 

--- a/src/OFS/tests/test_event.py
+++ b/src/OFS/tests/test_event.py
@@ -44,7 +44,7 @@ class DontComplain:
 class NotifyBase(DontComplain):
 
     def manage_afterAdd(self, item, container):
-        print('old manage_afterAdd %s %s %s' % (
+        print('old manage_afterAdd {} {} {}'.format(
             self.getId(), item.getId(), container.getId()))
         super().manage_afterAdd(item, container)
 
@@ -52,12 +52,12 @@ class NotifyBase(DontComplain):
 
     def manage_beforeDelete(self, item, container):
         super().manage_beforeDelete(item, container)
-        print('old manage_beforeDelete %s %s %s' % (
+        print('old manage_beforeDelete {} {} {}'.format(
             self.getId(), item.getId(), container.getId()))
     manage_beforeDelete.__five_method__ = True  # Shut up deprecation warnings
 
     def manage_afterClone(self, item):
-        print('old manage_afterClone %s %s' % (self.getId(), item.getId()))
+        print('old manage_afterClone {} {}'.format(self.getId(), item.getId()))
         super().manage_afterClone(item)
     manage_afterClone.__five_method__ = True  # Shut up deprecation warnings
 

--- a/src/Products/Five/browser/adding.py
+++ b/src/Products/Five/browser/adding.py
@@ -132,7 +132,7 @@ class Adding(BrowserView):
 
         if queryMultiAdapter((self, self.request),
                              name=view_name) is not None:
-            url = "%s/%s=%s" % (
+            url = "{}/{}={}".format(
                 absoluteURL(self, self.request), type_name, id)
             self.request.response.redirect(url)
             return

--- a/src/Products/Five/browser/metaconfigure.py
+++ b/src/Products/Five/browser/metaconfigure.py
@@ -340,7 +340,7 @@ def resource(_context, name, layer=IDefaultBrowserLayer,
     factory_info = _factory_map.get(res_type)
     factory_info['count'] += 1
     res_factory = factory_info['factory']
-    class_name = '%s%s' % (factory_info['prefix'], factory_info['count'])
+    class_name = f'{factory_info["prefix"]}{factory_info["count"]}'
     new_class = type(class_name, (res_factory.resource,), {})
     factory = res_factory(name, res, resource_factory=new_class)
 
@@ -390,8 +390,8 @@ def resourceDirectory(_context, name, directory, layer=IDefaultBrowserLayer,
             continue
         factory_info = _rd_map.get(factory)
         factory_info['count'] += 1
-        class_name = '%s%s' % (factory_info['prefix'], factory_info['count'])
-        factory_name = '%s%s' % (factory.__name__, factory_info['count'])
+        class_name = f'{factory_info["prefix"]}{factory_info["count"]}'
+        factory_name = f'{factory.__name__}{factory_info["count"]}'
         f_resource = type(class_name, (factory.resource,), {})
         f_cache[factory] = type(factory_name, (factory,),
                                 {'resource': f_resource})
@@ -405,7 +405,7 @@ def resourceDirectory(_context, name, directory, layer=IDefaultBrowserLayer,
 
     factory_info = _rd_map.get(DirectoryResourceFactory)
     factory_info['count'] += 1
-    class_name = '%s%s' % (factory_info['prefix'], factory_info['count'])
+    class_name = f'{factory_info["prefix"]}{factory_info["count"]}'
     dir_factory = type(class_name, (resource,), cdict)
     factory = DirectoryResourceFactory(name, directory,
                                        resource_factory=dir_factory)

--- a/src/Products/Five/browser/resource.py
+++ b/src/Products/Five/browser/resource.py
@@ -50,7 +50,7 @@ class Resource:
         url = unquote(absoluteURL(container, self.request))
         if not isinstance(container, DirectoryResource):
             name = '++resource++%s' % name
-        return "%s/%s" % (url, name)
+        return f"{url}/{name}"
 
 
 @implementer(IBrowserPublisher)

--- a/src/Products/Five/browser/tests/classes.py
+++ b/src/Products/Five/browser/tests/classes.py
@@ -33,4 +33,4 @@ class ViewOne(BrowserView):
     'Yet another class'
 
     def my_method(self, arg1, arg2, kw1=None, kw2='D'):
-        print('CALLED %s %s %s %s' % (arg1, arg2, kw1, kw2))
+        print(f'CALLED {arg1} {arg2} {kw1} {kw2}')

--- a/src/Products/Five/browser/tests/test_scriptsecurity.py
+++ b/src/Products/Five/browser/tests/test_scriptsecurity.py
@@ -14,7 +14,7 @@ def checkRestricted(folder, path, method=''):
     if not method:
         body = '<dtml-call "%s()">' % traverse
     else:
-        body = '<dtml-call "%s.%s()">' % (traverse, method)
+        body = f'<dtml-call "{traverse}.{method}()">'
 
     addDTMLMethod(folder, 'ps', body=body)
     try:
@@ -30,7 +30,7 @@ def checkUnauthorized(folder, path, method=''):
     if not method:
         body = '<dtml-call "%s()">' % traverse
     else:
-        body = '<dtml-call "%s.%s()">' % (traverse, method)
+        body = f'<dtml-call "{traverse}.{method}()">'
     addDTMLMethod(folder, 'ps', body=body)
     try:
         folder.ps(client=folder)

--- a/src/Products/PageTemplates/PageTemplate.py
+++ b/src/Products/PageTemplates/PageTemplate.py
@@ -61,7 +61,7 @@ class PageTemplate(ExtensionClass.Base,
             __traceback_supplement__ = (
                 PageTemplateTracebackSupplement, self, {})
             raise PTRuntimeError(
-                'Page Template %s has errors: %s' % (
+                'Page Template {} has errors: {}'.format(
                     self.id, self._v_errors
                 ))
         return self._v_macros
@@ -114,9 +114,9 @@ class PageTemplate(ExtensionClass.Base,
                         (self._error_start, "%s: %s" % sys.exc_info()[:2],
                          self._text))
 
-        return ('%s\n %s\n-->\n%s' % (self._error_start,
-                                      '\n '.join(self._v_errors),
-                                      self._text))
+        return ('{}\n {}\n-->\n{}'.format(self._error_start,
+                                          '\n '.join(self._v_errors),
+                                          self._text))
 
     # convenience method for the ZMI which allows to explicitly
     # specify the HTMLness of a template. The old Zope 2

--- a/src/Products/PageTemplates/engine.py
+++ b/src/Products/PageTemplates/engine.py
@@ -39,7 +39,7 @@ from .Expressions import PathIterator
 from .Expressions import SecureModuleImporter
 
 
-class _PseudoContext(object):
+class _PseudoContext:
     """auxiliary context object.
 
     Used to bridge between ``chameleon`` and ``zope.tales`` iterators.
@@ -89,7 +89,7 @@ class RepeatItem(PathIterator):
         return self
 
     def __next__(self):
-        if super(RepeatItem, self).__next__():
+        if super().__next__():
             return self.item
         else:
             raise StopIteration
@@ -219,7 +219,7 @@ def _c_context_2_z_context(c_context):
 _c_context_2_z_context_node = Static(Symbol(_c_context_2_z_context))
 
 
-class MappedExpr(object):
+class MappedExpr:
     """map expression: ``zope.tales`` --> ``chameleon.tales``."""
     def __init__(self, type, expression, zt_engine):
         self.type = type
@@ -270,7 +270,7 @@ class MappedExpr(object):
             c2z_context=_c_context_2_z_context_node)
 
 
-class MappedExprType(object):
+class MappedExprType:
     """map expression type: ``zope.tales`` --> ``chameleon.tales``."""
     def __init__(self, engine, type):
         self.engine = engine
@@ -342,8 +342,8 @@ class Program:
 
         if isinstance(engine, ZopeBaseEngine):
             # use ``zope.tales`` expressions
-            expr_types = dict((ty, MappedExprType(engine, ty))
-                              for ty in engine.types)
+            expr_types = {ty: MappedExprType(engine, ty)
+                          for ty in engine.types}
         else:
             # use ``chameleon.tales`` expressions
             expr_types = engine.types

--- a/src/Products/PageTemplates/tests/testChameleonTalesExpressions.py
+++ b/src/Products/PageTemplates/tests/testChameleonTalesExpressions.py
@@ -10,7 +10,7 @@ class ChameleonAqPageTemplate(AqPageTemplate):
 
 class ChameleonTalesExpressionTests(HTMLTests):
     def setUp(self):
-        super(ChameleonTalesExpressionTests, self).setUp()
+        super().setUp()
         # override with templates using chameleon TALES expressions
         self.folder.laf = ChameleonAqPageTemplate()
         self.folder.t = ChameleonAqPageTemplate()

--- a/src/Products/PageTemplates/tests/testErrorHandling.py
+++ b/src/Products/PageTemplates/tests/testErrorHandling.py
@@ -21,11 +21,11 @@ from .util import useChameleonEngine
 
 class ErrorHandlingTests(PlacelessSetup, TestCase):
     def setUp(self):
-        super(ErrorHandlingTests, self).setUp()
+        super().setUp()
         useChameleonEngine()
 
     def test_repr_error_info(self):
-        class WithRepr(object):
+        class WithRepr:
             def __repr__(self):
                 return "with repr"
 

--- a/src/Products/PageTemplates/tests/testExpressions.py
+++ b/src/Products/PageTemplates/tests/testExpressions.py
@@ -1,5 +1,3 @@
-# *-* coding: iso-8859-1 -*-
-
 import unittest
 
 from zope.component.testing import PlacelessSetup
@@ -22,13 +20,13 @@ class EngineTestsBase(PlacelessSetup):
 
     def _makeContext(self, bindings=None):
 
-        class Dummy(object):
+        class Dummy:
             __allow_access_to_unprotected_subobjects__ = 1
 
             def __call__(self):
                 return 'dummy'
 
-        class DummyDocumentTemplate(object):
+        class DummyDocumentTemplate:
             __allow_access_to_unprotected_subobjects__ = 1
             isDocTemp = True
 
@@ -87,7 +85,7 @@ class EngineTestsBase(PlacelessSetup):
         self.assertEqual(ec.evaluate('dummy'), 'dummy')
 
     def test_evaluate_with_unimplemented_call(self):
-        class Dummy(object):
+        class Dummy:
             def __call__(self):
                 raise NotImplementedError()
 
@@ -183,7 +181,7 @@ class EngineTestsBase(PlacelessSetup):
         # 8-bit strings in unicode string expressions cause UnicodeDecodeErrors
         eng = self._makeEngine()
         ec = self._makeContext()
-        expr = eng.compile(u'string:$eightbit')
+        expr = eng.compile('string:$eightbit')
         self.assertRaises(UnicodeDecodeError,
                           ec.evaluate, expr)
         # But registering an appropriate IUnicodeEncodingConflictResolver
@@ -195,7 +193,7 @@ class EngineTestsBase(PlacelessSetup):
             import IUnicodeEncodingConflictResolver
         provideUtility(StrictUnicodeEncodingConflictResolver,
                        IUnicodeEncodingConflictResolver)
-        self.assertEqual(ec.evaluate(expr), u'äüö')
+        self.assertEqual(ec.evaluate(expr), 'Ã¤Ã¼Ã¶')
 
 
 class UntrustedEngineTests(EngineTestsBase, unittest.TestCase):
@@ -241,7 +239,7 @@ class UnicodeEncodingConflictResolverTests(PlacelessSetup, unittest.TestCase):
         provideUtility(StrictUnicodeEncodingConflictResolver,
                        IUnicodeEncodingConflictResolver)
         resolver = getUtility(IUnicodeEncodingConflictResolver)
-        text = u'\xe4\xfc\xe4'
+        text = '\xe4\xfc\xe4'
         self.assertEqual(resolver.resolve(None, text, None), text)
 
     def testIgnoringResolver(self):
@@ -267,7 +265,7 @@ class UnicodeEncodingConflictResolverTests(PlacelessSetup, unittest.TestCase):
                        IUnicodeEncodingConflictResolver)
         resolver = getUtility(IUnicodeEncodingConflictResolver)
         self.assertEqual(resolver.resolve(None, b'\xe4\xfc\xf6', None),
-                         u'\ufffd\ufffd\ufffd')
+                         '\ufffd\ufffd\ufffd')
 
 
 class ZopeContextTests(unittest.TestCase):
@@ -284,7 +282,7 @@ class ZopeContextTests(unittest.TestCase):
         return self._getTargetClass()(engine, contexts)
 
     def _makeEngine(self):
-        class DummyEngine(object):
+        class DummyEngine:
             pass
         return DummyEngine()
 

--- a/src/Products/PageTemplates/tests/testZopeTalesExpressions.py
+++ b/src/Products/PageTemplates/tests/testZopeTalesExpressions.py
@@ -10,12 +10,12 @@ class ZopeTalesExpressionTests(HTMLTests):
     is cleared at the start and end of each test.
     """
     def setUp(self):
-        super(ZopeTalesExpressionTests, self).setUp()
+        super().setUp()
         _zt_expr_registry.clear()
 
     def tearDown(self):
         _zt_expr_registry.clear()
-        super(ZopeTalesExpressionTests, self).tearDown()
+        super().tearDown()
 
     def testCaching(self):
         self.test_2()  # fill the cache

--- a/src/Products/PageTemplates/tests/test_persistenttemplate.py
+++ b/src/Products/PageTemplates/tests/test_persistenttemplate.py
@@ -90,7 +90,7 @@ python_path_source = """
 
 
 def generate_capture_source(names):
-    params = ", ".join("%s=%s" % (name, name)
+    params = ", ".join(f"{name}={name}"
                        for name in names)
     return options_capture_update_base % (params,)
 

--- a/src/Products/PageTemplates/tests/test_ptfile.py
+++ b/src/Products/PageTemplates/tests/test_ptfile.py
@@ -127,7 +127,7 @@ class TypeSniffingTestCase(unittest.TestCase):
         pt_id = pt.getId()
         self.assertEqual(
             pt_id, desired_id,
-            'getId() returned %r. Expecting %r' % (pt_id, desired_id)
+            f'getId() returned {pt_id!r}. Expecting {desired_id!r}'
         )
 
     def test_getPhysicalPath(self):
@@ -140,9 +140,8 @@ class TypeSniffingTestCase(unittest.TestCase):
         pt_path = pt.getPhysicalPath()
         self.assertEqual(
             pt_path, desired_path,
-            'getPhysicalPath() returned %r. Expecting %r' % (
-                desired_path, pt_path,
-            )
+            f'getPhysicalPath() returned {desired_path!r}.'
+            f' Expecting {pt_path!r}'
         )
 
 

--- a/src/Products/SiteAccess/VirtualHostMonster.py
+++ b/src/Products/SiteAccess/VirtualHostMonster.py
@@ -105,7 +105,7 @@ class VirtualHostMonster(Persistent, Item, Implicit):
                     host_map[hostname] = {}
                 host_map[hostname][port] = pp
             except ValueError as msg:
-                line = '%s #! %s' % (line, msg)
+                line = f'{line} #! {msg}'
             new_lines.append(line)
         self.lines = tuple(new_lines)
         self.have_map = bool(fixed_map or sub_map)  # booleanize
@@ -263,7 +263,7 @@ def manage_addVirtualHostMonster(self, id=None, REQUEST=None, **ignored):
     if REQUEST is not None:
         goto = '%s/manage_main' % self.absolute_url()
         qs = 'manage_tabs_message=Virtual+Host+Monster+added.'
-        REQUEST['RESPONSE'].redirect('%s?%s' % (goto, qs))
+        REQUEST['RESPONSE'].redirect(f'{goto}?{qs}')
 
 
 constructors = (

--- a/src/Products/SiteAccess/tests/testVirtualHostMonster.py
+++ b/src/Products/SiteAccess/tests/testVirtualHostMonster.py
@@ -140,7 +140,7 @@ def gen_cases():
 
 for i, (vaddr, vr, _vh, p, ubase) in enumerate(gen_cases()):
     def test(self, vaddr=vaddr, vr=vr, _vh=_vh, p=p, ubase=ubase):
-        ob = self.traverse('%s/%s/' % (vaddr, p))
+        ob = self.traverse(f'{vaddr}/{p}/')
         sl_vh = (_vh and ('/' + _vh))
         aup = sl_vh + (p and ('/' + p))
         self.assertEqual(ob.absolute_url_path(), aup)

--- a/src/Shared/DC/Scripts/Bindings.py
+++ b/src/Shared/DC/Scripts/Bindings.py
@@ -127,7 +127,7 @@ class NameAssignments:
             if name in asgns:
                 assigned_name = asgns[name]
                 assigned_names.append(assigned_name)
-                exprtext.append('"%s":%s,' % (assigned_name, expr))
+                exprtext.append(f'"{assigned_name}":{expr},')
         text = '{%s}' % ''.join(exprtext)
         return self._generateCodeBlock(text, assigned_names)
 

--- a/src/Shared/DC/Scripts/Script.py
+++ b/src/Shared/DC/Scripts/Script.py
@@ -51,8 +51,8 @@ class Script(SimpleItem, BindingsUI):
         vv = []
         for argvar in argvars:
             if argvar.value:
-                vv.append("%s=%s" % (quote(argvar.name), quote(argvar.value)))
-        raise Redirect("%s?%s" % (REQUEST['URL1'], '&'.join(vv)))
+                vv.append(f"{quote(argvar.name)}={quote(argvar.value)}")
+        raise Redirect(f"{REQUEST['URL1']}?{'&'.join(vv)}")
 
     from .Signature import _setFuncSignature
 

--- a/src/Testing/ZopeTestCase/testFunctional.py
+++ b/src/Testing/ZopeTestCase/testFunctional.py
@@ -39,7 +39,7 @@ class TestFunctional(ZopeTestCase.FunctionalTestCase):
 
     def afterSetUp(self):
         self.folder_path = '/' + self.folder.absolute_url(1)
-        self.basic_auth = '%s:%s' % (user_name, user_password)
+        self.basic_auth = f'{user_name}:{user_password}'
 
         # A simple document
         self.folder.addDTMLDocument('index_html', file=b'index')

--- a/src/Testing/ZopeTestCase/zopedoctest/functional.py
+++ b/src/Testing/ZopeTestCase/zopedoctest/functional.py
@@ -76,7 +76,7 @@ class HTTPHeaderOutput:
         out = ["%s: %s" % header for header in self.headers.items()]
         out.extend(["%s: %s" % header for header in self.headersl])
         out.sort()
-        out.insert(0, "%s %s %s" % (self.protocol, self.status, self.reason))
+        out.insert(0, f"{self.protocol} {self.status} {self.reason}")
         return '\n'.join(out)
 
 
@@ -93,7 +93,7 @@ class DocResponseWrapper(ResponseWrapper):
     def __str__(self):
         body = self._decode(self.getBody())
         if body:
-            return "%s\n\n%s" % (self.header_output, body)
+            return f"{self.header_output}\n\n{body}"
         return "%s\n" % (self.header_output)
 
 

--- a/src/Testing/tests/test_testbrowser.py
+++ b/src/Testing/tests/test_testbrowser.py
@@ -54,7 +54,7 @@ class TestTestbrowser(FunctionalTestCase):
 
     def test_auth(self):
         # Based on Testing.ZopeTestCase.testFunctional
-        basic_auth = '%s:%s' % (user_name, user_password)
+        basic_auth = f'{user_name}:{user_password}'
         self.folder.addDTMLDocument('secret_html', file='secret')
         self.folder.secret_html.manage_permission(view, ['Owner'])
         path = '/' + self.folder.absolute_url(1) + '/secret_html'

--- a/src/ZPublisher/BaseRequest.py
+++ b/src/ZPublisher/BaseRequest.py
@@ -509,7 +509,7 @@ class BaseRequest:
                         break
                 step = quote(entry_name)
                 _steps.append(step)
-                request['URL'] = URL = '%s/%s' % (request['URL'], step)
+                request['URL'] = URL = f'{request["URL"]}/{step}'
 
                 try:
                     subobject = self.traverseName(object, entry_name)

--- a/src/ZPublisher/BaseResponse.py
+++ b/src/ZPublisher/BaseResponse.py
@@ -104,7 +104,7 @@ class BaseResponse:
         return bytes(self.body)
 
     def __repr__(self):
-        return '%s(%r)' % (self.__class__.__name__, self.body)
+        return f'{self.__class__.__name__}({self.body!r})'
 
     def flush(self):
         pass

--- a/src/ZPublisher/BeforeTraverse.py
+++ b/src/ZPublisher/BeforeTraverse.py
@@ -110,7 +110,7 @@ class MultiHook:
             try:
                 cob(container, request)
             except TypeError:
-                LOG.error('%r call %r failed.' % (
+                LOG.error('{!r} call {!r} failed.'.format(
                     self._hookname, cob), exc_info=True)
 
     def add(self, cob):

--- a/src/ZPublisher/HTTPRequest.py
+++ b/src/ZPublisher/HTTPRequest.py
@@ -202,8 +202,8 @@ class HTTPRequest(BaseRequest):
         if (port is None or default_port[protocol] == port):
             host = hostname
         else:
-            host = '{}:{}'.format(hostname, port)
-        server_url = other['SERVER_URL'] = '%s://%s' % (protocol, host)
+            host = f'{hostname}:{port}'
+        server_url = other['SERVER_URL'] = f'{protocol}://{host}'
         self._resetURLS()
         return server_url
 
@@ -410,13 +410,13 @@ class HTTPRequest(BaseRequest):
             server_url = server_url[:-1]
 
         if b:
-            self.base = "%s/%s" % (server_url, b)
+            self.base = f"{server_url}/{b}"
         else:
             self.base = server_url
         while script[:1] == '/':
             script = script[1:]
         if script:
-            script = "%s/%s" % (server_url, script)
+            script = f"{server_url}/{script}"
         else:
             script = server_url
         other['URL'] = self.script = script
@@ -1155,7 +1155,7 @@ class HTTPRequest(BaseRequest):
                     path = path[:-1]
             else:
                 path = ''
-            other['PATH_INFO'] = "%s/%s" % (path, meth)
+            other['PATH_INFO'] = f"{path}/{meth}"
             self._hacked_path = 1
 
     def resolve_url(self, url):
@@ -1497,7 +1497,7 @@ class HTTPRequest(BaseRequest):
         return result + "</table>"
 
     def __repr__(self):
-        return "<%s, URL=%s>" % (self.__class__.__name__, self.get('URL'))
+        return "<{}, URL={}>".format(self.__class__.__name__, self.get('URL'))
 
     def text(self):
         result = "FORM\n\n"
@@ -1781,7 +1781,7 @@ class record:
     def __repr__(self):
         # return repr( self.__dict__ )
         return '{%s}' % ', '.join(
-            "'%s': %s" % (item[0], repr(item[1])) for item in
+            "'{}': {!r}".format(*item) for item in
             sorted(self.__dict__.items()))
 
     def __eq__(self, other):

--- a/src/ZPublisher/HTTPResponse.py
+++ b/src/ZPublisher/HTTPResponse.py
@@ -301,7 +301,7 @@ class HTTPBaseResponse(BaseResponse):
         else:
             cookie = cookies[name] = {}
         if 'value' in cookie:
-            cookie['value'] = '%s:%s' % (cookie['value'], value)
+            cookie['value'] = '{}:{}'.format(cookie['value'], value)
         else:
             cookie['value'] = value
 
@@ -383,7 +383,7 @@ class HTTPBaseResponse(BaseResponse):
         headers = self.headers
         if name in headers:
             h = headers[name]
-            h = "%s%s%s" % (h, delimiter, value)
+            h = f"{h}{delimiter}{value}"
         else:
             h = value
         self.setHeader(name, h, scrubbed=True)
@@ -524,15 +524,14 @@ class HTTPBaseResponse(BaseResponse):
 
         if content_type is None:
             if self.isHTML(body):
-                content_type = 'text/html; charset=%s' % self.charset
+                content_type = f'text/html; charset={self.charset}'
             else:
-                content_type = 'text/plain; charset=%s' % self.charset
+                content_type = f'text/plain; charset={self.charset}'
             self.setHeader('content-type', content_type)
         else:
             if content_type.startswith('text/') and \
                'charset=' not in content_type:
-                content_type = '%s; charset=%s' % (content_type,
-                                                   self.charset)
+                content_type = f'{content_type}; charset={self.charset}'
                 self.setHeader('content-type', content_type)
 
         self.setHeader('content-length', len(self.body))
@@ -644,21 +643,21 @@ class HTTPBaseResponse(BaseResponse):
             # of name=value pairs may be quoted.
 
             if attrs.get('quoted', True):
-                cookie = '%s="%s"' % (name, quote(attrs['value']))
+                cookie = '{}="{}"'.format(name, quote(attrs['value']))
             else:
-                cookie = '%s=%s' % (name, quote(attrs['value']))
+                cookie = '{}={}'.format(name, quote(attrs['value']))
             for name, v in attrs.items():
                 name = name.lower()
                 if name == 'expires':
-                    cookie = '%s; Expires=%s' % (cookie, v)
+                    cookie = f'{cookie}; Expires={v}'
                 elif name == 'domain':
-                    cookie = '%s; Domain=%s' % (cookie, v)
+                    cookie = f'{cookie}; Domain={v}'
                 elif name == 'path':
-                    cookie = '%s; Path=%s' % (cookie, v)
+                    cookie = f'{cookie}; Path={v}'
                 elif name == 'max_age':
-                    cookie = '%s; Max-Age=%s' % (cookie, v)
+                    cookie = f'{cookie}; Max-Age={v}'
                 elif name == 'comment':
-                    cookie = '%s; Comment=%s' % (cookie, v)
+                    cookie = f'{cookie}; Comment={v}'
                 elif name == 'secure' and v:
                     cookie = '%s; Secure' % cookie
                 # Some browsers recognize this cookie attribute
@@ -670,7 +669,7 @@ class HTTPBaseResponse(BaseResponse):
                 # providing some protection against CSRF attacks
                 # https://tools.ietf.org/html/draft-west-first-party-cookies-07
                 elif name == 'same_site' and v:
-                    cookie = '%s; SameSite=%s' % (cookie, v)
+                    cookie = f'{cookie}; SameSite={v}'
             cookie_list.append(('Set-Cookie', cookie))
 
         # Should really check size of cookies here!
@@ -1009,7 +1008,7 @@ class WSGIResponse(HTTPBaseResponse):
         if content_length is None and not self._streaming:
             self.setHeader('content-length', len(self.body))
 
-        return '%s %s' % (self.status, self.errmsg), self.listHeaders()
+        return f'{self.status} {self.errmsg}', self.listHeaders()
 
     def listHeaders(self):
         result = []

--- a/src/ZPublisher/tests/testHTTPRangeSupport.py
+++ b/src/ZPublisher/tests/testHTTPRangeSupport.py
@@ -29,7 +29,7 @@ class TestRangeHeaderParse(unittest.TestCase):
         result = parseRange(header)
         self.assertTrue(
             result == sets,
-            'Expected %r, got %r' % (sets, result))
+            f'Expected {sets!r}, got {result!r}')
 
     # Syntactically incorrect headers
     def testGarbage(self):
@@ -87,7 +87,7 @@ class TestExpandRanges(unittest.TestCase):
         result = expandRanges(sets, size)
         self.assertTrue(
             result == expect,
-            'Expected %r, got %r' % (expect, result))
+            f'Expected {expect!r}, got {result!r}')
 
     def testExpandOpenEnd(self):
         self.expectSets([(1, 2), (5, None)], 50, [(1, 2), (5, 50)])

--- a/src/ZPublisher/tests/testHTTPRequest.py
+++ b/src/ZPublisher/tests/testHTTPRequest.py
@@ -79,7 +79,7 @@ class RecordTests(unittest.TestCase):
         rec = self._makeOne()
         rec.a = b'foo'
         rec.b = 8
-        rec.c = u'bar'
+        rec.c = 'bar'
         self.assertIsInstance(str(rec), str)
 
     def test_str(self):
@@ -145,7 +145,7 @@ class HTTPRequestTests(unittest.TestCase, HTTPRequestFactoryMixin):
         query_string = []
         add = query_string.append
         for key, val in inputs:
-            add("%s=%s" % (quote_plus(key), quote_plus(val)))
+            add("{}={}".format(quote_plus(key), quote_plus(val)))
         query_string = '&'.join(query_string)
 
         env = {'SERVER_NAME': 'testingharnas', 'SERVER_PORT': '80'}

--- a/src/ZPublisher/tests/test_WSGIPublisher.py
+++ b/src/ZPublisher/tests/test_WSGIPublisher.py
@@ -492,7 +492,7 @@ class TestPublishModule(ZopeTestCase):
             def read(self):
                 return self.data
 
-        class Wrapper(object):
+        class Wrapper:
             def __init__(self, file):
                 self.file = file
 
@@ -527,7 +527,7 @@ class TestPublishModule(ZopeTestCase):
             def read(self):
                 return self.data
 
-        class Wrapper(object):
+        class Wrapper:
             def __init__(self, file):
                 self.file = file
 
@@ -556,13 +556,13 @@ class TestPublishModule(ZopeTestCase):
         from ZPublisher.HTTPResponse import WSGIResponse
 
         @implementer(IStreamIterator)
-        class TestStreamIterator(object):
+        class TestStreamIterator:
             data = "hello" * 20
 
             def __len__(self):
                 return len(self.data)
 
-        class Wrapper(object):
+        class Wrapper:
             def __init__(self, file):
                 self.file = file
 
@@ -988,7 +988,7 @@ class CustomExceptionView:
         self.request = request
 
     def __call__(self):
-        return ('Exception View: %s\nContext: %s' % (
+        return ('Exception View: {}\nContext: {}'.format(
                 self.context.__class__.__name__,
                 self.__parent__.__class__.__name__))
 

--- a/src/ZPublisher/tests/test_mapply.py
+++ b/src/ZPublisher/tests/test_mapply.py
@@ -60,7 +60,7 @@ class MapplyTests(unittest.TestCase):
 
         class CallableObject:
             def __call__(self, a, b):
-                return '%s%s' % (a, b)
+                return f'{a}{b}'
 
         class Container:
             __call__ = CallableObject()

--- a/src/ZPublisher/tests/test_pubevents.py
+++ b/src/ZPublisher/tests/test_pubevents.py
@@ -181,7 +181,7 @@ class ExceptionView:
     def __call__(self):
         global_request = getRequest()
         self.request.response.events.append('exc_view')
-        return ('Exception: %s\nRequest: %r' % (
+        return ('Exception: {}\nRequest: {!r}'.format(
             self.context.__class__, global_request))
 
 
@@ -241,7 +241,7 @@ class TestGlobalRequestPubEventsAndExceptionUpgrading(FunctionalTestCase):
         self.folder.addDTMLDocument('index_html', file='index')
         response = self.publish(
             self.folder.absolute_url_path(),
-            basic='%s:%s' % (user_name, user_password))
+            basic=f'{user_name}:{user_password}')
         self.assertEqual(response.getStatus(), 200)
         self.assertEqual(response._response.events,
                          ['PubStart', 'PubAfterTraversal',

--- a/src/ZPublisher/xmlrpc.py
+++ b/src/ZPublisher/xmlrpc.py
@@ -188,7 +188,7 @@ class Response:
                 from traceback import format_exception
                 value = '\n' + ''.join(format_exception(t, vstr, tb))
             else:
-                value = '%s - %s' % (t, vstr)
+                value = f'{t} - {vstr}'
             if isinstance(v, Fault):
                 f = v
             elif isinstance(v, Exception):

--- a/src/ZTUtils/Zope.py
+++ b/src/ZTUtils/Zope.py
@@ -70,7 +70,7 @@ class LazyFilter(Lazy):
                 except Unauthorized as vv:
                     if skip is None:
                         self._eindex = e
-                        msg = '(item %s): %s' % (index, vv)
+                        msg = f'(item {index}): {vv}'
                         raise Unauthorized(msg)
                     skip_this = 1
                 else:
@@ -208,7 +208,7 @@ def make_query(*args, **kwargs):
     qlist = complex_marshal(list(d.items()))
     for i in range(len(qlist)):
         k, m, v = qlist[i]
-        qlist[i] = '%s%s=%s' % (quote(k), m, quote(str(v)))
+        qlist[i] = '{}{}={}'.format(quote(k), m, quote(str(v)))
 
     return '&'.join(qlist)
 
@@ -272,11 +272,11 @@ def complex_marshal(pairs):
                 if isinstance(sv, list):
                     for ssv in sv:
                         sm = simple_marshal(ssv)
-                        sublist.append(('%s.%s' % (k, sk),
+                        sublist.append((f'{k}.{sk}',
                                         '%s:list:record' % sm, ssv))
                 else:
                     sm = simple_marshal(sv)
-                    sublist.append(('%s.%s' % (k, sk), '%s:record' % sm, sv))
+                    sublist.append((f'{k}.{sk}', '%s:record' % sm, sv))
         elif isinstance(v, list):
             sublist = []
             for sv in v:
@@ -301,7 +301,7 @@ def simple_marshal(v):
     if isinstance(v, str):
         # Py 2 only
         encoding = _default_encoding()
-        return ':%s:ustring' % (encoding,)
+        return f':{encoding}:ustring'
     if isinstance(v, bool):
         return ':boolean'
     if isinstance(v, int):
@@ -350,4 +350,4 @@ def url_query(request, req_name="URL", omit=None):
         qs = '&'.join([part for part in qsparts if part])
 
     # We always append '?' since arguments will be appended to the URL
-    return '%s?%s' % (base, qs)
+    return f'{base}?{qs}'

--- a/src/Zope2/Startup/datatypes.py
+++ b/src/Zope2/Startup/datatypes.py
@@ -72,7 +72,7 @@ def importable_name(name):
         IO = io.StringIO()
         traceback.print_exc(file=IO)
         raise ValueError(
-            'The object named by "%s" could not be imported\n%s' % (
+            'The object named by "{}" could not be imported\n{}'.format(
                 name, IO.getvalue()))
 
 

--- a/src/Zope2/Startup/tests/test_schema.py
+++ b/src/Zope2/Startup/tests/test_schema.py
@@ -161,13 +161,13 @@ class WSGIStartupTestCase(unittest.TestCase):
                          '0')
 
     def test_webdav_source_port(self):
-        conf, handler = self.load_config_text(u"""\
+        conf, handler = self.load_config_text("""\
             instancehome <<INSTANCE_HOME>>
             """)
         handleWSGIConfig(None, handler)
         self.assertEqual(conf.webdav_source_port, 0)
 
-        conf, handler = self.load_config_text(u"""\
+        conf, handler = self.load_config_text("""\
             instancehome <<INSTANCE_HOME>>
             webdav-source-port 9800
             """)

--- a/src/Zope2/utilities/zconsole.py
+++ b/src/Zope2/utilities/zconsole.py
@@ -30,7 +30,7 @@ def debug(zopeconf):
 
 
 def debug_console(zopeconf):
-    cmd = '{} -i -c "import sys; sys.path={}; from Zope2.utilities.zconsole import debug; app = debug(\\\"{}\\\")"'.format(sys.executable, sys.path, zopeconf)  # noqa: E501
+    cmd = f'{sys.executable} -i -c "import sys; sys.path={sys.path}; from Zope2.utilities.zconsole import debug; app = debug(\\\"{zopeconf}\\\")"'  # noqa: E501
     os.system(cmd)
 
 

--- a/src/webdav/PropertySheet.py
+++ b/src/webdav/PropertySheet.py
@@ -22,7 +22,7 @@ def xml_escape(value):
     return escape(value)
 
 
-class DAVPropertySheetMixin(object):
+class DAVPropertySheetMixin:
 
     propstat = ('<d:propstat xmlns:n="%s">\n'
                 '  <d:prop>\n'
@@ -57,7 +57,7 @@ class DAVPropertySheetMixin(object):
                 attrs = ''
                 if not hasattr(self, "dav__" + name):
                     value = xml_escape(value)
-            prop = '  <n:%s%s>%s</n:%s>' % (name, attrs, value, name)
+            prop = f'  <n:{name}{attrs}>{value}</n:{name}>'
 
             result.append(prop)
         if not result:
@@ -85,7 +85,7 @@ class DAVPropertySheetMixin(object):
         propdict = self._propdict()
         if name not in propdict:
             if xml_id:
-                prop = '<n:%s xmlns:n="%s"/>\n' % (name, xml_id)
+                prop = f'<n:{name} xmlns:n="{xml_id}"/>\n'
             else:
                 prop = '<%s xmlns=""/>\n' % name
             code = '404 Not Found'
@@ -115,11 +115,10 @@ class DAVPropertySheetMixin(object):
                 if not hasattr(self, 'dav__%s' % name):
                     value = xml_escape(value)
             if xml_id:
-                prop = '<n:%s%s xmlns:n="%s">%s</n:%s>\n' % (
+                prop = '<n:{}{} xmlns:n="{}">{}</n:{}>\n'.format(
                     name, attrs, xml_id, value, name)
             else:
-                prop = '<%s%s xmlns="">%s</%s>\n' % (
-                    name, attrs, value, name)
+                prop = f'<{name}{attrs} xmlns="">{value}</{name}>\n'
             code = '200 OK'
             if code not in result:
                 result[code] = [prop]

--- a/src/webdav/PropertySheets.py
+++ b/src/webdav/PropertySheets.py
@@ -139,7 +139,7 @@ class DAVProperties(Virtual, PropertySheet, View):
                 else:
                     fake = 1
 
-                out = '%s\n%s' % (
+                out = '{}\n{}'.format(
                     out, lock.asLockDiscoveryProperty('n', fake=fake))
 
             out = '%s\n' % out

--- a/src/webdav/common.py
+++ b/src/webdav/common.py
@@ -115,7 +115,7 @@ ListItem = re.compile(
     re.I)
 
 
-class TagList(object):
+class TagList:
     def __init__(self):
         self.resource = None
         self.list = []

--- a/src/webdav/davcmds.py
+++ b/src/webdav/davcmds.py
@@ -61,7 +61,7 @@ class DAVProps(DAVProperties):
     p_self = v_self
 
 
-class PropFind(object):
+class PropFind:
     """Model a PROPFIND request."""
 
     def __init__(self, request):
@@ -145,7 +145,7 @@ class PropFind(object):
                 if ps is not None and hasattr(aq_base(ps), 'dav__propstat'):
                     ps.dav__propstat(name, rdict)
                 else:
-                    prop = '<n:%s xmlns:n="%s"/>' % (name, ns)
+                    prop = f'<n:{name} xmlns:n="{ns}"/>'
                     code = '404 Not Found'
                     if code not in rdict:
                         rdict[code] = [prop]
@@ -187,7 +187,7 @@ class PropFind(object):
         return result.getvalue()
 
 
-class PropPatch(object):
+class PropPatch:
     """Model a PROPPATCH request."""
 
     def __init__(self, request):
@@ -306,7 +306,7 @@ class PropPatch(object):
         return result
 
 
-class Lock(object):
+class Lock:
     """Model a LOCK request."""
 
     def __init__(self, request):
@@ -433,7 +433,7 @@ class Lock(object):
         return token, result.getvalue()
 
 
-class Unlock(object):
+class Unlock:
     """ Model an Unlock request """
 
     def apply(self, obj, token, url=None, result=None, top=1):
@@ -499,7 +499,7 @@ class Unlock(object):
         return result.getvalue()
 
 
-class DeleteCollection(object):
+class DeleteCollection:
     """ With WriteLocks in the picture, deleting a collection involves
     checking *all* descendents (deletes on collections are always of depth
     infinite) for locks and if the locks match. """

--- a/src/webdav/interfaces.py
+++ b/src/webdav/interfaces.py
@@ -26,11 +26,11 @@ class IDAVResource(IWriteLock):
     """Provide basic WebDAV support for non-collection objects."""
 
     __dav_resource__ = Bool(
-        title=u"Is DAV resource")
+        title="Is DAV resource")
 
     __http_methods__ = Tuple(
-        title=u"HTTP methods",
-        description=u"Sequence of valid HTTP methods")
+        title="HTTP methods",
+        description="Sequence of valid HTTP methods")
 
     def dav__init(request, response):
         """Init expected HTTP 1.1 / WebDAV headers which are not
@@ -124,8 +124,8 @@ class IDAVCollection(IDAVResource):
     than those for non-collection resources."""
 
     __dav_collection__ = Bool(
-        title=u"Is a DAV collection",
-        description=u"Should be true")
+        title="Is a DAV collection",
+        description="Should be true")
 
     def PUT(REQUEST, RESPONSE):
         """The PUT method has no inherent meaning for collection

--- a/src/webdav/tests/testCopySupportEvents.py
+++ b/src/webdav/tests/testCopySupportEvents.py
@@ -17,7 +17,7 @@ from zope.testing import cleanup
 Zope2.startup_wsgi()
 
 
-class EventLogger(object):
+class EventLogger:
     def __init__(self):
         self.reset()
 
@@ -59,7 +59,7 @@ class TestFolder(Folder):
         pass  # Always allow
 
 
-class EventLayer(object):
+class EventLayer:
 
     @classmethod
     def setUp(cls):
@@ -182,7 +182,7 @@ class TestCopySupportSublocation(EventTest):
         #      relied on between objects.
         if not set(first) == set(second):
             raise self.failureException(
-                (msg or '%r != %r' % (first, second)))
+                msg or f'{first!r} != {second!r}')
 
     def test_5_COPY(self):
         # Test COPY

--- a/src/webdav/tests/testCopySupportHooks.py
+++ b/src/webdav/tests/testCopySupportHooks.py
@@ -15,7 +15,7 @@ from zope.testing import cleanup
 Zope2.startup_wsgi()
 
 
-class EventLogger(object):
+class EventLogger:
     def __init__(self):
         self.reset()
 
@@ -66,7 +66,7 @@ class TestFolder(Folder):
         Folder.manage_beforeDelete(self, item, container)
 
 
-class HookLayer(object):
+class HookLayer:
 
     @classmethod
     def setUp(cls):

--- a/src/webdav/tests/testNullResource.py
+++ b/src/webdav/tests/testNullResource.py
@@ -30,7 +30,7 @@ class TestNullResource(unittest.TestCase):
         from zExceptions import NotFound
 
         # See https://bugs.launchpad.net/bugs/239636
-        class DummyResponse(object):
+        class DummyResponse:
             _server_version = 'Dummy'  # emulate ZServer response
             locked = False
             body = None
@@ -57,14 +57,14 @@ class TestNullResource(unittest.TestCase):
         from OFS.CopySupport import CopyError
         from zExceptions import Unauthorized
 
-        class DummyRequest(object):
+        class DummyRequest:
             def get_header(self, header, default=''):
                 return default
 
             def get(self, name, default=None):
                 return default
 
-        class DummyResponse(object):
+        class DummyResponse:
             _server_version = 'Dummy'  # emulate ZServer response
 
             def setHeader(self, *args):

--- a/src/webdav/tests/testResource.py
+++ b/src/webdav/tests/testResource.py
@@ -27,7 +27,7 @@ def make_request_response(environ=None):
     return req, resp
 
 
-class DummyLock(object):
+class DummyLock:
 
     def isValid(self):
         return True
@@ -45,7 +45,7 @@ class DummyContent(Implicit):
         return True
 
 
-class DummyRequest(object):
+class DummyRequest:
 
     def __init__(self, form, headers):
         self.form = form
@@ -64,7 +64,7 @@ class DummyRequest(object):
         return ['']
 
 
-class DummyResponse(object):
+class DummyResponse:
 
     def __init__(self):
         self.headers = {}
@@ -73,7 +73,7 @@ class DummyResponse(object):
         self.headers[name] = value
 
 
-class _DummySecurityPolicy(object):
+class _DummySecurityPolicy:
 
     def validate(self, *args, **kw):
         return True

--- a/src/webdav/tests/test_davcmds.py
+++ b/src/webdav/tests/test_davcmds.py
@@ -8,14 +8,14 @@ from zExceptions import Forbidden
 from zope.interface import implementer
 
 
-class _DummySecurityPolicy(object):
+class _DummySecurityPolicy:
 
     def checkPermission(self, permission, object, context):
         return False
 
 
 @implementer(IWriteLock)
-class _DummyContent(object):
+class _DummyContent:
 
     def __init__(self, token=None):
         self.token = token

--- a/src/webdav/tests/test_xmltools.py
+++ b/src/webdav/tests/test_xmltools.py
@@ -11,7 +11,7 @@ class NodeTests(unittest.TestCase):
         return self._getTargetClass()(wrapped)
 
     def test_remove_namespace_attrs(self):
-        class DummyMinidomNode(object):
+        class DummyMinidomNode:
             def __init__(self):
                 self.attributes = {
                     'xmlns:foo': 'foo',

--- a/src/webdav/xmltools.py
+++ b/src/webdav/xmltools.py
@@ -71,7 +71,7 @@ def unescape(value, entities=None):
 zope_encoding = 'utf-8'
 
 
-class Node(object):
+class Node:
     """ Our nodes no matter what type
     """
 
@@ -90,7 +90,7 @@ class Node(object):
         return nodes
 
     def qname(self):
-        return '%s%s' % (self.namespace(), self.name())
+        return '{}{}'.format(self.namespace(), self.name())
 
     def addNode(self, node):
         # XXX: no support for adding nodes here
@@ -158,7 +158,7 @@ class Node(object):
 
     def __repr__(self):
         if self.namespace():
-            return "<Node %s (from %s)>" % (self.name(), self.namespace())
+            return "<Node {} (from {})>".format(self.name(), self.namespace())
         else:
             return "<Node %s>" % self.name()
 
@@ -167,7 +167,7 @@ class Element(Node):
 
     def toxml(self):
         # When dealing with Elements, we only want the Element's content.
-        writer = StringIO(u'')
+        writer = StringIO('')
         for n in self.node.childNodes:
             if n.nodeType == n.CDATA_SECTION_NODE:
                 # CDATA sections should not be unescaped.
@@ -216,7 +216,7 @@ class ProtectedExpatParser(ExpatParser):
             self._parser.UnparsedEntityDeclHandler = self.unparsed_entity_decl
 
 
-class XmlParser(object):
+class XmlParser:
     """ Simple wrapper around minidom to support the required
     interfaces for zope.webdav
     """

--- a/src/webdav/xmltools.py
+++ b/src/webdav/xmltools.py
@@ -90,7 +90,7 @@ class Node:
         return nodes
 
     def qname(self):
-        return '{}{}'.format(self.namespace(), self.name())
+        return f'{self.namespace()}{self.name()}'
 
     def addNode(self, node):
         # XXX: no support for adding nodes here
@@ -158,7 +158,7 @@ class Node:
 
     def __repr__(self):
         if self.namespace():
-            return "<Node {} (from {})>".format(self.name(), self.namespace())
+            return f"<Node {self.name()} (from {self.namespace()})>"
         else:
             return "<Node %s>" % self.name()
 

--- a/src/zmi/styles/tests.py
+++ b/src/zmi/styles/tests.py
@@ -29,7 +29,7 @@ class SubscriberTests(Testing.ZopeTestCase.FunctionalTestCase):
             # which the WSGI publisher does not expect.
             endInteraction()
             response = self.publish(
-                '/{0.folder_name}/manage_main'.format(Testing.ZopeTestCase),
+                f'/{Testing.ZopeTestCase.folder_name}/manage_main',
                 basic=basic_auth)
             return str(response)
         return temporaryPlacelessSetUp(


### PR DESCRIPTION
I called `pyupgrade --py3-only --py3-plus --py36-plus --py37-plus` on
the Python files.
While looking through the changes, I did some adoptions to sometimes
use f-strings in places where the tool did not use them.

Additionally `pyupgrade` removed some Python 2 compatiblity leftovers.