### PR TITLE
make "Unicode Conflict Resolution" available for `chameleon` rendering

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,11 @@ https://zope.readthedocs.io/en/2.13/CHANGES.html
 4.4.5 (unreleased)
 ------------------
 
+- Make "Unicode Conflict Resolution" available for templates
+  rendered with ``chameleon``
+  (`Products.CMFPlone#3145
+  <https://github.com/plone/Products.CMFPlone/issues/3145>`_).
+
 - New interface ``Products.PageTemplates.interfaces.IZopeAwareEngine``.
   It can be used as the "provides" of an adapter registration
   to adapt a non ``Zope`` tales engine to an engine to be used

--- a/src/Products/PageTemplates/engine.py
+++ b/src/Products/PageTemplates/engine.py
@@ -33,10 +33,10 @@ from zope.pagetemplate.interfaces import IPageTemplateEngine
 from zope.pagetemplate.interfaces import IPageTemplateProgram
 from zope.tales.expressions import PathExpr
 from zope.tales.expressions import SubPathExpr
-from zope.tales.tales import Context
 
 from .Expressions import PathIterator
 from .Expressions import SecureModuleImporter
+from .Expressions import ZopeContext
 from .interfaces import IZopeAwareEngine
 
 
@@ -148,7 +148,7 @@ def _compile_zt_expr(type, expression, engine=None, econtext=None):
 _compile_zt_expr_node = Static(Symbol(_compile_zt_expr))
 
 
-class _C2ZContextWrapper(Context):
+class _C2ZContextWrapper(ZopeContext):
     """Behaves like "zope" context with vars from "chameleon" context."""
     def __init__(self, c_context, attrs):
         self.__c_context = c_context

--- a/src/Products/PageTemplates/tests/testZopePageTemplate.py
+++ b/src/Products/PageTemplates/tests/testZopePageTemplate.py
@@ -127,11 +127,11 @@ class ZPTUtilsTests(unittest.TestCase):
 
 
 class ZPTUnicodeEncodingConflictResolution(ZopeTestCase):
-    # BBB The unicode conflict resolution feature is only available
-    # for the old Zope page template engine!
+
+    select_engine = staticmethod(useOldZopeEngine)
 
     def afterSetUp(self):
-        useOldZopeEngine()
+        self.select_engine()
         zope.component.provideAdapter(DefaultTraversable, (None,))
         zope.component.provideAdapter(HTTPCharsets, (None,))
         provideUtility(PreferredCharsetResolver,
@@ -235,6 +235,12 @@ class ZPTUnicodeEncodingConflictResolution(ZopeTestCase):
                          u'<div tal:content="string:foo">foo</div>')
         self.app.REQUEST.debug.sourceAnnotations = True
         self.assertEqual(zpt.pt_render().startswith(u'<!--'), True)
+
+
+class ZPTUnicodeEncodingConflictResolution_chameleon(
+        ZPTUnicodeEncodingConflictResolution):
+
+    select_engine = staticmethod(useChameleonEngine)
 
 
 class ZopePageTemplateFileTests(ZopeTestCase):


### PR DESCRIPTION
This should fix https://github.com/plone/Products.CMFPlone/issues/3145

`Products.PageTemplates.Expressions.ZopeContext` has provisions for so called "Unicode Conflict Resolution", i.e. logic to convert bytes to unicode. This was never supported for `chameleon` (which uses its own independent logic for this case).

Due to a bug, it became not available with the combination of `zope.tales` and `chameleon`. This bug is fixed by this PR and now "Unicode Conflict Resolution" is available for `chameleon` rendering as well.

The "Unicode Conflict Resolution" relies on extensions by `ZopePageTemplate`, it does not work for a raw `PageTemplate`.