### PR TITLE
Fix AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,7 @@ environment:
     - TOXENV: py36
 
 install:
+  - pip install "setuptools < 52"
   - pip install tox
 
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,6 @@ environment:
     - TOXENV: py36
 
 install:
-  - pip install "setuptools < 52"
   - pip install tox
 
 build: off

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ skip_install = true
 deps =
     -cconstraints.txt
     coverage
-    setuptools>=36.2
+    setuptools < 52
     zc.buildout>=2.12
 setenv =
     COVERAGE_FILE=.coverage.{envname}


### PR DESCRIPTION
We still need easy_install (removed in setuptools 52) to install packages which have no wheels.