### PR TITLE
Restore the ZMI `Debug Information` control panel page

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ https://zope.readthedocs.io/en/2.13/CHANGES.html
 4.5.2 (unreleased)
 ------------------
 
+- Restore the ZMI `Debug Information` control panel page
+  (`#898 <https://github.com/zopefoundation/Zope/issues/898>`_)
+
 - Update dependencies to the latest releases that still support Python 2.
 
 - Update to ``zope.interface > 5.1.0`` to fix a memory leak.

--- a/src/App/ApplicationManager.py
+++ b/src/App/ApplicationManager.py
@@ -153,6 +153,7 @@ class DebugManager(Tabs, Traversable, Implicit):
     id = 'DebugInfo'
     name = title = 'Debug Information'
     meta_type = name
+    zmi_icon = 'fas fa-bug'
 
     manage_options = (
         {'label': 'Control Panel', 'action': '../manage_main'},

--- a/src/App/ApplicationManager.py
+++ b/src/App/ApplicationManager.py
@@ -16,6 +16,7 @@ import sys
 import time
 import types
 
+from six import class_types
 from six.moves._thread import get_ident
 from six.moves.urllib import parse
 
@@ -163,7 +164,7 @@ class DebugManager(Tabs, Traversable, Implicit):
         {'label': 'Debug Information', 'action': 'manage_main'},
     )
 
-    def refcount(self, n=None, t=(type(Implicit), )):
+    def refcount(self, n=None, t=(type(Implicit),) + class_types):
         # return class reference info
         counts = {}
         for m in list(sys.modules.values()):
@@ -177,10 +178,11 @@ class DebugManager(Tabs, Traversable, Implicit):
                     counts[ob] = sys.getrefcount(ob)
         pairs = []
         for ob, v in counts.items():
+            ob_name = getattr(ob, "__name__", "unknown")
             if hasattr(ob, '__module__'):
-                name = '%s.%s' % (ob.__module__, ob.__name__)
+                name = '%s.%s' % (ob.__module__, ob_name)
             else:
-                name = '%s' % ob.__name__
+                name = '%s' % ob_name
             pairs.append((v, name))
         pairs.sort()
         pairs.reverse()

--- a/src/App/CacheManager.py
+++ b/src/App/CacheManager.py
@@ -1,0 +1,86 @@
+##############################################################################
+#
+# Copyright (c) 2002 Zope Foundation and Contributors.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE
+#
+##############################################################################
+"""Cache management support.
+
+This class is mixed into the application manager in App.ApplicationManager.
+"""
+
+from AccessControl.class_init import InitializeClass
+from Acquisition import aq_parent
+
+
+class CacheManager:
+    """Cache management mix-in
+    """
+
+    def _getDB(self):
+        try:
+            return self._p_jar.db()
+        except AttributeError:
+            return aq_parent(self)._p_jar.db()
+
+    def cache_size(self):
+        db = self._getDB()
+        return db.getCacheSize()
+
+    def cache_detail(self, REQUEST=None):
+        """
+        Returns the name of the classes of the objects in the cache
+        and the number of objects in the cache for each class.
+        """
+        detail = self._getDB().cacheDetail()
+        if REQUEST is not None:
+            # format as text
+            REQUEST.RESPONSE.setHeader('Content-Type', 'text/plain')
+            return '\n'.join(
+                ['%6d %s' % (count, name) for name, count in detail])
+        # raw
+        return detail
+
+    def cache_extreme_detail(self, REQUEST=None):
+        """
+        Returns information about each object in the cache.
+        """
+        detail = self._getDB().cacheExtremeDetail()
+        if REQUEST is not None:
+            # sort the list.
+            lst = [((dict['conn_no'], dict['oid']), dict) for dict in detail]
+            # format as text.
+            res = [
+                '# Table shows connection number, oid, refcount, state, '
+                'and class.',
+                '# States: L = loaded, G = ghost, C = changed']
+            for sortkey, dict in lst:
+                id = dict.get('id', None)
+                if id:
+                    idinfo = ' (%s)' % id
+                else:
+                    idinfo = ''
+                s = dict['state']
+                if s == 0:
+                    state = 'L'  # loaded
+                elif s == 1:
+                    state = 'C'  # changed
+                else:
+                    state = 'G'  # ghost
+                res.append('%d %-34s %6d %s %s%s' % (
+                    dict['conn_no'], repr(dict['oid']), dict['rc'],
+                    state, dict['klass'], idinfo))
+            REQUEST.RESPONSE.setHeader('Content-Type', 'text/plain')
+            return '\n'.join(res)
+        else:
+            # raw
+            return detail
+
+
+InitializeClass(CacheManager)

--- a/src/App/DavLockManager.py
+++ b/src/App/DavLockManager.py
@@ -31,10 +31,16 @@ class DavLockManager(Item, Implicit):
 
     security.declareProtected(webdav_manage_locks,  # NOQA: D001
                               'manage_davlocks')
-    manage_davlocks = manage_main = manage = DTMLFile(
+    manage_davlocks = manage_main = manage = manage_workspace = DTMLFile(
         'dtml/davLockManager', globals())
     manage_davlocks._setName('manage_davlocks')
-    manage_options = ({'label': 'Write Locks', 'action': 'manage_main'}, )
+    manage_options = (
+        {'label': 'Control Panel', 'action': '../manage_main'},
+        {'label': 'Databases', 'action': 'manage_main'},
+        {'label': 'Configuration', 'action': '../Configuration/manage_main'},
+        {'label': 'DAV Locks', 'action': 'manage_main'},
+        {'label': 'Debug Information', 'action': '../DebugInfo/manage_main'},
+    )
 
     @security.protected(webdav_manage_locks)
     def findLockedObjects(self, frompath=''):

--- a/src/App/dtml/davLockManager.dtml
+++ b/src/App/dtml/davLockManager.dtml
@@ -1,5 +1,7 @@
 <dtml-var manage_page_header>
-<dtml-var manage_tabs>
+<dtml-with "_(management_view='DAV Locks')">
+  <dtml-var manage_tabs>
+</dtml-with>
 
 <main class="container-fluid">
 

--- a/src/App/dtml/debug.dtml
+++ b/src/App/dtml/debug.dtml
@@ -1,0 +1,107 @@
+<dtml-var manage_page_header>
+<dtml-if debug_auto_reload>
+<meta HTTP-EQUIV="Refresh"
+  CONTENT="&dtml-debug_auto_reload;;URL=&dtml-URL;?debug_auto_reload=&dtml-debug_auto_reload;">
+</dtml-if>
+<dtml-with "_(management_view='Debug Information')">
+  <dtml-var manage_tabs>
+</dtml-with>
+
+<dtml-if update_snapshot>
+  <dtml-call rcsnapshot>
+</dtml-if>
+
+<main class="container-fluid">
+
+  <p class="form-help mt-4">
+    Reference count and database connection information
+  </p>
+
+  <h4>Top 100 reference counts</h4>
+  <select name="foo" size="10">
+    <dtml-in "refcount(100)">
+      <option>&dtml-sequence-item;: &dtml-sequence-key;</option>
+    </dtml-in>
+  </select>
+
+  <dtml-let delta_info="rcdeltas">
+    <dtml-if delta_info>
+      <p><br/></p>
+      <h4>Changes since last refresh</h4>
+
+      <table border="1">
+      <dtml-in rcdeltas mapping>
+      <dtml-if sequence-start>
+      <tr>
+      <th class="header" align="left" valign="top">
+      Class
+      </th>
+      <th class="header" align="left" valign="top">
+      <dtml-var rcdate fmt="fCommon" null="">
+      </th>
+      <th class="header" align="left" valign="top">
+      <dtml-var ZopeTime fmt="fCommon">
+      </th>
+      <th class="header" align="left" valign="top">
+      Delta
+      </th>
+      </tr>
+      </dtml-if>
+      <tr>
+      <td class="cell" align="left" valign="top">
+      &dtml-name;
+      </td>
+      <td class="cell" align="left" valign="top">
+      &dtml-pc;
+      </td>
+      <td class="cell" align="left" valign="top">
+      &dtml-rc;
+      </td>
+      <td class="cell" align="left" valign="top">
+      +&dtml-delta;
+      </td>
+      </tr>
+      </dtml-in>
+      </table>
+    </dtml-if>
+  </dtml-let>
+  
+  <p>
+    <a href="../Database/cache_detail">Cache detail</a> |
+    <a href="../Database/cache_extreme_detail">Cache extreme detail</a>
+  </p>
+
+  <p>
+    <form action="&dtml-URL;" method="GET">
+    <a href="&dtml-URL;?update_snapshot=1">Update Snapshot</a> | 
+    <dtml-if debug_auto_reload>
+      <a href="&dtml-URL;">Stop auto refresh</a>
+    <dtml-else>
+        <a href="&dtml-URL;">Refresh</a> |
+        Auto refresh interval (seconds):
+        <input type="text" name="debug_auto_reload" size="3" value="10">
+        <input type="submit" value="Start auto refresh">
+      </form>
+    </dtml-if>
+    </form>
+  </p>
+  
+  <h4>ZODB database connections</h4>
+  <table border="1">
+    <tr>
+      <th>Opened</th>
+      <th>Info</th>
+    </tr>
+    <dtml-in dbconnections mapping>
+      <tr>
+        <td>&dtml-opened;</td>
+        <td>&dtml-info;</td>
+      </tr>
+    </dtml-in>
+  </table>
+
+  <p><br/></p>
+  
+</main>
+
+<dtml-var manage_page_footer>

--- a/src/App/tests/test_ApplicationManager.py
+++ b/src/App/tests/test_ApplicationManager.py
@@ -5,6 +5,7 @@ import tempfile
 import time
 import unittest
 
+import Testing.testbrowser
 import Testing.ZopeTestCase
 
 

--- a/src/App/tests/test_ApplicationManager.py
+++ b/src/App/tests/test_ApplicationManager.py
@@ -366,6 +366,121 @@ class AltDatabaseManagerTests(unittest.TestCase):
         self.assertIsNone(am._getDB()._packed)
 
 
+class DebugManagerTests(unittest.TestCase):
+
+    def setUp(self):
+        import sys
+        self._sys = sys
+        self._old_sys_modules = sys.modules.copy()
+
+    def tearDown(self):
+        self._sys.modules.clear()
+        self._sys.modules.update(self._old_sys_modules)
+
+    def _getTargetClass(self):
+        from App.ApplicationManager import DebugManager
+        return DebugManager
+
+    def _makeOne(self, id):
+        return self._getTargetClass()(id)
+
+    def _makeModuleClasses(self):
+        import sys
+        import types
+        from ExtensionClass import Base
+
+        class Foo(Base):
+            pass
+
+        class Bar(Base):
+            pass
+
+        class Baz(Base):
+            pass
+
+        foo = sys.modules['foo'] = types.ModuleType('foo')
+        foo.Foo = Foo
+        Foo.__module__ = 'foo'
+        foo.Bar = Bar
+        Bar.__module__ = 'foo'
+        qux = sys.modules['qux'] = types.ModuleType('qux')
+        qux.Baz = Baz
+        Baz.__module__ = 'qux'
+        return Foo, Bar, Baz
+
+    def test_refcount_no_limit(self):
+        import sys
+        dm = self._makeOne('test')
+        Foo, Bar, Baz = self._makeModuleClasses()
+        pairs = dm.refcount()
+        # XXX : Ugly empiricism here:  I don't know why the count is up 1.
+        foo_count = sys.getrefcount(Foo)
+        self.assertTrue((foo_count + 1, 'foo.Foo') in pairs)
+        bar_count = sys.getrefcount(Bar)
+        self.assertTrue((bar_count + 1, 'foo.Bar') in pairs)
+        baz_count = sys.getrefcount(Baz)
+        self.assertTrue((baz_count + 1, 'qux.Baz') in pairs)
+
+    def test_refdict(self):
+        import sys
+        dm = self._makeOne('test')
+        Foo, Bar, Baz = self._makeModuleClasses()
+        mapping = dm.refdict()
+        # XXX : Ugly empiricism here:  I don't know why the count is up 1.
+        foo_count = sys.getrefcount(Foo)
+        self.assertEqual(mapping['foo.Foo'], foo_count + 1)
+        bar_count = sys.getrefcount(Bar)
+        self.assertEqual(mapping['foo.Bar'], bar_count + 1)
+        baz_count = sys.getrefcount(Baz)
+        self.assertEqual(mapping['qux.Baz'], baz_count + 1)
+
+    def test_rcsnapshot(self):
+        import sys
+        import App.ApplicationManager
+        from DateTime.DateTime import DateTime
+        dm = self._makeOne('test')
+        Foo, Bar, Baz = self._makeModuleClasses()
+        before = DateTime()
+        dm.rcsnapshot()
+        after = DateTime()
+        # XXX : Ugly empiricism here:  I don't know why the count is up 1.
+        self.assertTrue(before <= App.ApplicationManager._v_rst <= after)
+        mapping = App.ApplicationManager._v_rcs
+        foo_count = sys.getrefcount(Foo)
+        self.assertEqual(mapping['foo.Foo'], foo_count + 1)
+        bar_count = sys.getrefcount(Bar)
+        self.assertEqual(mapping['foo.Bar'], bar_count + 1)
+        baz_count = sys.getrefcount(Baz)
+        self.assertEqual(mapping['qux.Baz'], baz_count + 1)
+
+    def test_rcdate(self):
+        import App.ApplicationManager
+        dummy = object()
+        App.ApplicationManager._v_rst = dummy
+        dm = self._makeOne('test')
+        found = dm.rcdate()
+        App.ApplicationManager._v_rst = None
+        self.assertTrue(found is dummy)
+
+    def test_rcdeltas(self):
+        dm = self._makeOne('test')
+        dm.rcsnapshot()
+        Foo, Bar, Baz = self._makeModuleClasses()
+        mappings = dm.rcdeltas()
+        self.assertTrue(len(mappings))
+        mapping = mappings[0]
+        self.assertTrue('rc' in mapping)
+        self.assertTrue('pc' in mapping)
+        self.assertEqual(mapping['delta'], mapping['rc'] - mapping['pc'])
+
+    # def test_dbconnections(self):  XXX -- TOO UGLY TO TEST
+
+    def test_manage_getSysPath(self):
+        import sys
+        dm = self._makeOne('test')
+        self.assertEqual(dm.manage_getSysPath(), list(sys.path))
+
+
 class MenuDtmlTests(ConfigTestBase, Testing.ZopeTestCase.FunctionalTestCase):
     """Browser testing ..dtml.menu.dtml."""
 

--- a/src/App/tests/test_cachemanager.py
+++ b/src/App/tests/test_cachemanager.py
@@ -1,0 +1,60 @@
+##############################################################################
+#
+# Copyright (c) 2003 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+"""Tests for the CacheManager.
+"""
+
+import unittest
+
+
+class DummyConnection:
+
+    def __init__(self, db):
+        self.__db = db
+
+    def db(self):
+        return self.__db
+
+
+class DummyDB:
+
+    def __init__(self, cache_size):
+        self._set_sizes(cache_size)
+
+    def _set_sizes(self, cache_size):
+        self.__cache_size = cache_size
+
+    def getCacheSize(self):
+        return self.__cache_size
+
+
+class CacheManagerTestCase(unittest.TestCase):
+
+    def _getManagerClass(self):
+        from App.CacheManager import CacheManager
+
+        class TestCacheManager(CacheManager):
+            # Derived CacheManager that fakes enough of the DatabaseManager to
+            # make it possible to test at least some parts of the CacheManager.
+            def __init__(self, connection):
+                self._p_jar = connection
+
+        return TestCacheManager
+
+    def test_cache_size(self):
+        db = DummyDB(42)
+        connection = DummyConnection(db)
+        manager = self._getManagerClass()(connection)
+        self.assertEqual(manager.cache_size(), 42)
+        db._set_sizes(12)
+        self.assertEqual(manager.cache_size(), 12)

--- a/src/ZPublisher/WSGIPublisher.py
+++ b/src/ZPublisher/WSGIPublisher.py
@@ -248,6 +248,18 @@ def publish(request, module_info):
     request['PARENTS'] = [obj]
 
     obj = request.traverse(path, validated_hook=validate_user)
+
+    # Set debug information from the active request on the open connection
+    # Used to be done in ZApplicationWrapper.__bobo_traverse__ for ZServer
+    try:
+        # Grab the connection from the last (root application) object,
+        # which usually has a connection available.
+        request['PARENTS'][-1]._p_jar.setDebugInfo(request.environ,
+                                                   request.other)
+    except AttributeError:
+        # If there is no connection don't worry
+        pass
+
     notify(pubevents.PubAfterTraversal(request))
     recordMetaData(obj, request)
 


### PR DESCRIPTION
Fixes #898 

This PR adds a "Debug Information" page to the control panel. This Debug Information page restores those parts of the old Zope 2  DebugInfo page that are not already presented on other control panel tabs.

The trickiest part was finding a place to add the request debugging information for running requests that shows up at the bottom of the page where the database connection information is. I have added it inside the WSGI publisher code. This used to be done by the `App.ZApplication.ZApplicationWrapper.__bobo_traverse__`, but that method is only called by the old ZServer publisher.

The ZMI bits could use some prettification, but functionally it's all there.