### PR TITLE
Exclude ${} from use in TALES path expressions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,10 +10,16 @@ https://zope.readthedocs.io/en/2.13/CHANGES.html
 4.5.2 (unreleased)
 ------------------
 
+Backward incompatible changes
++++++++++++++++++++++++++++++
+
 - Exclude characters special for ``chameleon``'s interpolation syntax
-  (i.e. ``${}``) from use in path expressions to reduce the failure risk
+  (i.e. ``${}``) from use in TALES path expressions to reduce the failure risk
   for the ``chameleon`` interpolation heuristics
   (`#925 <https://github.com/zopefoundation/Zope/issues/925>`_)
+
+Fixes
++++++
 
 - Fix ``length`` for page template repeat variables
   (`#913 <https://github.com/zopefoundation/Zope/issues/913>`_)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,11 @@ https://zope.readthedocs.io/en/2.13/CHANGES.html
 4.5.2 (unreleased)
 ------------------
 
+- Exclude characters special for ``chameleon``'s interpolation syntax
+  (i.e. ``${}``) from use in path expressions to reduce the failure risk
+  for the ``chameleon`` interpolation heuristics
+  (`#925 <https://github.com/zopefoundation/Zope/issues/925>`_)
+
 - Fix ``length`` for page template repeat variables
   (`#913 <https://github.com/zopefoundation/Zope/issues/913>`_)
 

--- a/src/Products/PageTemplates/tests/input/InterpolationInContent.html
+++ b/src/Products/PageTemplates/tests/input/InterpolationInContent.html
@@ -2,5 +2,6 @@
 <head></head>
 <body>
 <p tal:define="d python:{'a': 'A', 'b': 'B'}">${d/a} &rarr; ${d/b}</p>
+<p tal:define="d python:{'a': 'A', 'b': 'B'}">${d/a} }</p>
 </body>
 </html>

--- a/src/Products/PageTemplates/tests/output/InterpolationInContent.html
+++ b/src/Products/PageTemplates/tests/output/InterpolationInContent.html
@@ -2,5 +2,6 @@
 <head></head>
 <body>
 <p>A &rarr; B</p>
+<p>A }</p>
 </body>
 </html>

--- a/versions-prod.cfg
+++ b/versions-prod.cfg
@@ -11,6 +11,7 @@ AuthEncoding = 4.2
 BTrees = 4.7.2
 Chameleon = 3.8.1
 DateTime = 4.3
+# DocumentTemplate 4+ no longer supports Zope 4.
 DocumentTemplate = 3.4
 ExtensionClass = 4.4
 Missing = 4.1


### PR DESCRIPTION
Fixes #925 

The `chameleon` interpolation has special characters `${}`. When those characters are usable in TALES path expressions, `chameleon`'s interpolation heuristics (use the longest possible interpolation string the compilation of which does not cause a syntax error) has a high risk to break. One such example is #925 

This PR (essentially) forbids the use of `${}` in path expressions to reduce the failure risk for the interpolation heuristics (actually, it forbids those characters only in `SubPathExpr`s with a standard path; they can still be used in other types, e.g. a trailing `python` or `string` expression).