### PR TITLE
[4.x] Backport fixes for the ``compute_size`` method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@ https://zope.readthedocs.io/en/2.13/CHANGES.html
 4.5.5 (unreleased)
 ------------------
 
+- The ``compute_size`` method properly returns None if the content does not
+  have a ``get_size`` method but the parent has.
+  (`#948 <https://github.com/zopefoundation/Zope/issues/948>`_)
+
 - Fix control panel tab links on all control panel pages
 
 - Update dependencies to the latest releases that still support Python 2.

--- a/src/OFS/ObjectManager.py
+++ b/src/OFS/ObjectManager.py
@@ -884,7 +884,7 @@ class ObjectManager(
 
     @security.protected(access_contents_information)
     def compute_size(self, ob):
-        if hasattr(ob, 'get_size'):
+        if hasattr(aq_base(ob), 'get_size'):
             ob_size = ob.get_size()
             if ob_size < 1024:
                 return '1 KiB'


### PR DESCRIPTION
The ``compute_size`` method properly returns None if the content does not  have a ``get_size`` method but the parent has.

Refs #948