### PR TITLE
add test for `tal:switch` - to verify #862

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ https://zope.readthedocs.io/en/2.13/CHANGES.html
 4.4.5 (unreleased)
 ------------------
 
+- Add ``tal:switch`` test
+
 - Update dependencies to the latest releases that still support Python 2.
 
 

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -20,6 +20,12 @@ parts =
     requirements
 sources-dir = develop
 auto-checkout =
+    Chameleon
+
+
+[sources]
+Chameleon = git https://github.com/malthe/chameleon.git branch=patch/fix-static-attrs
+
 
 [testenv]
 PYTHONHASHSEED = random

--- a/src/Products/PageTemplates/tests/input/switch.html
+++ b/src/Products/PageTemplates/tests/input/switch.html
@@ -1,0 +1,12 @@
+<html>
+<head></head>
+<body>
+<div tal:switch="python:1"><tal:case
+  case="python:0">case 0</tal:case><tal:case
+  case="python:1">case 1</tal:case><tal:case
+  case="default">case default</tal:case></div>
+<div tal:switch="python:2"><tal:case
+  case="python:0">case 0</tal:case><tal:case
+  case="python:1">case 1</tal:case><tal:case
+  case="default">case default</tal:case></div>
+</body>

--- a/src/Products/PageTemplates/tests/output/switch.html
+++ b/src/Products/PageTemplates/tests/output/switch.html
@@ -1,0 +1,6 @@
+<html>
+<head></head>
+<body>
+<div>case 1</div>
+<div>case default</div>
+</body>

--- a/src/Products/PageTemplates/tests/testHTMLTests.py
+++ b/src/Products/PageTemplates/tests/testHTMLTests.py
@@ -197,3 +197,6 @@ class HTMLTests(zope.component.testing.PlacelessSetup, unittest.TestCase):
 
     def testDefaultKeywordHandling(self):
         self.assert_expected(self.folder.t, 'Default.html')
+
+    def testSwitch(self):
+        self.assert_expected(self.folder.t, 'switch.html')


### PR DESCRIPTION
This PR adds a test for `tal:switch` in relation to #862 .

Note that the test requires a new (upcoming) `chameleon` version to succeed. Do not merge until this version is used by `Zope`.