### PR TITLE
zmi: added styles to debug info, minor fixes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,8 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 - Fix rendering of not found resources.
   (`#933 <https://github.com/zopefoundation/Zope/pull/933>`_)
   
+-  Revised debug info GUI
+  
 - Update to newest versions of dependencies.
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,13 +11,14 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 5.1.1 (unreleased)
 ------------------
 
+- Revised debug info GUI
+  (`#937 <https://github.com/zopefoundation/Zope/pull/937>`_)
+
 - Convert ``bytes`` ``HTTPResponse`` header value to ``str``
   via ``ISO-8859-1`` (the default encoding of ``HTTP/1.1``).
   
 - Fix rendering of not found resources.
   (`#933 <https://github.com/zopefoundation/Zope/pull/933>`_)
-  
--  Revised debug info GUI
   
 - Update to newest versions of dependencies.
 

--- a/src/App/dtml/cpConfiguration.dtml
+++ b/src/App/dtml/cpConfiguration.dtml
@@ -10,22 +10,24 @@
     Configuration information for the running Zope process.
   </p>
 
-  <table class="table">
+  <div class="table-responsive">
+  <table class="table table-sm table-striped">
     <dtml-in manage_getConfiguration mapping sort="name">
       <tr>
         <th class="text-muted">&dtml-name;</th>
-        <td class="code syspath">&dtml-value;</td>
+        <td class="code text-nowrap">&dtml-value;</td>
       </tr>
     </dtml-in>
     <tr>
       <th class="text-muted">Python path (sys.path)</th>
-      <td class="code syspath">
+      <td class="code text-nowrap">
         <dtml-in manage_getSysPath>
           <dtml-var sequence-item><br/>
         </dtml-in>
       </td>
     </tr>
   </table>
+  </div>
 
 </main>
 

--- a/src/App/dtml/debug.dtml
+++ b/src/App/dtml/debug.dtml
@@ -17,8 +17,8 @@
     Reference count and database connection information
   </p>
 
-  <h4>Top 100 reference counts</h4>
-  <select name="foo" size="10">
+  <h3>Top 100 reference counts</h3>
+  <select name="foo" size="10" class="form-control">
     <dtml-in "refcount(100)">
       <option>&dtml-sequence-item;: &dtml-sequence-key;</option>
     </dtml-in>
@@ -26,82 +26,74 @@
 
   <dtml-let delta_info="rcdeltas">
     <dtml-if delta_info>
-      <p><br/></p>
-      <h4>Changes since last refresh</h4>
+      <h3 class="mt-4">Changes since last refresh</h3>
 
-      <table border="1">
+      <table class="table table-bordered table-sm mb-2">
       <dtml-in rcdeltas mapping>
       <dtml-if sequence-start>
       <tr>
-      <th class="header" align="left" valign="top">
-      Class
-      </th>
-      <th class="header" align="left" valign="top">
-      <dtml-var rcdate fmt="fCommon" null="">
-      </th>
-      <th class="header" align="left" valign="top">
-      <dtml-var ZopeTime fmt="fCommon">
-      </th>
-      <th class="header" align="left" valign="top">
-      Delta
-      </th>
+      <th>Class</th>
+      <th><dtml-var rcdate fmt="%Y/%m/%d - %H:%M:%S" null=""></th>
+      <th><dtml-var ZopeTime fmt="%Y/%m/%d - %H:%M:%S"></th>
+      <th>Delta</th>
       </tr>
       </dtml-if>
       <tr>
-      <td class="cell" align="left" valign="top">
-      &dtml-name;
-      </td>
-      <td class="cell" align="left" valign="top">
-      &dtml-pc;
-      </td>
-      <td class="cell" align="left" valign="top">
-      &dtml-rc;
-      </td>
-      <td class="cell" align="left" valign="top">
-      +&dtml-delta;
-      </td>
+      <td>&dtml-name;</td>
+      <td>&dtml-pc;</td>
+      <td>&dtml-rc;</td>
+      <td>+&dtml-delta;</td>
       </tr>
       </dtml-in>
       </table>
     </dtml-if>
   </dtml-let>
   
-  <p>
-    <a href="../Database/cache_detail">Cache detail</a> |
-    <a href="../Database/cache_extreme_detail">Cache extreme detail</a>
+  <p class="form-help">
+    <a href="../Database/cache_detail" class="mr-3" target="blank">
+      <i class="fas fa-microchip" title="Cache detail"></i> 
+      Cache detail
+    </a>
+    <a href="../Database/cache_extreme_detail" target="blank">
+      <i class="fas fa-microchip" title="Cache extreme detail"></i> 
+      Cache extreme detail
+    </a>
   </p>
 
-  <p>
-    <form action="&dtml-URL;" method="GET">
-    <a href="&dtml-URL;?update_snapshot=1">Update Snapshot</a> | 
-    <dtml-if debug_auto_reload>
-      <a href="&dtml-URL;">Stop auto refresh</a>
-    <dtml-else>
-        <a href="&dtml-URL;">Refresh</a> |
-        Auto refresh interval (seconds):
-        <input type="text" name="debug_auto_reload" size="3" value="10">
-        <input type="submit" value="Start auto refresh">
-      </form>
-    </dtml-if>
+  <div class="zmi-controls row border-top border-bottom p-3 bg-light">
+    <form action="&dtml-URL;" method="GET" class="form-group form-inline p-0 m-0">
+      <button class="btn btn-primary mr-3" 
+        onclick="window.location.href='&dtml-URL;?update_snapshot=1';"
+      >Update Snapshot</button>
+      <dtml-if debug_auto_reload>
+        <button class="btn btn-primary mr-3"
+          onclick="window.location.href='&dtml-URL;';"
+        >Stop auto refresh</button>
+      <dtml-else>
+        <button class="btn btn-primary mr-3"
+          onclick="window.location.href='&dtml-URL;';"
+        >Refresh</button>
+        <label for="debug_auto_reload" class="mx-3">Auto refresh interval (seconds):</label>
+        <input class="form-control mr-3" type="text" id="debug_auto_reload" name="debug_auto_reload" size="3" value="10" />
+        <input class="btn btn-primary" type="submit" value="Start auto refresh" />
+      </dtml-if>
     </form>
-  </p>
+  </div>
   
-  <h4>ZODB database connections</h4>
-  <table border="1">
+  <h3>ZODB database connections</h3>
+  <table class="table table-sm table-bordered mb-5">
     <tr>
       <th>Opened</th>
       <th>Info</th>
     </tr>
     <dtml-in dbconnections mapping>
       <tr>
-        <td>&dtml-opened;</td>
-        <td>&dtml-info;</td>
+        <td class="text-nowrap">&dtml-opened;</td>
+        <td><samp>&dtml-info;</samp></td>
       </tr>
     </dtml-in>
   </table>
 
-  <p><br/></p>
-  
 </main>
 
 <dtml-var manage_page_footer>

--- a/src/App/dtml/undo.dtml
+++ b/src/App/dtml/undo.dtml
@@ -38,7 +38,7 @@
 						&nbsp;
 					</dtml-if>
 				</div>
-			</nav>	
+			</nav>
 
 			<table class="table table-sm table-striped">
 				<tbody>
@@ -51,7 +51,7 @@
 								<dtml-var description html_quote newline_to_br> 
 								by <strong><dtml-if user_name>&dtml-user_name;<dtml-else><em>Zope</em></dtml-if></strong>
 							</td>
-							<td style="white-space:nowrap">
+							<td class="text-nowrap">
 								<dtml-var time fmt="%Y-%m-%d %H:%M:%S">
 							</td>
 						</tr>


### PR DESCRIPTION
hi @icemac,
i added some missing style to the ZMI of the debug-info page and montonized the look:

![zmi_debuginfo](https://user-images.githubusercontent.com/29705216/101542113-9e677e80-39a2-11eb-8335-bdc2b3f9b0b5.gif)

Thanks for taking at look at it
f