### PR TITLE
Port of #933 to 4.x

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,8 @@ https://zope.readthedocs.io/en/2.13/CHANGES.html
 4.5.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix rendering of not found resources.
+  (`#933 <https://github.com/zopefoundation/Zope/pull/933>`_)
 
 
 4.5.3 (2020-11-16)

--- a/src/ZPublisher/HTTPResponse.py
+++ b/src/ZPublisher/HTTPResponse.py
@@ -22,6 +22,7 @@ from email.header import Header
 from email.message import _parseparam
 from email.utils import encode_rfc2231
 from io import BytesIO
+from io import IOBase
 
 from six import PY2
 from six import PY3
@@ -54,10 +55,10 @@ try:
 except ImportError:  # PY2
     from cgi import escape
 
-if sys.version_info >= (3, ):
-    from io import IOBase
+if PY2:
+    stream_handle = (file, IOBase)  # NOQA: F821
 else:
-    IOBase = file  # NOQA
+    stream_handle = IOBase
 
 # This may get overwritten during configuration
 default_encoding = 'utf-8'
@@ -533,8 +534,6 @@ class HTTPBaseResponse(BaseResponse):
             body = self._encode_unicode(body)
         elif isinstance(body, bytes):
             pass
-        elif isinstance(body, BytesIO):
-            body = body.getvalue()
         else:
             try:
                 body = bytes(body)
@@ -1106,7 +1105,7 @@ class WSGIResponse(HTTPBaseResponse):
         if self._locked_body:
             return
 
-        if isinstance(body, IOBase):
+        if isinstance(body, stream_handle):
             body.seek(0, 2)
             length = body.tell()
             body.seek(0)

--- a/src/ZPublisher/HTTPResponse.py
+++ b/src/ZPublisher/HTTPResponse.py
@@ -85,7 +85,7 @@ status_codes['resourcelockederror'] = 423
 
 start_of_header_search = re.compile('(<head[^>]*>)', re.IGNORECASE).search
 base_re_search = re.compile('(<base.*?>)', re.I).search
-bogus_str_search = re.compile(b" [a-fA-F0-9]+>$").search
+bogus_str_search = re.compile(b" 0x[a-fA-F0-9]+>$").search
 charset_re_str = (r'(?:application|text)/[-+0-9a-z]+\s*;\s*'
                   r'charset=([-_0-9a-z]+)(?:(?:\s*;)|\Z)')
 charset_re_match = re.compile(charset_re_str, re.IGNORECASE).match
@@ -533,6 +533,9 @@ class HTTPBaseResponse(BaseResponse):
             body = self._encode_unicode(body)
         elif isinstance(body, bytes):
             pass
+        elif isinstance(body, BytesIO):
+            print('XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
+            body = body.getvalue()
         else:
             try:
                 body = bytes(body)

--- a/src/ZPublisher/HTTPResponse.py
+++ b/src/ZPublisher/HTTPResponse.py
@@ -534,7 +534,6 @@ class HTTPBaseResponse(BaseResponse):
         elif isinstance(body, bytes):
             pass
         elif isinstance(body, BytesIO):
-            print('XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
             body = body.getvalue()
         else:
             try:

--- a/src/ZPublisher/tests/testHTTPResponse.py
+++ b/src/ZPublisher/tests/testHTTPResponse.py
@@ -654,7 +654,7 @@ class HTTPResponseTests(unittest.TestCase):
         # (r19315): "merged content type on error fixes from 2.3
         # If the str of the object returs a Python "pointer" looking mess,
         # don't let it get treated as HTML.
-        BOGUS = b'<Bogus a39d53d>'
+        BOGUS = b'<Bogus 0xa39d53d>'
         response = self._makeOne()
         self.assertRaises(NotFound, response.setBody, BOGUS)
 


### PR DESCRIPTION
I created a PR for this backport because it required an additional fix in response handling that I need some eyes on. The fix only affects Python 2 where the `setBody` method receives a body of type `io.BytesIO` sometimes, and the code would misinterpret that as one of the objects to raise the `NotFound`