### PR TITLE
allow (some) builtins as first element in a path expression

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,13 @@ https://zope.readthedocs.io/en/2.13/CHANGES.html
 4.4.5 (unreleased)
 ------------------
 
+- Allow (some) builtins as first element of a (TALES) path expression:
+  in an untrusted context, the builtins from
+  ``AccessControl.safe_builtins`` are allowed;
+  in a trusted context, all Python builtins are allowed in addition
+  (and take precedence)
+  (`zope.tales#23 <https://github.com/zopefoundation/zope.tales/issues/23>`_).
+
 - Add ``tal:switch`` test
 
 - Support the ``attrs`` predefined template variable again (as

--- a/docs/zopebook/AdvZPT.rst
+++ b/docs/zopebook/AdvZPT.rst
@@ -750,7 +750,8 @@ Path Expressions
 Path expressions refer to objects with a path that resembles a
 URL path. A path describes a traversal from object to
 object. All paths begin with a known object (such as a built-in
-variable, a repeat variable, or a user defined variable) and
+variable, a built-in (such as ``True``),
+a repeat variable, or a user defined variable) and
 depart from there to the desired object. Here are some example
 paths expressions::
 
@@ -760,6 +761,7 @@ paths expressions::
   container/master.html/macros/header
   request/form/address
   root/standard_look_and_feel.html
+  True
 
 With path expressions you can traverse from an object to its
 sub-objects including properties and methods. You can also use

--- a/docs/zopebook/ZPT.rst
+++ b/docs/zopebook/ZPT.rst
@@ -201,7 +201,8 @@ be useful.  We'll come back to that later in this chapter::
   <p tal:content="request/URL"></p>
   <p tal:content="user/getUserName"></p>
 
-Every *path expression* starts with a variable name.  The available
+Every *path expression* starts either with a variable name or with
+a (supported) builtin.  The available
 variable names refer either to objects like *context*, *request* or
 *user* that are bound to every *Page Template* by default or variables
 defined within the *Page Template* using TAL.  Note that *here* is an
@@ -215,6 +216,15 @@ If the variable itself returns the value you want, you are done.
 Otherwise, you add a slash ('/') and the name of a sub-object or
 attribute.  You may need to work your way through several
 sub-objects to get to the value you're looking for.
+
+Which builtins are supported as first element of a path
+expression depends on the context. In an untrusted context,
+only "safe builtins" (as specified by ``AccessControl.safe_builtins``)
+are supported; in a trusted context, beside those all
+Python builtins are supported in addition (and take precedence over
+the former). Note that many builtins are callable. For those,
+you will refer to them usually via the ``nocall`` variant of
+a path expression.
 
 Python Expressions
 %%%%%%%%%%%%%%%%%%

--- a/src/Products/PageTemplates/tests/testExpressions.py
+++ b/src/Products/PageTemplates/tests/testExpressions.py
@@ -4,6 +4,8 @@ import unittest
 
 from six import text_type
 
+from AccessControl import safe_builtins
+
 from zope.component.testing import PlacelessSetup
 
 
@@ -199,6 +201,12 @@ class EngineTestsBase(PlacelessSetup):
                        IUnicodeEncodingConflictResolver)
         self.assertEqual(ec.evaluate(expr), u'äüö')
 
+    def test_builtin_in_path_expr(self):
+        ec = self._makeContext()
+        self.assertIs(ec.evaluate('True'), True)
+        self.assertIs(ec.evaluate('False'), False)
+        self.assertIs(ec.evaluate('nocall: test'), safe_builtins["test"])
+
 
 class UntrustedEngineTests(EngineTestsBase, unittest.TestCase):
 
@@ -208,6 +216,15 @@ class UntrustedEngineTests(EngineTestsBase, unittest.TestCase):
 
     # XXX:  add tests that show security checks being enforced
 
+    def test_open_in_path_expr(self):
+        ec = self._makeContext()
+        with self.assertRaises(KeyError):
+            ec.evaluate("nocall:open")
+
+    def test_list_in_path_expr(self):
+        ec = self._makeContext()
+        self.assertIs(ec.evaluate('nocall: list'), safe_builtins["list"])
+
 
 class TrustedEngineTests(EngineTestsBase, unittest.TestCase):
 
@@ -216,6 +233,14 @@ class TrustedEngineTests(EngineTestsBase, unittest.TestCase):
         return createTrustedZopeEngine()
 
     # XXX:  add tests that show security checks *not* being enforced
+
+    def test_open_in_path_expr(self):
+        ec = self._makeContext()
+        self.assertIs(ec.evaluate("nocall:open"), open)
+
+    def test_list_in_path_expr(self):
+        ec = self._makeContext()
+        self.assertIs(ec.evaluate('nocall: list'), list)
 
 
 class UnicodeEncodingConflictResolverTests(PlacelessSetup, unittest.TestCase):

--- a/src/Products/PageTemplates/tests/testExpressions.py
+++ b/src/Products/PageTemplates/tests/testExpressions.py
@@ -5,7 +5,6 @@ import unittest
 from six import text_type
 
 from AccessControl import safe_builtins
-
 from zope.component.testing import PlacelessSetup
 
 

--- a/src/Products/PageTemplates/unicodeconflictresolver.py
+++ b/src/Products/PageTemplates/unicodeconflictresolver.py
@@ -17,7 +17,7 @@ import sys
 
 from six import text_type
 
-import ZPublisher
+import ZPublisher.HTTPRequest
 from Acquisition import aq_get
 from Products.PageTemplates.interfaces import IUnicodeEncodingConflictResolver
 from zope.i18n.interfaces import IUserPreferredCharsets


### PR DESCRIPTION
This PR is one possible implementation for "https://github.com/zopefoundation/Zope/issues/863".

It interprets "some builtins" as:
 * in an untrusted context: the builtins from `AccessControl.safe_builtins`
 * in a trusted context: all Python builtins and those from `AccessControl.safe_builtins`

Thus, the set of allowed builtins is likely larger than that natively supported by `chameleon`. I believe that `chameleon` currently does not expose its set for external access; this would be necessary to ensure that the same set of builtins is supported.

