### PR TITLE
Fixed css of html code element height

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 .installed.cfg
 .mr.developer.cfg
 .tox/
+.vscode/
 __pycache__/
 bin/
 build/

--- a/src/zmi/styles/resources/zmi_base.css
+++ b/src/zmi/styles/resources/zmi_base.css
@@ -541,15 +541,14 @@ textarea.zmi-code {
 	z-index:1000;
 	box-shadow: 0px 20px 50px 0px silver;
 }
-
 .code {
 	font-size: 87.5%;
 	color: #e83e8c;
 	word-break: break-word;
 	font-size: 1em;
 	font-family: SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;
+	height:unset;
 }
-
 .code.syspath {
 	font-size: .75em;
 }


### PR DESCRIPTION
Hi @icemac ,
here is a small css fix for rendering the SQL code in the Test menu:

![querytemplate](https://user-images.githubusercontent.com/29705216/107890441-70119c80-6f19-11eb-822d-22f73e6c67ad.gif)

And  I added .vscode to the git-ignored folders.

Cheers
f
