### PR TITLE
Zope 4: use DocumentTemplate branch 3.x.

### DIFF
--- a/sources.cfg
+++ b/sources.cfg
@@ -8,7 +8,7 @@ AccessControl = git ${remotes:github}/AccessControl pushurl=${remotes:github_pus
 Acquisition = git ${remotes:github}/Acquisition pushurl=${remotes:github_push}/Acquisition
 AuthEncoding = git ${remotes:github}/AuthEncoding pushurl=${remotes:github_push}/AuthEncoding
 DateTime = git ${remotes:github}/DateTime pushurl=${remotes:github_push}/DateTime
-DocumentTemplate = git ${remotes:github}/DocumentTemplate pushurl=${remotes:github_push}/DocumentTemplate
+DocumentTemplate = git ${remotes:github}/DocumentTemplate pushurl=${remotes:github_push}/DocumentTemplate branch=3.x
 ExtensionClass = git ${remotes:github}/ExtensionClass pushurl=${remotes:github_push}/ExtensionClass
 MultiMapping = git ${remotes:github}/MultiMapping pushurl=${remotes:github_push}/MultiMapping
 Persistence = git ${remotes:github}/Persistence pushurl=${remotes:github_push}/Persistence


### PR DESCRIPTION
The master branch targets Zope 5.
It fails with python 2.7:

```
File "/Users/maurits/community/plone-coredev/5.2/src/DocumentTemplate/src/DocumentTemplate/DT_Var.py", line 156, in <module>
    import urllib.parse
ImportError: No module named parse
```