### PR TITLE
Remove obsolete test

### DIFF
--- a/src/ZPublisher/tests/test_Converters.py
+++ b/src/ZPublisher/tests/test_Converters.py
@@ -143,12 +143,6 @@ class ConvertersTests(unittest.TestCase):
         to_convert = 'to_convert'
         self.assertEqual(field2string(to_convert), to_convert)
 
-    def test_field2string_with_unicode_default_encoding(self):
-        from ZPublisher.Converters import field2string
-        to_convert = 'to_convert'
-        expected = 'to_convert'
-        self.assertEqual(field2string(to_convert), expected)
-
     def test_field2string_with_filelike_object(self):
         from ZPublisher.Converters import field2string
         to_convert = 'to_convert'


### PR DESCRIPTION
The intention for this test is obsolete since we are on Python 3.

And especially after applying pyupgrade via
https://github.com/zopefoundation/Zope/commit/5bfcac7fc0c5a620326955571fc69f20e106a884
the deleted test duplicated test_field2string_with_string.