### PR TITLE
Upgrade zodbupdate to 1.5. [4.x]

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -83,4 +83,4 @@ zc.recipe.testrunner = 2.1
 zest.releaser = 6.21.0
 # Version 2 requires Python 3
 zipp = 1.1.1
-zodbupdate = 1.4
+zodbupdate = 1.5


### PR DESCRIPTION
Needed for ZODB 5.6.0.

After this, I think we are ready for a Zope 4.5.1 release.