### PR TITLE
let "unicode conflict resolution" work for all templates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ https://zope.readthedocs.io/en/2.13/CHANGES.html
 4.5.1 (unreleased)
 ------------------
 
+- Let "unicode conflict resolution" work for all templates (not just
+  ``ZopePageTemplate``).
+
 - Update dependencies to the latest releases that still support Python 2.
 
 

--- a/src/Products/PageTemplates/Expressions.py
+++ b/src/Products/PageTemplates/Expressions.py
@@ -292,7 +292,8 @@ class ZopeContext(Context):
                 return text.decode('ascii')
 
             try:
-                return resolver.resolve(self.contexts['context'], text, expr)
+                return resolver.resolve(
+                    self.contexts.get('context'), text, expr)
             except UnicodeDecodeError as e:
                 LOG.error("UnicodeDecodeError detected for expression \"%s\"\n"
                           "Resolver class: %s\n"

--- a/src/Products/PageTemplates/tests/input/UnicodeResolution.html
+++ b/src/Products/PageTemplates/tests/input/UnicodeResolution.html
@@ -1,0 +1,5 @@
+<html>
+<head></head>
+<body>
+<div tal:define="b python: 'äöü'" tal:content="string:$b" />
+</body>

--- a/src/Products/PageTemplates/tests/output/UnicodeResolution.html
+++ b/src/Products/PageTemplates/tests/output/UnicodeResolution.html
@@ -1,0 +1,5 @@
+<html>
+<head></head>
+<body>
+<div>äöü</div>
+</body>

--- a/src/Products/PageTemplates/tests/testHTMLTests.py
+++ b/src/Products/PageTemplates/tests/testHTMLTests.py
@@ -25,6 +25,8 @@ from Products.PageTemplates.PageTemplate import PageTemplate
 from Products.PageTemplates.tests import util
 from Products.PageTemplates.unicodeconflictresolver import \
     DefaultUnicodeEncodingConflictResolver
+from Products.PageTemplates.unicodeconflictresolver import \
+    PreferredCharsetResolver
 from zope.component import provideUtility
 from zope.traversing.adapters import DefaultTraversable
 
@@ -200,3 +202,9 @@ class HTMLTests(zope.component.testing.PlacelessSetup, unittest.TestCase):
 
     def testSwitch(self):
         self.assert_expected(self.folder.t, 'switch.html')
+
+    def test_unicode_conflict_resolution(self):
+        # override with the more "demanding" resolver
+        provideUtility(PreferredCharsetResolver)
+        t = PageTemplate()
+        self.assert_expected(t, 'UnicodeResolution.html')

--- a/src/Products/PageTemplates/tests/util.py
+++ b/src/Products/PageTemplates/tests/util.py
@@ -98,6 +98,9 @@ class argv(Base):
 
 
 def check_html(s1, s2):
+    if not isinstance(s2, bytes) and isinstance(s1, bytes):
+        # convert to common type
+        s1 = s1.decode("utf-8")  # our encoding
     s1 = normalize_html(s1)
     s2 = normalize_html(s2)
     TEST_CASE.assertEqual(s1, s2)


### PR DESCRIPTION
Previously, the "unicode conflict resolution" integration (needlessly) relied on `contexts` containing `context`. While this is guaranteed for `ZopePageTemplate` this is usually not the case for a raw `PageTemplate`.

This PR removes the restriction.