### PR TITLE
Ensure native string response headers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,14 @@ https://zope.readthedocs.io/en/2.13/CHANGES.html
 
 - Update dependencies to the latest releases that still support Python 2.
 
+Fixes
++++++
+
+- Convert ``bytes`` (Python 3) and ``unicode`` (Python 2) values for
+  HTTP response headers into native strings using the HTTP/1.1
+  stipulated ``ISO-8859-1`` encoding. This makes ``waitress`` happy
+  which insists on native strings for those values.
+
 
 4.5.2 (2020-11-12)
 ------------------

--- a/src/ZPublisher/HTTPResponse.py
+++ b/src/ZPublisher/HTTPResponse.py
@@ -113,6 +113,10 @@ _CRLF = re.compile(r'[\r\n]')
 
 
 def _scrubHeader(name, value):
+    if PY3 and isinstance(value, bytes):
+        # handle ``bytes`` values correctly
+        # we assume that the provider knows that HTTP 1.1 stipulates ISO-8859-1
+        value = value.decode("ISO-8859-1")
     if not isinstance(value, string_types):
         value = str(value)
     return ''.join(_CRLF.split(str(name))), ''.join(_CRLF.split(value))

--- a/src/ZPublisher/HTTPResponse.py
+++ b/src/ZPublisher/HTTPResponse.py
@@ -800,7 +800,7 @@ class HTTPResponse(HTTPBaseResponse):
     def _error_html(self, title, body):
         return ("""<!DOCTYPE html><html>
   <head><title>Site Error</title><meta charset="utf-8" /></head>
-  <body bgcolor="#FFFFFF">
+  <body bgcolor="white">
   <h2>Site Error</h2>
   <p>An error was encountered while publishing this resource.
   </p>

--- a/src/ZPublisher/HTTPResponse.py
+++ b/src/ZPublisher/HTTPResponse.py
@@ -116,7 +116,7 @@ def _scrubHeader(name, value):
     if PY3 and isinstance(value, bytes):
         # handle ``bytes`` values correctly
         # we assume that the provider knows that HTTP 1.1 stipulates ISO-8859-1
-        value = value.decode("ISO-8859-1")
+        value = value.decode('ISO-8859-1')
     if not isinstance(value, string_types):
         value = str(value)
     return ''.join(_CRLF.split(str(name))), ''.join(_CRLF.split(value))
@@ -727,7 +727,12 @@ class HTTPBaseResponse(BaseResponse):
             ('X-Powered-By', 'Zope (www.zope.org), Python (www.python.org)')
         ]
 
-        encode = header_encoding_registry.encode
+        def encode(key, value, henc=header_encoding_registry.encode):
+            value = henc(key, value)
+            if PY2 and not isinstance(value, str):
+                # ``value`` is ``unicode``
+                value = value.encode('ISO-8859-1')
+            return value
         for key, value in self.headers.items():
             if key.lower() == key:
                 # only change non-literal header names

--- a/src/ZPublisher/tests/testHTTPResponse.py
+++ b/src/ZPublisher/tests/testHTTPResponse.py
@@ -4,6 +4,8 @@ import traceback
 import unittest
 from io import BytesIO
 
+from six import PY2
+
 from zExceptions import BadRequest
 from zExceptions import Forbidden
 from zExceptions import InternalError
@@ -1384,20 +1386,24 @@ class HTTPResponseTests(unittest.TestCase):
 
     def test_header_encoding(self):
         r = self._makeOne()
-        r.setHeader("unencoded1", u"€")
+        ae = u"ä"
+        ae_enc = ae.encode("ISO-8859-1") if PY2 else ae
+        r.setHeader("unencoded1", ae)
         r.setHeader("content-disposition", u"a; p=€")
-        r.addHeader("unencoded2", u"€")
+        r.addHeader("unencoded2", ae)
         r.addHeader("content-disposition", u"a2; p2=€")
+        r.addHeader("bytes", b"abc")
         hdrs = r.listHeaders()[1:]  # drop `X-Powered...`
         shdrs, ahdrs = dict(hdrs[:2]), dict(hdrs[2:])
         # for some reasons, `set` headers change their name
         #   while `add` headers do not
-        self.assertEqual(shdrs["Unencoded1"], u"€")
-        self.assertEqual(ahdrs["unencoded2"], u"€")
+        self.assertEqual(shdrs["Unencoded1"], ae_enc)
+        self.assertEqual(ahdrs["unencoded2"], ae_enc)
         self.assertEqual(shdrs["Content-Disposition"],
                          u"a; p=?; p*=utf-8''%E2%82%AC")
         self.assertEqual(ahdrs["content-disposition"],
                          u"a2; p2=?; p2*=utf-8''%E2%82%AC")
+        self.assertEqual(ahdrs["bytes"], "abc")
 
 
 class TestHeaderEncodingRegistry(unittest.TestCase):


### PR DESCRIPTION
Apparently (--> "https://github.com/zopefoundation/Zope/pull/905#issuecomment-726018560"), `waitress` insists on native strings as values for HTTP response headers and rejects `unicode` values on Python 2.

Looking into this problem, I noticed that under Python 3 `bytes` header values are not handled correctly (this time by `ZPublisher.HTTPResponse._scrubHeader`).

This PR ensures proper use of native strings as HTTP response header values converting via `ISO-8859-1` if necessary.