### PR TITLE
field2* converters should not handle files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,9 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
   ``rfc850_date``, and ``rfc1123_date`` which used to be in ``App.Common``
   keeping backwards-compatibility imports in place.
 
+- With the exception of ``field2bytes``, field converters should not handle
+  files (`#558 <https://github.com/zopefoundation/Zope/issues/558>`_)
+
 
 5.1.2 (2021-03-02)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,8 +8,8 @@ The change log for the previous version, Zope 4, is at
 https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 
 
-5.1.3 (unreleased)
-------------------
+5.2 (unreleased)
+----------------
 
 - Updated/fixed the poll application tutorial in the Zope Developers Guide
   (`#958 <https://github.com/zopefoundation/Zope/issues/958>`_)
@@ -20,8 +20,12 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
   ``rfc850_date``, and ``rfc1123_date`` which used to be in ``App.Common``
   keeping backwards-compatibility imports in place.
 
-- With the exception of ``field2bytes``, field converters should not handle
-  files (`#558 <https://github.com/zopefoundation/Zope/issues/558>`_)
+Backwards incompatible changes
+++++++++++++++++++++++++++++++
+
+- With the exception of ``field2bytes``, field converters do no longer try to
+  read file like objects
+  (`#558 <https://github.com/zopefoundation/Zope/issues/558>`_)
 
 
 5.1.2 (2021-03-02)

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ def _read_file(filename):
 README = _read_file('README.rst')
 CHANGES = _read_file('CHANGES.rst')
 
-version = '5.1.3.dev0'
+version = '5.2.dev0'
 
 
 setup(

--- a/src/ZPublisher/Converters.py
+++ b/src/ZPublisher/Converters.py
@@ -23,13 +23,8 @@ default_encoding = 'utf-8'
 
 
 def field2string(v):
-    """Converts value to native strings.
-
-    So always to `str` no matter which Python version you are on.
-    """
-    if hasattr(v, 'read'):
-        return v.read()
-    elif isinstance(v, bytes):
+    """Converts value to string."""
+    if isinstance(v, bytes):
         return v.decode(default_encoding)
     else:
         return str(v)

--- a/src/ZPublisher/Converters.py
+++ b/src/ZPublisher/Converters.py
@@ -167,8 +167,6 @@ class _unicode_converter:
         #       <input name="description:utf8:ustring" .....
         # rather than
         #       <input name="description:ustring" .....
-        if hasattr(v, 'read'):
-            v = v.read()
         v = str(v)
         return self.convert_unicode(v)
 

--- a/src/ZPublisher/Converters.py
+++ b/src/ZPublisher/Converters.py
@@ -204,8 +204,6 @@ field2utext = field2utext()
 
 class field2ulines:
     def __call__(self, v):
-        if hasattr(v, 'read'):
-            v = v.read()
         if isinstance(v, (list, tuple)):
             return [field2ustring(x) for x in v]
         v = str(v)

--- a/src/ZPublisher/Converters.py
+++ b/src/ZPublisher/Converters.py
@@ -31,7 +31,7 @@ def field2string(v):
 
 
 def field2bytes(v):
-    # Converts value to bytes.
+    """Converts value to bytes."""
     if hasattr(v, 'read'):
         return v.read()
     elif isinstance(v, str):

--- a/src/ZPublisher/tests/test_Converters.py
+++ b/src/ZPublisher/tests/test_Converters.py
@@ -160,6 +160,14 @@ class ConvertersTests(unittest.TestCase):
         expected = b'to_convert'
         self.assertEqual(field2bytes(to_convert), expected)
 
+    def test_field2bytes_with_filelike_object(self):
+        from ZPublisher.Converters import field2bytes
+        to_convert = b'to_convert'
+        class Filelike:
+            def read(self):
+                return to_convert
+        self.assertEqual(field2bytes(Filelike()), to_convert)
+
     def test_field2date_international_with_proper_date_string(self):
         from ZPublisher.Converters import field2date_international
         to_convert = "2.1.2019"

--- a/src/ZPublisher/tests/test_Converters.py
+++ b/src/ZPublisher/tests/test_Converters.py
@@ -149,15 +149,6 @@ class ConvertersTests(unittest.TestCase):
         expected = 'to_convert'
         self.assertEqual(field2string(to_convert), expected)
 
-    def test_field2string_with_filelike_object(self):
-        from ZPublisher.Converters import field2string
-        to_convert = 'to_convert'
-
-        class Filelike:
-            def read(self):
-                return to_convert
-        self.assertEqual(field2string(Filelike()), to_convert)
-
     def test_field2bytes_with_bytes(self):
         from ZPublisher.Converters import field2bytes
         to_convert = b'to_convert'

--- a/src/ZPublisher/tests/test_Converters.py
+++ b/src/ZPublisher/tests/test_Converters.py
@@ -163,6 +163,7 @@ class ConvertersTests(unittest.TestCase):
     def test_field2bytes_with_filelike_object(self):
         from ZPublisher.Converters import field2bytes
         to_convert = b'to_convert'
+
         class Filelike:
             def read(self):
                 return to_convert


### PR DESCRIPTION
Until now field converters could be applied on files with unclear outcome.

The problems with trying to convert files to text (detect MIME type, guess charset...)
were discussed in length in https://github.com/zopefoundation/Zope/issues/558#issuecomment-485064104.

Handling files only makes sense for the `field2bytes` converter.

This fixes #558 