### PR TITLE
avoid repeated execution of the same `HTMLTests`

### DIFF
--- a/src/Products/PageTemplates/tests/testChameleonTalesExpressions.py
+++ b/src/Products/PageTemplates/tests/testChameleonTalesExpressions.py
@@ -1,14 +1,13 @@
 from ..expression import getEngine
-from .testHTMLTests import AqPageTemplate
-from .testHTMLTests import HTMLTests
+from . import testHTMLTests
 
 
-class ChameleonAqPageTemplate(AqPageTemplate):
+class ChameleonAqPageTemplate(testHTMLTests.AqPageTemplate):
     def pt_getEngine(self):
         return getEngine()
 
 
-class ChameleonTalesExpressionTests(HTMLTests):
+class ChameleonTalesExpressionTests(testHTMLTests.HTMLTests):
     def setUp(self):
         super(ChameleonTalesExpressionTests, self).setUp()
         # override with templates using chameleon TALES expressions

--- a/src/Products/PageTemplates/tests/testZopeTalesExpressions.py
+++ b/src/Products/PageTemplates/tests/testZopeTalesExpressions.py
@@ -1,10 +1,10 @@
 from ..engine import _compile_zt_expr
 from ..engine import _zt_expr_registry
 from ..Expressions import getEngine
-from .testHTMLTests import HTMLTests
+from . import testHTMLTests
 
 
-class ZopeTalesExpressionTests(HTMLTests):
+class ZopeTalesExpressionTests(testHTMLTests.HTMLTests):
     """The tests (currently) always use ``zope.tales`` expressions.
     The tests in this class ensure that the ``_zt_expr_registry``
     is cleared at the start and end of each test.


### PR DESCRIPTION
https://github.com/zopefoundation/zope.testrunner/issues/108
has caused that each test from `HTMLTests` was executed 3 times. Avoid this unnecessary (though harmless) repeated test execution.

The change is cosmetic only -- therefore, not described in `CHANGES.rst`.