### PR TITLE
make "chameleon zope context wrapping" more faithfull

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ https://zope.readthedocs.io/en/2.13/CHANGES.html
 4.5.1 (unreleased)
 ------------------
 
+- Make "chameleon-zope context wrapping" more faithful
+
 - Update dependencies to the latest releases that still support Python 2.
 
 

--- a/src/Products/PageTemplates/engine.py
+++ b/src/Products/PageTemplates/engine.py
@@ -187,6 +187,9 @@ class Name2KeyError(Mapping):
     def __iter__(self):
         return iter(self.data)
 
+    def __len__(self):
+        return len(self.data)
+
 
 class _C2ZContextWrapperBase(object):
     """Behaves like "zope" context with vars from "chameleon" context.

--- a/src/Products/PageTemplates/tests/testC2ZContext.py
+++ b/src/Products/PageTemplates/tests/testC2ZContext.py
@@ -94,10 +94,10 @@ class C2ZContextTests(unittest.TestCase):
 
             def my_get(self, k):
                 return self[k]
-        
+
         c_context = self.c_context
         c_context["__zt_context__"] = my_context = MyContext()
-        zc = _C2ZContextWrapper(c_context, None) 
+        zc = _C2ZContextWrapper(c_context, None)
         # attributes in ``my_context``
         #   -- via method
         zc.set("attr")

--- a/src/Products/PageTemplates/tests/testC2ZContext.py
+++ b/src/Products/PageTemplates/tests/testC2ZContext.py
@@ -16,51 +16,57 @@ from chameleon.utils import Scope
 
 from zope.tales.tales import Context
 
+from ..engine import DEFAULT_MARKER
 from ..engine import _C2ZContextWrapper
+from ..engine import _context_class_registry
+from ..engine import _with_vars_from_chameleon as wrap
 
 
 class C2ZContextTests(unittest.TestCase):
     def setUp(self):
         self.c_context = c_context = Scope()
-        c_context["__zt_context__"] = Context(None, {})
+        z_context = Context(None, {})
+        z_context.setContext("default", DEFAULT_MARKER)
+        c_context["__zt_context__"] = wrap(z_context)
         self.z_context = _C2ZContextWrapper(c_context, None)
 
     def test_elementary_functions(self):
         c = self.z_context
+        cv = c.vars
         c.setLocal("a", "A")
         c.setLocal("b", "B")
-        self.assertEqual(c["a"], "A")
+        self.assertEqual(cv["a"], "A")
         self.assertEqual(c.get("b"), "B")
         self.assertIsNone(c.get("c"))
         with self.assertRaises(KeyError):
-            c["c"]
-        self.assertEqual(sorted(c.keys()), ["__zt_context__", "a", "b"])
-        self.assertEqual(sorted(c), ["__zt_context__", "a", "b"])
-        vs = c.values()
+            cv["c"]
+        self.assertEqual(sorted(cv.keys()),
+                         ["__zt_context__", "a", "attrs", "b"])
+        self.assertEqual(sorted(cv), ["__zt_context__", "a", "attrs", "b"])
+        vs = cv.values()
         for v in ("A", "B"):
             self.assertIn(v, vs)
-        its = c.items()
+        its = cv.items()
         for k in "ab":
             self.assertIn((k, k.capitalize()), its)
-        self.assertIn("a", c)
-        self.assertNotIn("c", c)
-        self.assertEqual(len(c), 3)
-        # templates typically use ``vars`` as ``dict`` instead of API methods
-        self.assertIs(c.vars, c)
+        self.assertIn("a", cv)
+        self.assertNotIn("c", cv)
+        self.assertEqual(len(cv), 4)
 
     def test_setGlobal(self):
-        top_context = self.z_context
+        top_context = self.z_context.vars
         c_context = self.c_context.copy()  # context push
         c = _C2ZContextWrapper(c_context, None)  # local ``zope`` context
+        cv = c.vars
         c.setLocal("a", "A")
-        self.assertIn("a", c)
+        self.assertIn("a", cv)
         self.assertNotIn("a", top_context)
         c.setGlobal("b", "B")
         # the following (commented code) line fails due to
         #   "https://github.com/malthe/chameleon/issues/305"
         # self.assertIn("b", c)
         self.assertIn("b", top_context)
-        self.assertEqual(c["b"], "B")
+        self.assertEqual(cv["b"], "B")
         self.assertEqual(top_context["b"], "B")
         # Note: "https://github.com/malthe/chameleon/issues/305":
         #   ``dict`` methods are unreliable in presence of global variables
@@ -69,7 +75,8 @@ class C2ZContextTests(unittest.TestCase):
     def test_unimplemented(self):
         c = self.z_context
         cd = Context.__dict__
-        for m in ("beginScope", "endScope", "setSourceFile", "setPosition"):
+        for m in ("beginScope", "endScope", "setSourceFile", "setPosition",
+                  "setRepeat"):
             self.assertIn(m, cd)  # check against spelling errors
             with self.assertRaises(NotImplementedError):
                 getattr(c, m)()
@@ -80,36 +87,71 @@ class C2ZContextTests(unittest.TestCase):
 
     def test_attrs(self):
         c = self.z_context
-        self.assertIsNone(c["attrs"])
+        self.assertIsNone(c.vars["attrs"])
         c.setLocal("attrs", "hallo")
-        self.assertEqual(c["attrs"], "hallo")
+        self.assertEqual(c.vars["attrs"], "hallo")
 
     def test_faithful_wrapping(self):
-        class MyContext(object):
-            def set(self, v):
-                self.attr = v
+        class MyContextBase(object):
+            var = None
+            var2 = None
 
             def get_vars(self):
                 return self.vars
 
+        class MyContext(MyContextBase):
+            var = None
+
+            def set(self, v):
+                self.attr = v
+
+            def get_vars(self):
+                return super(MyContext, self).get_vars()
+
             def my_get(self, k):
-                return self[k]
+                return self.vars[k]
+
+            def override_var(self):
+                self.var = "var"
 
         c_context = self.c_context
-        c_context["__zt_context__"] = my_context = MyContext()
+        my_context = MyContext()
+        my_context.var2 = "var2"
+        c_context["__zt_context__"] = wrap(my_context)
         zc = _C2ZContextWrapper(c_context, None)
-        # attributes in ``my_context``
+        # attributes
         #   -- via method
         zc.set("attr")
-        self.assertEqual(my_context.attr, "attr")
+        self.assertEqual(zc.attr, "attr")
         #  -- via wrapper
         zc.wattr = "wattr"
-        self.assertEqual(my_context.wattr, "wattr")
-        # correct ``vars``
-        self.assertIs(zc.get_vars(), zc)
+        self.assertEqual(zc.wattr, "wattr")
+        # correct ``vars``; including ``super``
+        self.assertEqual(zc.get_vars(), zc.vars)
         # correct subscription
         zc.setLocal("a", "a")
         self.assertEqual(zc.my_get("a"), "a")
         # correct attribute access
         my_context.my_attr = "my_attr"
         self.assertEqual(zc.my_attr, "my_attr")
+        # override class variable
+        self.assertIsNone(zc.var)
+        zc.override_var()
+        self.assertEqual(zc.var, "var")
+        # instance variable over class variable
+        self.assertEqual(zc.var2, "var2")
+
+    def test_context_class_registry(self):
+        class MyContext(object):
+            pass
+
+        class_regs = len(_context_class_registry)
+        wc1 = wrap(MyContext())()
+        self.assertEqual(len(_context_class_registry), class_regs + 1)
+        wc2 = wrap(MyContext())()
+        self.assertEqual(len(_context_class_registry), class_regs + 1)
+        self.assertIs(wc1.__class__, wc2.__class__)
+
+    def test_default(self):
+        c = self.z_context
+        self.assertIs(c.getDefault(), DEFAULT_MARKER)


### PR DESCRIPTION
This PR improves the faithfulness of the "chameleon zope context wrapping".

`chameleon` evaluates TALES expressions in a do called `Scope` -- a mapping from (variable) names to their current values.

`zope.tales` TALES expressions are functions returning a value when called with a "context". The "context" is expected to know about the current name to value mapping and to know the TALES engine. The precise details of the "context" are determined by the TALES engine.

The "chameleon zope context wrapper" integrates `chameleon`'s `Scope` and `zope.tales`' "context" into one object. Its task is to manage variable settings in the `Scope` and everything else in the "context".

Formerly, the wrapper delegated data to the correct subobjects; but it took much of its implementation directly from `ZopeContext`, the class of the "context" used by `Products.PageTemplates`. This is wrong in the case that the "context" is not an instance of `ZopeContext`. This PR lets the wrapper delegate unknown method calls to the "context" rebindung their `__self__` to ensure that those methods access the correct "variable -> value" mapping.