### PR TITLE
[5.0.x] Backport fixes for the ``compute_size`` method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,9 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 5.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- The ``compute_size`` method properly returns None if the content does not
+  have a ``get_size`` method but the parent has.
+  (`#948 <https://github.com/zopefoundation/Zope/issues/948>`_)
 
 
 5.0 (2020-10-08)

--- a/src/OFS/ObjectManager.py
+++ b/src/OFS/ObjectManager.py
@@ -770,7 +770,7 @@ class ObjectManager(
 
     @security.protected(access_contents_information)
     def compute_size(self, ob):
-        if hasattr(ob, 'get_size'):
+        if hasattr(aq_base(ob), 'get_size'):
             ob_size = ob.get_size()
             if ob_size < 1024:
                 return '1 KiB'


### PR DESCRIPTION
The `compute_size` method properly returns `None` if the content does not have a `get_size` method but the parent has.

Refs #948
