### PR TITLE
Http response header encoding

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ https://zope.readthedocs.io/en/2.13/CHANGES.html
 ------------------
 
 - HTTP header encoding support
+  (`#905 <https://github.com/zopefoundation/Zope/pull/905>`_)
 
 - Update dependencies to the latest releases that still support Python 2.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ https://zope.readthedocs.io/en/2.13/CHANGES.html
 4.5.2 (unreleased)
 ------------------
 
+- HTTP header encoding support
+
 - Update dependencies to the latest releases that still support Python 2.
 
 - Update to ``zope.interface > 5.1.0`` to fix a memory leak.

--- a/src/ZPublisher/HTTPResponse.py
+++ b/src/ZPublisher/HTTPResponse.py
@@ -800,7 +800,7 @@ class HTTPResponse(HTTPBaseResponse):
     def _error_html(self, title, body):
         return ("""<!DOCTYPE html><html>
   <head><title>Site Error</title><meta charset="utf-8" /></head>
-  <body bgcolor='#FFFFFF'>
+  <body bgcolor="#FFFFFF">
   <h2>Site Error</h2>
   <p>An error was encountered while publishing this resource.
   </p>

--- a/src/ZPublisher/HTTPResponse.py
+++ b/src/ZPublisher/HTTPResponse.py
@@ -790,7 +790,7 @@ class HTTPResponse(HTTPBaseResponse):
     def _error_html(self, title, body):
         return ("""<!DOCTYPE html><html>
   <head><title>Site Error</title><meta charset="utf-8" /></head>
-  <body bgcolor="#FFFFFF">
+  <body bgcolor='#FFFFFF'>
   <h2>Site Error</h2>
   <p>An error was encountered while publishing this resource.
   </p>

--- a/src/ZPublisher/HTTPResponse.py
+++ b/src/ZPublisher/HTTPResponse.py
@@ -1218,7 +1218,7 @@ def encode_params(value):
 
     Many HTTP headers use `,` separated lists. For simplicity,
     such headers are not supported (we would need to recognize
-    `,` inside quoted strings as special).1G
+    `,` inside quoted strings as special).
     """
     params = []
     for p in _parseparam(";" + value):


### PR DESCRIPTION
HTTP requires that response (and request) header fields use `ISO-8859-1` (or a subset) as charset for their values. `waitress` builds on this and raises an exception when a field value cannot be represented in this charset.

This PR provides support for RFC 2047 ("encode_words") and RFC 2231 ("encode params"; in its HTTP specialization by RFC 5987/8187) for response header field values not covered by `ISO-8859-1` via new `ZPublisher.HTTPResponse.header_encoding_registry` (of class `HeaderEncodingRegistry`). `HTTPResponse.listHeaders` consults this registry in its `listHeaders` method to determine how header field values outside `ISO-8859-1` should be handled. By default, it uses `encode_params` as encoding for `Content-Type` and `Content-Disposition` and does not encode other header fields (which may result in exceptions in the web server framework). An application can register encodings for additional fields.

`encode_params` is usable for structured headers to support non-ISO-8859-1 values in parameter values. Currently, it cannot be for used headers that support multiple (comma separated) parameter sets.

`encode_words` can be used for unstructured headers.

The cookie header fields are under complete control of `HTTPResponse`'s cookie handling and not affected by `header_encoding_registry`.