### PR TITLE
Fix longstanding issue with incorrect identification of Python memory…

### DIFF
--- a/src/ZPublisher/HTTPResponse.py
+++ b/src/ZPublisher/HTTPResponse.py
@@ -69,7 +69,7 @@ status_codes['resourcelockederror'] = 423
 
 start_of_header_search = re.compile('(<head[^>]*>)', re.IGNORECASE).search
 base_re_search = re.compile('(<base.*?>)', re.I).search
-bogus_str_search = re.compile(b" [a-fA-F0-9]+>$").search
+bogus_str_search = re.compile(b" 0x[a-fA-F0-9]+>$").search
 charset_re_str = (r'(?:application|text)/[-+0-9a-z]+\s*;\s*'
                   r'charset=([-_0-9a-z]+)(?:(?:\s*;)|\Z)')
 charset_re_match = re.compile(charset_re_str, re.IGNORECASE).match

--- a/src/ZPublisher/tests/testHTTPResponse.py
+++ b/src/ZPublisher/tests/testHTTPResponse.py
@@ -651,7 +651,7 @@ class HTTPResponseTests(unittest.TestCase):
         # (r19315): "merged content type on error fixes from 2.3
         # If the str of the object returs a Python "pointer" looking mess,
         # don't let it get treated as HTML.
-        BOGUS = b'<Bogus a39d53d>'
+        BOGUS = b'<Bogus 0xa39d53d>'
         response = self._makeOne()
         self.assertRaises(NotFound, response.setBody, BOGUS)
 


### PR DESCRIPTION
… address strings

This is used so that generic object __repr__ strings are not returned to a client browser. The code to perform this function has existed for a long time and been buggy the entire time because the regex used is incorrect. The existing (wrong) behaviour can be observed by putting in the name of any generic view against a running zope instance, eg:

http://localhost:8080/resource

returns:

<Zope2.App.traversing.resource object at 0x7f81ed0c1d90>

But what the code in HTTPResponse.py *tries* to do is identify these and return 'Not Found' instead.