### PR TITLE
Restore "attrs" template variable support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,12 +10,11 @@ https://zope.readthedocs.io/en/2.13/CHANGES.html
 4.4.5 (unreleased)
 ------------------
 
-- support the ``attrs`` predefined template variable again (as
+- Support the ``attrs`` predefined template variable again (as
   far as ``chameleon`` allows it)
   (`#860 <https://github.com/zopefoundation/Zope/issues/860>`_).
 
-- in the "Zope Book" remove ``CONTEXTS`` from the list of predefined
-  template variables (because it was never implemented).
+- Improve documentation of ``CONTEXTS`` in the "Zope Book".
   
 - Update dependencies to the latest releases that still support Python 2.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,13 @@ https://zope.readthedocs.io/en/2.13/CHANGES.html
 4.4.5 (unreleased)
 ------------------
 
+- support the ``attrs`` predefined template variable again (as
+  far as ``chameleon`` allows it)
+  (`#860 <https://github.com/zopefoundation/Zope/issues/860>`_).
+
+- in the "Zope Book" remove ``CONTENTS`` from the list of predefined
+  template variables (because it was never implemented).
+  
 - Update dependencies to the latest releases that still support Python 2.
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,7 @@ https://zope.readthedocs.io/en/2.13/CHANGES.html
   far as ``chameleon`` allows it)
   (`#860 <https://github.com/zopefoundation/Zope/issues/860>`_).
 
-- in the "Zope Book" remove ``CONTENTS`` from the list of predefined
+- in the "Zope Book" remove ``CONTEXTS`` from the list of predefined
   template variables (because it was never implemented).
   
 - Update dependencies to the latest releases that still support Python 2.

--- a/docs/zopebook/AppendixC.rst
+++ b/docs/zopebook/AppendixC.rst
@@ -698,6 +698,13 @@ Note that the (popular) ``chameleon`` template engine implements ``attrs``
 and ``default`` not as standard variables but in a special way.
 Trying to change their value may have undefined effects.
 
+Note that beside variables you can use ``CONTEXTS``
+as initial element in a path expression. Its value is a mapping
+from predefined variable names to their value. This can be used to
+access the predefined variable when it is hidden by a user defined
+definition for its name. Again, `attrs` is special; it is not covered
+by `CONTEXTS`.
+
 
 TALES Exists expressions
 ========================

--- a/docs/zopebook/AppendixC.rst
+++ b/docs/zopebook/AppendixC.rst
@@ -674,10 +674,6 @@ These are the names always available to TALES expressions in Zope:
 - *attrs*- - a dictionary containing the initial values of the attributes of
   the current statement tag.
 
-- *CONTEXTS*- - the list of standard names (this list). This can be used to
-  access a built-in variable that has been hidden by a local or global variable
-  with the same name.
-
 - *root*- - the system's top-most object: the Zope root folder.
 
 - *context*- - the object to which the template is being applied.

--- a/docs/zopebook/AppendixC.rst
+++ b/docs/zopebook/AppendixC.rst
@@ -694,6 +694,11 @@ Note the names `root`, `context`, `container`, `template`, `request`, `user`, an
 `modules` are optional names supported by Zope, but are not required by the
 TALES standard.
 
+Note that the (popular) ``chameleon`` template engine implements ``attrs``
+and ``default`` not as standard variables but in a special way.
+Trying to change their value may have undefined effects.
+
+
 TALES Exists expressions
 ========================
 

--- a/src/Products/PageTemplates/engine.py
+++ b/src/Products/PageTemplates/engine.py
@@ -149,9 +149,10 @@ _compile_zt_expr_node = Static(Symbol(_compile_zt_expr))
 
 class _C2ZContextWrapper(Context):
     """Behaves like "zope" context with vars from "chameleon" context."""
-    def __init__(self, c_context):
+    def __init__(self, c_context, attrs):
         self.__c_context = c_context
         self.__z_context = c_context["__zt_context__"]
+        self.__attrs = attrs
 
     # delegate to ``__c_context``
     @property
@@ -162,6 +163,8 @@ class _C2ZContextWrapper(Context):
         try:
             return self.__c_context.__getitem__(key)
         except NameError:  # Exception for missing key
+            if key == "attrs":
+                return self.__attrs
             raise KeyError(key)
 
     def getValue(self, name, default=None):
@@ -214,11 +217,7 @@ class _C2ZContextWrapper(Context):
         return getattr(self.__z_context, attr)
 
 
-def _c_context_2_z_context(c_context):
-    return _C2ZContextWrapper(c_context)
-
-
-_c_context_2_z_context_node = Static(Symbol(_c_context_2_z_context))
+_c_context_2_z_context_node = Static(Symbol(_C2ZContextWrapper))
 
 
 class MappedExpr(object):
@@ -262,14 +261,21 @@ class MappedExpr(object):
                                     raise ExpressionError("$ unsupported", spe)
 
     def __call__(self, target, c_engine):
+        # the convoluted handling of attrs is necessary to work around
+        # "https://github.com/malthe/chameleon/issues/323"
+        # The work round is partial only: until the ``chameleon``
+        # problem is fixed, `attrs` cannot be used inside ``tal:define``
         return template(
+            "try: __zt_tmp = attrs\n"
+            "except NameError: __zt_tmp = None\n"
             "target = compile_zt_expr(type, expression, econtext=econtext)"
-            "(c2z_context(econtext))",
+            "(c2z_context(econtext, __zt_tmp))",
             target=target,
             compile_zt_expr=_compile_zt_expr_node,
             type=ast.Str(self.type),
             expression=ast.Str(self.expression),
-            c2z_context=_c_context_2_z_context_node)
+            c2z_context=_c_context_2_z_context_node,
+            attrs=ast.Name("attrs", ast.Load()))
 
 
 class MappedExprType(object):

--- a/src/Products/PageTemplates/engine.py
+++ b/src/Products/PageTemplates/engine.py
@@ -266,8 +266,10 @@ class MappedExpr(object):
         # The work round is partial only: until the ``chameleon``
         # problem is fixed, `attrs` cannot be used inside ``tal:define``
         return template(
+            "try: __zt_tmp = attrs\n"
+            "except NameError: __zt_tmp = None\n"
             "target = compile_zt_expr(type, expression, econtext=econtext)"
-            "(c2z_context(econtext, attrs))",
+            "(c2z_context(econtext, __zt_tmp))",
             target=target,
             compile_zt_expr=_compile_zt_expr_node,
             type=ast.Str(self.type),

--- a/src/Products/PageTemplates/engine.py
+++ b/src/Products/PageTemplates/engine.py
@@ -261,10 +261,13 @@ class MappedExpr(object):
                                     raise ExpressionError("$ unsupported", spe)
 
     def __call__(self, target, c_engine):
-        # the convoluted handling of attrs is necessary to work around
-        # "https://github.com/malthe/chameleon/issues/323"
+        # The convoluted handling of ``attrs`` below was necessary
+        # for some ``chameleon`` versions to work around
+        # "https://github.com/malthe/chameleon/issues/323".
         # The work round is partial only: until the ``chameleon``
-        # problem is fixed, `attrs` cannot be used inside ``tal:define``
+        # problem is fixed, `attrs` cannot be used inside ``tal:define``.
+        # Potentially, ``attrs`` handling could be simplified
+        # for ``chameleon > 3.8.0``.
         return template(
             "try: __zt_tmp = attrs\n"
             "except NameError: __zt_tmp = None\n"

--- a/src/Products/PageTemplates/engine.py
+++ b/src/Products/PageTemplates/engine.py
@@ -266,10 +266,8 @@ class MappedExpr(object):
         # The work round is partial only: until the ``chameleon``
         # problem is fixed, `attrs` cannot be used inside ``tal:define``
         return template(
-            "try: __zt_tmp = attrs\n"
-            "except NameError: __zt_tmp = None\n"
             "target = compile_zt_expr(type, expression, econtext=econtext)"
-            "(c2z_context(econtext, __zt_tmp))",
+            "(c2z_context(econtext, attrs))",
             target=target,
             compile_zt_expr=_compile_zt_expr_node,
             type=ast.Str(self.type),

--- a/src/Products/PageTemplates/tests/testC2ZContext.py
+++ b/src/Products/PageTemplates/tests/testC2ZContext.py
@@ -23,7 +23,7 @@ class C2ZContextTests(unittest.TestCase):
     def setUp(self):
         self.c_context = c_context = Scope()
         c_context["__zt_context__"] = Context(None, {})
-        self.z_context = _C2ZContextWrapper(c_context)
+        self.z_context = _C2ZContextWrapper(c_context, None)
 
     def test_elementary_functions(self):
         c = self.z_context
@@ -51,7 +51,7 @@ class C2ZContextTests(unittest.TestCase):
     def test_setGlobal(self):
         top_context = self.z_context
         c_context = self.c_context.copy()  # context push
-        c = _C2ZContextWrapper(c_context)  # local ``zope`` context
+        c = _C2ZContextWrapper(c_context, None)  # local ``zope`` context
         c.setLocal("a", "A")
         self.assertIn("a", c)
         self.assertNotIn("a", top_context)
@@ -77,3 +77,9 @@ class C2ZContextTests(unittest.TestCase):
     def test_attribute_delegation(self):
         c = self.z_context
         self.assertIsNone(c._engine)
+
+    def test_attrs(self):
+        c = self.z_context
+        self.assertIsNone(c["attrs"])
+        c.setLocal("attrs", "hallo")
+        self.assertEqual(c["attrs"], "hallo")

--- a/src/Products/PageTemplates/tests/testExpressions.py
+++ b/src/Products/PageTemplates/tests/testExpressions.py
@@ -1,4 +1,4 @@
-# *-* coding: iso-8859-1 -*-
+# -*- coding: utf-8 -*-
 
 import unittest
 
@@ -197,7 +197,7 @@ class EngineTestsBase(PlacelessSetup):
             import IUnicodeEncodingConflictResolver
         provideUtility(StrictUnicodeEncodingConflictResolver,
                        IUnicodeEncodingConflictResolver)
-        self.assertEqual(ec.evaluate(expr), u'äüö')
+        self.assertEqual(ec.evaluate(expr), u'Ã¤Ã¼Ã¶')
 
 
 class UntrustedEngineTests(EngineTestsBase, unittest.TestCase):

--- a/src/Products/PageTemplates/tests/testVariables.py
+++ b/src/Products/PageTemplates/tests/testVariables.py
@@ -1,0 +1,103 @@
+from unittest import TestCase
+
+from zope.component.testing import PlacelessSetup
+from OFS.Folder import Folder
+
+from ..Expressions import getTrustedEngine
+from ..ZopePageTemplate import ZopePageTemplate
+
+from .util import useChameleonEngine
+
+
+class PageTemplate(ZopePageTemplate):
+    def pt_getEngine(self):
+        return getTrustedEngine()
+
+
+class TestPredefinedVariables(PlacelessSetup, TestCase):
+    """test predefined variables
+
+    as documented by
+    `<https://zope.readthedocs.io/en/latest/zopebook/AppendixC.html#built-in-names`_
+    """
+    def setUp(self):
+        super(TestPredefinedVariables, self).setUp()
+
+        def add(dest, id, factory):
+            nid = dest._setObject(id, factory(id))
+            obj = dest._getOb(nid)
+            if hasattr(obj, "_setId"):
+                obj._setId(nid)
+            return obj
+
+        self.root = Folder()
+        self.root.getPhysicalRoot = lambda: self.root
+        self.f = add(self.root, "f", Folder)
+        self.g = add(self.f, "g", Folder)
+        self.template = add(self.f, "t", PageTemplate)
+        # useChameleonEngine()
+
+    def test_nothing(self):
+        self.assertIsNone(self.check("nothing"))
+
+    def test_default(self):
+        self.assertTrue(self.check("default"))
+
+    def test_options(self):
+        self.assertTrue(self.check("options"))
+
+    def test_repeat(self):
+        self.check("repeat")
+
+    def test_attrs(self):
+        attrs = self.check("attrs")
+        self.assertEqual(attrs["attr"], "attr")
+
+    # ``test_attrs`` should have the previous definition
+    # Unfortunately, "https://github.com/malthe/chameleon/issues/323"
+    # (``attrs`` cannot be used in ``tal:define`` nor in ``tal:replace``)
+    # lets it fail.
+    # We must therefore test (what works with the current
+    # ``chameleon``) in a different way.
+    def test_attrs(self):  # noqa: F811
+        t = self.g.t
+        t.write("<div attr='attr' tal:content='python: attrs[\"attr\"]'/>")
+        # the two template engines use different quotes - we
+        #  must normalize
+        self.assertEqual(t().replace("'", '"'), '<div attr="attr">attr</div>')
+
+    def test_root(self):
+        self.assertEqual(self.check("root"), self.root)
+
+    def test_context(self):
+        self.assertEqual(self.check("context"), self.g)
+
+    def test_container(self):
+        self.assertEqual(self.check("container"), self.f)
+
+    def test_template(self):
+        self.assertEqual(self.check("template"), self.template)
+
+    def test_request(self):
+        self.check("request")
+
+    def test_user(self):
+        self.check("user")
+
+    def test_modules(self):
+        self.check("modules")
+
+    def check(self, what):
+        t = self.g.t
+        t.write("<div attr='attr' "
+                """tal:define="dummy python:options['acc'].append(%s)"/>"""
+                % what)
+        acc = []
+        t(acc=acc)
+        return acc[0]
+
+
+class TestPredefinedVariables_chameleon(TestPredefinedVariables):
+    def setUp(self):
+        super(TestPredefinedVariables_chameleon, self).setUp()
+        useChameleonEngine()

--- a/src/Products/PageTemplates/tests/testVariables.py
+++ b/src/Products/PageTemplates/tests/testVariables.py
@@ -19,6 +19,27 @@ class TestPredefinedVariables(PlacelessSetup, TestCase):
     as documented by
     `<https://zope.readthedocs.io/en/latest/zopebook/AppendixC.html#built-in-names`_
     """
+
+    # variables documented in the Zope Book
+    VARIABLES = set((
+        "nothing",
+        "default",
+        "options",
+        "repeat",
+        # "attrs",  # special -- not contained in ``CONTEXTS``
+        "root",
+        "context",
+        "container",
+        "template",
+        "request",
+        "user",
+        "modules",
+        #   special
+        #     - only usable as initial component in path expr
+        #     - not contained in ``CONTEXTS``
+        # "CONTEXTS",
+        ))  # noqa: E123
+
     def setUp(self):
         super(TestPredefinedVariables, self).setUp()
 
@@ -86,6 +107,24 @@ class TestPredefinedVariables(PlacelessSetup, TestCase):
 
     def test_modules(self):
         self.check("modules")
+
+    def test_CONTEXTS(self):
+        # the "Zope Book" describes ``CONTEXTS`` as a variable.
+        # But, in fact, it is not a (regular) variable but a special
+        # case of the initial component of a (sub)path expression.
+        # As a consequence, it cannot be used in a Python expression
+        # but only as the first component in a path expression
+        # Therefore, we cannot use ``check`` to access it.
+        t = self.g.t
+        t.write("""<div tal:define="
+                x CONTEXTS;
+                dummy python:options['acc'].append(x)" />""")
+        acc = []
+        t(acc=acc)
+        ctx = acc[0]
+        self.assertIsInstance(ctx, dict)
+        # all variables included?
+        self.assertEqual(len(self.VARIABLES - set(ctx)), 0)
 
     def check(self, what):
         t = self.g.t

--- a/src/Products/PageTemplates/tests/testVariables.py
+++ b/src/Products/PageTemplates/tests/testVariables.py
@@ -52,6 +52,19 @@ class TestPredefinedVariables(PlacelessSetup, TestCase):
         attrs = self.check("attrs")
         self.assertEqual(attrs["attr"], "attr")
 
+    # ``test_attrs`` should have the previous definition
+    # Unfortunately, "https://github.com/malthe/chameleon/issues/323"
+    # (``attrs`` cannot be used in ``tal:define`` nor in ``tal:replace``)
+    # lets it fail.
+    # We must therefore test (what works with the current
+    # ``chameleon``) in a different way.
+    def test_attrs(self):  # noqa: F811
+        t = self.g.t
+        t.write("<div attr='attr' tal:content='python: attrs[\"attr\"]'/>")
+        # the two template engines use different quotes - we
+        #  must normalize
+        self.assertEqual(t().replace("'", '"'), '<div attr="attr">attr</div>')
+
     def test_root(self):
         self.assertEqual(self.check("root"), self.root)
 

--- a/src/Products/PageTemplates/tests/testVariables.py
+++ b/src/Products/PageTemplates/tests/testVariables.py
@@ -54,10 +54,11 @@ class TestPredefinedVariables(PlacelessSetup, TestCase):
 
     # ``test_attrs`` should have the previous definition
     # Unfortunately, "https://github.com/malthe/chameleon/issues/323"
-    # (``attrs`` cannot be used in ``tal:define`` nor in ``tal:replace``)
+    # (``attrs`` cannot be used in ``tal:define``)
     # lets it fail.
     # We must therefore test (what works with the current
     # ``chameleon``) in a different way.
+    # Note ``chameleon > 3.8.0`` likely will allow the previous definition
     def test_attrs(self):  # noqa: F811
         t = self.g.t
         t.write("<div attr='attr' tal:content='python: attrs[\"attr\"]'/>")

--- a/src/Products/PageTemplates/tests/testVariables.py
+++ b/src/Products/PageTemplates/tests/testVariables.py
@@ -1,11 +1,10 @@
 from unittest import TestCase
 
-from zope.component.testing import PlacelessSetup
 from OFS.Folder import Folder
+from zope.component.testing import PlacelessSetup
 
 from ..Expressions import getTrustedEngine
 from ..ZopePageTemplate import ZopePageTemplate
-
 from .util import useChameleonEngine
 
 

--- a/src/Products/PageTemplates/tests/testVariables.py
+++ b/src/Products/PageTemplates/tests/testVariables.py
@@ -52,19 +52,6 @@ class TestPredefinedVariables(PlacelessSetup, TestCase):
         attrs = self.check("attrs")
         self.assertEqual(attrs["attr"], "attr")
 
-    # ``test_attrs`` should have the previous definition
-    # Unfortunately, "https://github.com/malthe/chameleon/issues/323"
-    # (``attrs`` cannot be used in ``tal:define`` nor in ``tal:replace``)
-    # lets it fail.
-    # We must therefore test (what works with the current
-    # ``chameleon``) in a different way.
-    def test_attrs(self):  # noqa: F811
-        t = self.g.t
-        t.write("<div attr='attr' tal:content='python: attrs[\"attr\"]'/>")
-        # the two template engines use different quotes - we
-        #  must normalize
-        self.assertEqual(t().replace("'", '"'), '<div attr="attr">attr</div>')
-
     def test_root(self):
         self.assertEqual(self.check("root"), self.root)
 


### PR DESCRIPTION
This fixes #860 as far as ``chameleon`` allows it.

As "https://github.com/malthe/chameleon/issues/323" demonstrates, `chameleon` currently supports `attrs` only in `tal:content` but not in `tal:define` nor in `tal:replace`. This PR allows the use of the predefined page template variable `attrs` at locations where `chameleon` supports it; if used at other places, `attrs` has the value `None`. The code should continue to work after the `chameleon` problem is fixed - but some cleanup would be possible after that.

The PR also removes the mentioning of `CONTEXTS` as predefined page template variable from the Zope Book as no template engine (neither `zope.pagetemplate`nor `chameleon`) implements it. It adds tests for the remaining predefined variables.