### PR TITLE
`IZopeAwareEngine` to address #864

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,16 @@ https://zope.readthedocs.io/en/2.13/CHANGES.html
 4.4.5 (unreleased)
 ------------------
 
+- New interface ``Products.PageTemplates.interfaces.IZopeAwareEngine``.
+  It can be used as the "provides" of an adapter registration
+  to adapt a non ``Zope`` tales engine to an engine to be used
+  by ``Zope`` page templates
+  (`#864 <https://github.com/zopefoundation/Zope/issues/864>`_).
+  Currently, the adaptation is used only when the
+  template is rendered with ``chameleon``;
+  with ``zope.pagetemplate``, the engine is used
+  as is - this may change in the future.
+
 - Allow (some) builtins as first element of a (TALES) path expression:
   in an untrusted context, the builtins from
   ``AccessControl.safe_builtins`` are allowed;

--- a/src/Products/PageTemplates/Expressions.py
+++ b/src/Products/PageTemplates/Expressions.py
@@ -18,6 +18,8 @@ for Python expressions, string literals, and paths.
 
 import logging
 
+from Products.PageTemplates import ZRPythonExpr
+from Products.PageTemplates.interfaces import IUnicodeEncodingConflictResolver
 from six import binary_type
 from six import text_type
 
@@ -25,8 +27,6 @@ import OFS.interfaces
 from AccessControl import safe_builtins
 from Acquisition import aq_base
 from MultiMapping import MultiMapping
-from Products.PageTemplates import ZRPythonExpr
-from Products.PageTemplates.interfaces import IUnicodeEncodingConflictResolver
 from zExceptions import NotFound
 from zExceptions import Unauthorized
 from zope.component import queryUtility
@@ -48,6 +48,8 @@ from zope.tales.tales import ErrorInfo as BaseErrorInfo
 from zope.tales.tales import Iterator
 from zope.traversing.adapters import traversePathElement
 from zope.traversing.interfaces import ITraversable
+
+from .interfaces import IZopeAwareEngine
 
 
 SecureModuleImporter = ZRPythonExpr._SecureModuleImporter()
@@ -325,6 +327,12 @@ class ErrorInfo(BaseErrorInfo):
     __allow_access_to_unprotected_subobjects__ = True
 
 
+# Whether an engine is Zope aware does not depend on the class
+# but how it is configured - especially, that is uses a Zope aware
+# `PathExpr` implementation.
+# Nevertheless, we mark the class as "Zope aware" for simplicity
+# assuming that users of the class use a proper `PathExpr`
+@implementer(IZopeAwareEngine)
 class ZopeEngine(Z3Engine):
 
     _create_context = ZopeContext

--- a/src/Products/PageTemplates/Expressions.py
+++ b/src/Products/PageTemplates/Expressions.py
@@ -18,8 +18,6 @@ for Python expressions, string literals, and paths.
 
 import logging
 
-from Products.PageTemplates import ZRPythonExpr
-from Products.PageTemplates.interfaces import IUnicodeEncodingConflictResolver
 from six import binary_type
 from six import text_type
 
@@ -49,6 +47,8 @@ from zope.tales.tales import Iterator
 from zope.traversing.adapters import traversePathElement
 from zope.traversing.interfaces import ITraversable
 
+from . import ZRPythonExpr
+from .interfaces import IUnicodeEncodingConflictResolver
 from .interfaces import IZopeAwareEngine
 
 

--- a/src/Products/PageTemplates/engine.py
+++ b/src/Products/PageTemplates/engine.py
@@ -20,12 +20,12 @@ from chameleon.exc import ExpressionError
 from chameleon.tal import RepeatDict
 from chameleon.tales import DEFAULT_MARKER  # only in chameleon 3.8.0 and up
 from chameleon.zpt.template import Macros
-from z3c.pt.pagetemplate import PageTemplate as ChameleonPageTemplate
 
 from AccessControl.class_init import InitializeClass
 from AccessControl.SecurityInfo import ClassSecurityInfo
 from App.version_txt import getZopeVersion
 from MultiMapping import MultiMapping
+from z3c.pt.pagetemplate import PageTemplate as ChameleonPageTemplate
 from zope.interface import implementer
 from zope.interface import provider
 from zope.pagetemplate.engine import ZopeBaseEngine

--- a/src/Products/PageTemplates/engine.py
+++ b/src/Products/PageTemplates/engine.py
@@ -20,12 +20,12 @@ from chameleon.exc import ExpressionError
 from chameleon.tal import RepeatDict
 from chameleon.tales import DEFAULT_MARKER  # only in chameleon 3.8.0 and up
 from chameleon.zpt.template import Macros
+from z3c.pt.pagetemplate import PageTemplate as ChameleonPageTemplate
 
 from AccessControl.class_init import InitializeClass
 from AccessControl.SecurityInfo import ClassSecurityInfo
 from App.version_txt import getZopeVersion
 from MultiMapping import MultiMapping
-from z3c.pt.pagetemplate import PageTemplate as ChameleonPageTemplate
 from zope.interface import implementer
 from zope.interface import provider
 from zope.pagetemplate.engine import ZopeBaseEngine
@@ -37,6 +37,7 @@ from zope.tales.tales import Context
 
 from .Expressions import PathIterator
 from .Expressions import SecureModuleImporter
+from .interfaces import IZopeAwareEngine
 
 
 class _PseudoContext(object):
@@ -310,7 +311,7 @@ class Program(object):
 
     def __init__(self, template, engine):
         self.template = template
-        self.engine = engine
+        self.engine = IZopeAwareEngine(engine, engine)
 
     def __call__(self, context, macros, tal=True, **options):
         if tal is False:

--- a/src/Products/PageTemplates/expression.py
+++ b/src/Products/PageTemplates/expression.py
@@ -8,7 +8,9 @@ from chameleon.astutil import Symbol
 from chameleon.codegen import template
 from chameleon.tales import NotExpr
 from chameleon.tales import StringExpr
+from Products.PageTemplates.Expressions import render
 from six import class_types
+from z3c.pt import expressions
 
 from AccessControl.ZopeGuards import guarded_apply
 from AccessControl.ZopeGuards import guarded_getattr
@@ -16,15 +18,16 @@ from AccessControl.ZopeGuards import guarded_getitem
 from AccessControl.ZopeGuards import guarded_iter
 from AccessControl.ZopeGuards import protected_inplacevar
 from OFS.interfaces import ITraversable
-from Products.PageTemplates.Expressions import render
 from RestrictedPython import RestrictingNodeTransformer
 from RestrictedPython.Utilities import utility_builtins
-from z3c.pt import expressions
 from zExceptions import NotFound
 from zExceptions import Unauthorized
+from zope.interface import implementer
 from zope.tales.tales import ExpressionEngine
 from zope.traversing.adapters import traversePathElement
 from zope.traversing.interfaces import TraversalError
+
+from .interfaces import IZopeAwareEngine
 
 
 _marker = object()
@@ -167,6 +170,12 @@ class UntrustedPythonExpr(expressions.PythonExpr):
         return node
 
 
+# Whether an engine is Zope aware does not depend on the class
+# but how it is configured - especially, that is uses a Zope aware
+# `PathExpr` implementation.
+# Nevertheless, we mark the class as "Zope aware" for simplicity
+# assuming that users of the class use a proper `PathExpr`
+@implementer(IZopeAwareEngine)
 class ChameleonEngine(ExpressionEngine):
     """Expression engine for ``chameleon.tales``.
 

--- a/src/Products/PageTemplates/expression.py
+++ b/src/Products/PageTemplates/expression.py
@@ -8,9 +8,7 @@ from chameleon.astutil import Symbol
 from chameleon.codegen import template
 from chameleon.tales import NotExpr
 from chameleon.tales import StringExpr
-from Products.PageTemplates.Expressions import render
 from six import class_types
-from z3c.pt import expressions
 
 from AccessControl.ZopeGuards import guarded_apply
 from AccessControl.ZopeGuards import guarded_getattr
@@ -20,6 +18,7 @@ from AccessControl.ZopeGuards import protected_inplacevar
 from OFS.interfaces import ITraversable
 from RestrictedPython import RestrictingNodeTransformer
 from RestrictedPython.Utilities import utility_builtins
+from z3c.pt import expressions
 from zExceptions import NotFound
 from zExceptions import Unauthorized
 from zope.interface import implementer
@@ -27,6 +26,7 @@ from zope.tales.tales import ExpressionEngine
 from zope.traversing.adapters import traversePathElement
 from zope.traversing.interfaces import TraversalError
 
+from .Expressions import render
 from .interfaces import IZopeAwareEngine
 
 

--- a/src/Products/PageTemplates/interfaces.py
+++ b/src/Products/PageTemplates/interfaces.py
@@ -27,3 +27,7 @@ class IUnicodeEncodingConflictResolver(Interface):
             'expression' is the original expression (can be used for
             logging purposes)
         """
+
+
+class IZopeAwareEngine(Interface):
+    """Interface to mark a TALES engine aware of Zope specifics."""

--- a/src/Products/PageTemplates/tests/testZopeAwareEngine.py
+++ b/src/Products/PageTemplates/tests/testZopeAwareEngine.py
@@ -1,0 +1,59 @@
+##############################################################################
+#
+# Copyright (c) 2020 Zope Foundation and Contributors.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE
+#
+##############################################################################
+
+from unittest import TestCase
+
+from zope.component import provideAdapter
+from zope.component.testing import PlacelessSetup
+from zope.pagetemplate.engine import Engine as base_engine
+
+from ..engine import Program
+from ..expression import getEngine as getChameleonEngine
+from ..Expressions import getEngine as getZopeEngine
+from ..interfaces import IZopeAwareEngine
+
+
+def adapt(engine):
+    return getZopeEngine()
+
+
+class TestsWithoutAdapter(PlacelessSetup, TestCase):
+    def test_ch_engine(self):
+        self.check(getChameleonEngine())
+
+    def test_zope_engine(self):
+        self.check(getZopeEngine())
+
+    def test_base_engine(self):
+        self.check(base_engine, getZopeEngine())
+
+    def check(self, engine, zengine=None):
+        zengine = self.should(zengine)
+        if zengine is None:
+            zengine = engine
+        p = Program(None, engine)
+        self.assertIs(p.engine, zengine)
+
+    def should(self, zengine):
+        # without adapter, we must ignore *zengine*
+        return
+
+
+class TestWithsAdapter(TestsWithoutAdapter):
+    def setUp(self):
+        super(TestWithsAdapter, self).setUp()
+        provideAdapter(adapt, (None,), IZopeAwareEngine)
+
+    def should(self, zengine):
+        # with adapter, *zengine* specifies the result
+        return zengine


### PR DESCRIPTION
This PR addresses #864 .

It defines a new interface `Products.PageTemplates.interfaces.IZopeAwareEngine` which conceptionally is a marker indicating that a TALES engine has a `Zope` compatible `PathExpr`.

The PR marks the "Engine" classes defined by `Products.PageTemplates` with `IZopeAwareEngine` even though Zope awareness is not a property of the class but of the individual instances and their `PathExpr`. The motivation here is that components which derive from or instantiate those classes are likely providing a Zope compatible `PathExpr`.

`IZopeAwareEngine` can be used as the `provides` of an adapter registration in order to adapt a non `IZopeAwareEngine`. An adapter registered in this way is used only for engines which do not provide `IZopeAwareEngine` by themselves (currently, adaptation only takes place for template rendering via `chameleon` -- this may change in the future). Therefore, the code fragment below can restore Zope 4.3 behavior regarding Zope awareness for non `Zope` TALES engines:
```
from zope.component import provideAdapter
from Products.PageTemplates.Expressions import getTrustedEngine
from Products.PageTemplates.interfaces import IZopeAwareEngine

def adapt(engine):
    return getTrustedZopeEngine()

provideAdapter(adapt, (None,), IZopeAwareEngine)
```
Note: likely, one would put the adapter registration into ZCML; this way, it could be "unconfigured" if necessary.

Note: the `adapt` above reflects what Zope 4.3 effectively did.A more careful adaptation would look at the adapted *engine* to determine whether a trusted or untrusted Zope aware engine should be used and return the appropriate engine.