### PR TITLE
Enforce Zope permissions for recursive XML-RPC data dumps

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ https://zope.readthedocs.io/en/2.13/CHANGES.html
 4.5.5 (unreleased)
 ------------------
 
-- Enforce Zope permissions for recursive XML-RPC data dumps
+- Enforce Zope permissions during recursive XML-RPC data dumps
   (`#954 <https://github.com/zopefoundation/Zope/issues/954>`_)
 
 - The ``compute_size`` method properly returns None if the content does not

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ https://zope.readthedocs.io/en/2.13/CHANGES.html
 4.5.5 (unreleased)
 ------------------
 
+- Enforce Zope permissions for recursive XML-RPC data dumps
+  (`#954 <https://github.com/zopefoundation/Zope/issues/954>`_)
+
 - The ``compute_size`` method properly returns None if the content does not
   have a ``get_size`` method but the parent has.
   (`#948 <https://github.com/zopefoundation/Zope/issues/948>`_)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -18,7 +18,6 @@ recursive-include src *.rst
 recursive-include src *.txt
 recursive-include src *.zcml
 include *.py
-include *.yaml
 include sources.cfg
 include versions-prod.cfg
 include versions.cfg

--- a/src/ZPublisher/xmlrpc.py
+++ b/src/ZPublisher/xmlrpc.py
@@ -22,10 +22,13 @@ information about XML-RPC and Zope.
 import re
 import sys
 
+from AccessControl import getSecurityManager
+from AccessControl.Permissions import view
 from App.config import getConfiguration
 # Make DateTime.DateTime marshallable via XML-RPC
 # http://www.zope.org/Collectors/Zope/2109
 from DateTime.DateTime import DateTime
+from ExtensionClass import Base
 from zExceptions import Unauthorized
 from ZODB.POSException import ConflictError
 
@@ -50,9 +53,20 @@ def dump_instance(self, value, write):
         # We want to avoid disclosing private attributes.
         # Private attributes are by convention named with
         # a leading underscore character.
-        value = dict([(k, v) for (k, v) in value.__dict__.items()
-                      if k[:1] != '_'])
-        self.dump_struct(value, write)
+        ob_dict = dict([(k, v) for (k, v) in value.__dict__.items()
+                       if k[:1] != '_'])
+
+        # If the instance attribute is a Zope object we also want to prevent
+        # disclosing it to users without at least View permission.
+        zope_objects = [(k, v) for (k, v) in ob_dict.items()
+                        if isinstance(v, Base)]
+        if zope_objects:
+            sm = getSecurityManager()
+            for ob_id, ob in zope_objects:
+                if not sm.checkPermission(view, getattr(value, ob_id)):
+                    del ob_dict[ob_id]
+
+        self.dump_struct(ob_dict, write)
 
 
 # Override the standard marshaller for object instances


### PR DESCRIPTION
Fixes #954 

This PR attempts to detect attributes that are Zope objects during creation of an XML-RPC object dump and enforce at least the `View` permission on them.