### PR TITLE
avoid unsolicited translations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ https://zope.readthedocs.io/en/2.13/CHANGES.html
 4.5.1 (unreleased)
 ------------------
 
+- Avoid unsolicited translations
+  (`#876 <https://github.com/zopefoundation/Zope/issues/876>`_)
 
 - Make "chameleon-zope context wrapping" more faithful.
   (`#873 <https://github.com/zopefoundation/Zope/pull/873/files>`_)

--- a/src/Products/PageTemplates/engine.py
+++ b/src/Products/PageTemplates/engine.py
@@ -14,6 +14,7 @@ import logging
 import re
 from weakref import ref
 
+import six
 from chameleon.astutil import Static
 from chameleon.astutil import Symbol
 from chameleon.codegen import template
@@ -135,6 +136,13 @@ def _compile_zt_expr(type, expression, engine=None, econtext=None):
     """
     if engine is None:
         engine = econtext["__zt_engine__"]
+    # *expression* is a ``chameleon.tokenize.Token`` when
+    # the template is compiled but "text" when the template code
+    # comes from the ``chameleon`` cache.
+    # Under PY3, ``chameleon`` wrongly translates ``Token``;
+    # convert to ``str`` to avoid this
+    if six.PY3:
+        expression = str(expression)
     key = id(engine), type, expression
     # cache lookup does not need to be protected by locking
     #  (but we could potentially prevent unnecessary computations)

--- a/src/Products/PageTemplates/tests/testTranslation.py
+++ b/src/Products/PageTemplates/tests/testTranslation.py
@@ -14,7 +14,10 @@
 from unittest import TestCase
 
 from z3c.pt import pagetemplate
+from zope.component import provideAdapter
 from zope.component.testing import PlacelessSetup
+from zope.i18nmessageid import ZopeMessageFactory as _
+from zope.traversing.adapters import DefaultTraversable
 
 from ..PageTemplate import PageTemplate
 from .util import useChameleonEngine
@@ -41,6 +44,7 @@ class TranslationTests(PlacelessSetup, TestCase):
 
     def setUp(self):
         super(TranslationTests, self).setUp()
+        provideAdapter(DefaultTraversable, (None,))
         useChameleonEngine()
 
     def test_translation_body(self):
@@ -57,6 +61,11 @@ class TranslationTests(PlacelessSetup, TestCase):
         t = PageTemplate()
         t.write("""<p i18n:translate="" tal:replace="string:x">text</p>""")
         self.assertEqual(t(), "translated")
+
+    def test_translation_msgid(self):
+        t = PageTemplate()
+        t.write("""<p tal:replace="options/msgid">text</p>""")
+        self.assertEqual(t(msgid=_(u"x")), "translated")
 
     def test_no_translation_body(self):
         t = PageTemplate()

--- a/src/Products/PageTemplates/tests/testTranslation.py
+++ b/src/Products/PageTemplates/tests/testTranslation.py
@@ -1,0 +1,74 @@
+##############################################################################
+#
+# Copyright (c) 2020 Zope Foundation and Contributors.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE
+#
+##############################################################################
+
+from unittest import TestCase
+
+from z3c.pt import pagetemplate
+from zope.component.testing import PlacelessSetup
+
+from ..PageTemplate import PageTemplate
+from .util import useChameleonEngine
+
+
+def translate(*args, **kw):
+    return "translated"
+
+
+class TranslationLayer(object):
+    """set up our translation function."""
+    @classmethod
+    def setUp(cls):
+        cls._saved_translate = pagetemplate.fast_translate
+        pagetemplate.fast_translate = translate
+
+    @classmethod
+    def tearDown(cls):
+        pagetemplate.fast_translate = cls.__dict__["_saved_translate"]
+
+
+class TranslationTests(PlacelessSetup, TestCase):
+    layer = TranslationLayer
+
+    def setUp(self):
+        super(TranslationTests, self).setUp()
+        useChameleonEngine()
+
+    def test_translation_body(self):
+        t = PageTemplate()
+        t.write("""<p i18n:translate="">text</p>""")
+        self.assertEqual(t(), "<p>translated</p>")
+
+    def test_translation_content(self):
+        t = PageTemplate()
+        t.write("""<p i18n:translate="" tal:content="string:x">text</p>""")
+        self.assertEqual(t(), "<p>translated</p>")
+
+    def test_translation_replace(self):
+        t = PageTemplate()
+        t.write("""<p i18n:translate="" tal:replace="string:x">text</p>""")
+        self.assertEqual(t(), "translated")
+
+    def test_no_translation_body(self):
+        t = PageTemplate()
+        t.write("""<p>text</p>""")
+        self.assertEqual(t(), "<p>text</p>")
+
+    def test_no_translation_content(self):
+        t = PageTemplate()
+        t.write("""<p tal:content="string:x">text</p>""")
+        self.assertEqual(t(), "<p>x</p>")
+
+    def test_no_translation_replace(self):
+        t = PageTemplate()
+        t.write("""<p tal:replace="string:x">text</p>""")
+        self.assertEqual(t(), "x")


### PR DESCRIPTION
This PR fixes #876 

When a template is compiled by `chameleon` expressions are represented in the following execution by `chameleon.tokenize.Token`s, when the template code comes from the `chameleon` cache, expressions are represented in the execution by simple text. The `zope.tales` integration has been partially type preserving: in some cases a `Token` input resulted in a `Token` output. Under Python 3, `chameleon` interprets a `Token` result wrongly as "to be translated". The result has been unsolicited translations when a template was compiled by the current process and correct translations when the template came from the cache.

This PR works around this behavior by explicitly converting `Token` into `str` under Python 3.