### PR TITLE
Deprecate usage of `unicode` converters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,10 +8,15 @@ The change log for the previous version, Zope 4, is at
 https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 
 
-5.2.2 (unreleased)
-------------------
+5.3 (unreleased)
+----------------
 
 - Update to newest compatible versions of dependencies.
+
+- Deprecate usage of "unicode" converters. Also, the behavior of
+  ``field2lines`` is now aligned to the other converters and returns a list of
+  strings instead of a list of bytes.
+  (`#962 <https://github.com/zopefoundation/Zope/issues/962>`_)
 
 
 5.2.1 (2021-06-08)

--- a/docs/zdgbook/ObjectPublishing.rst
+++ b/docs/zdgbook/ObjectPublishing.rst
@@ -749,6 +749,10 @@ The publisher supports many converters:
 - **ulines**, **utokens**, **utext** -- like **lines**, **tokens**,
   **text**, but always converts into unicode strings.
 
+.. note::
+  Please note that the above listed **unicode converters** are deprecated,
+  and will be removed in Zope 6.
+
 The full list of supported converters can be found
 in ``ZPublisher.Converters.type_converters``.
 
@@ -770,6 +774,22 @@ could create a list of integers like so::
         <input type="checkbox" name="numbers:list:int" value="1">
         <input type="checkbox" name="numbers:list:int" value="2">
         <input type="checkbox" name="numbers:list:int" value="3">
+
+
+Create and register a custom converter
+++++++++++++++++++++++++++++++++++++++
+
+If you need a custom converter, you can create one on your own and register
+it as follows::
+
+        from ZPublisher.Converters import field2bytes, type_converters
+
+        def field2bytelines(v)
+            if isinstance(v, (list, tuple)):
+                return [field2bytes(item) for item in v]
+            return field2bytes(v).splitlines()
+
+        type_converters['bytelines'] = field2bytelines
 
 
 Aggregators

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ def _read_file(filename):
 README = _read_file('README.rst')
 CHANGES = _read_file('CHANGES.rst')
 
-version = '5.2.2.dev0'
+version = '5.3.0.dev0'
 
 
 setup(

--- a/src/App/tests/testManagement.py
+++ b/src/App/tests/testManagement.py
@@ -1,3 +1,5 @@
+import warnings
+
 import Testing.ZopeTestCase
 
 
@@ -18,21 +20,39 @@ class TestNavigation(Testing.ZopeTestCase.ZopeTestCase):
 
     def test_Management__Navigation__manage_page_header__2(self):
         """It respects `zmi_additional_css_paths` ustring property."""
-        self.folder.manage_addProperty(
-            'zmi_additional_css_paths', '/foo/bar.css', 'ustring')
+        # unicode converters will go away with Zope 6
+        # ignore deprecation warning for test run
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            self.folder.manage_addProperty(
+                'zmi_additional_css_paths', '/foo/bar.css', 'ustring')
         self.assertIn('href="/foo/bar.css"', self.folder.manage_page_header())
 
     def test_Management__Navigation__manage_page_header__3(self):
         """It respects `zmi_additional_css_paths` lines property."""
-        self.folder.manage_addProperty(
-            'zmi_additional_css_paths', ['/foo/bar.css', '/baz.css'], 'ulines')
+        # unicode converters will go away with Zope 6
+        # ignore deprecation warning for test run
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            self.folder.manage_addProperty(
+                'zmi_additional_css_paths',
+                ['/foo/bar.css', '/baz.css'],
+                'ulines'
+            )
         self.assertIn('href="/foo/bar.css"', self.folder.manage_page_header())
         self.assertIn('href="/baz.css"', self.folder.manage_page_header())
 
     def test_Management__Navigation__manage_page_header__4(self):
         """It respects `zmi_additional_css_paths` ulines property."""
-        self.folder.manage_addProperty(
-            'zmi_additional_css_paths', ['/foo/bar.css', '/baz.css'], 'ulines')
+        # unicode converters will go away with Zope 6
+        # ignore deprecation warning for test run
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            self.folder.manage_addProperty(
+                'zmi_additional_css_paths',
+                ['/foo/bar.css', '/baz.css'],
+                'ulines'
+            )
         self.assertIn('href="/foo/bar.css"', self.folder.manage_page_header())
         self.assertIn('href="/baz.css"', self.folder.manage_page_header())
 

--- a/src/App/tests/testManagement.py
+++ b/src/App/tests/testManagement.py
@@ -1,5 +1,3 @@
-import warnings
-
 import Testing.ZopeTestCase
 
 
@@ -19,44 +17,13 @@ class TestNavigation(Testing.ZopeTestCase.ZopeTestCase):
         self.assertIn('href="/foo/bar.css"', self.folder.manage_page_header())
 
     def test_Management__Navigation__manage_page_header__2(self):
-        """It respects `zmi_additional_css_paths` ustring property."""
-        # unicode converters will go away with Zope 6
-        # ignore deprecation warning for test run
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore')
-            self.folder.manage_addProperty(
-                'zmi_additional_css_paths', '/foo/bar.css', 'ustring')
+        """It respects `zmi_additional_css_paths` lines property."""
+        self.folder.manage_addProperty(
+            'zmi_additional_css_paths', ['/foo/bar.css', '/baz.css'], 'lines')
         self.assertIn('href="/foo/bar.css"', self.folder.manage_page_header())
+        self.assertIn('href="/baz.css"', self.folder.manage_page_header())
 
     def test_Management__Navigation__manage_page_header__3(self):
-        """It respects `zmi_additional_css_paths` lines property."""
-        # unicode converters will go away with Zope 6
-        # ignore deprecation warning for test run
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore')
-            self.folder.manage_addProperty(
-                'zmi_additional_css_paths',
-                ['/foo/bar.css', '/baz.css'],
-                'ulines'
-            )
-        self.assertIn('href="/foo/bar.css"', self.folder.manage_page_header())
-        self.assertIn('href="/baz.css"', self.folder.manage_page_header())
-
-    def test_Management__Navigation__manage_page_header__4(self):
-        """It respects `zmi_additional_css_paths` ulines property."""
-        # unicode converters will go away with Zope 6
-        # ignore deprecation warning for test run
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore')
-            self.folder.manage_addProperty(
-                'zmi_additional_css_paths',
-                ['/foo/bar.css', '/baz.css'],
-                'ulines'
-            )
-        self.assertIn('href="/foo/bar.css"', self.folder.manage_page_header())
-        self.assertIn('href="/baz.css"', self.folder.manage_page_header())
-
-    def test_Management__Navigation__manage_page_header__5(self):
         """It ignores an empty `zmi_additional_css_paths` property."""
         self.folder.manage_addProperty(
             'zmi_additional_css_paths', '', 'string')

--- a/src/OFS/tests/testProperties.py
+++ b/src/OFS/tests/testProperties.py
@@ -90,10 +90,10 @@ class TestPropertyManager(unittest.TestCase):
         pm._setProperty('test_lines', [], type='lines')
 
         pm._updateProperty('test_lines', 'foo\nbar')
-        self.assertEqual(pm.getProperty('test_lines'), (b'foo', b'bar'))
+        self.assertEqual(pm.getProperty('test_lines'), ('foo', 'bar'))
 
         pm._updateProperty('test_lines', b'bar\nbaz')
-        self.assertEqual(pm.getProperty('test_lines'), (b'bar', b'baz'))
+        self.assertEqual(pm.getProperty('test_lines'), ('bar', 'baz'))
 
 
 class TestPropertySheets(unittest.TestCase):
@@ -147,7 +147,7 @@ class TestPropertySheet(unittest.TestCase):
         ps._setProperty('test_lines', [], type='lines')
 
         ps._updateProperty('test_lines', 'foo\nbar')
-        self.assertEqual(ps.getProperty('test_lines'), (b'foo', b'bar'))
+        self.assertEqual(ps.getProperty('test_lines'), ('foo', 'bar'))
 
         ps._updateProperty('test_lines', b'bar\nbaz')
-        self.assertEqual(ps.getProperty('test_lines'), (b'bar', b'baz'))
+        self.assertEqual(ps.getProperty('test_lines'), ('bar', 'baz'))

--- a/src/ZPublisher/Converters.py
+++ b/src/ZPublisher/Converters.py
@@ -23,17 +23,12 @@ from DateTime.interfaces import SyntaxError
 default_encoding = 'utf-8'
 
 
-def convert_single_value_to_string(v):
-    """Converts a single value to string."""
+def field2string(v):
+    """Converts value to string."""
     if isinstance(v, bytes):
         return v.decode(default_encoding)
     else:
         return str(v)
-
-
-def field2string(v):
-    """Converts value to string."""
-    return convert_single_value_to_string(v)
 
 
 def field2bytes(v):
@@ -47,7 +42,7 @@ def field2bytes(v):
 
 
 def field2text(value, nl=re.compile('\r\n|\n\r').search):
-    value = convert_single_value_to_string(value)
+    value = field2string(value)
     match_object = nl(value)
     if match_object is None:
         return value
@@ -69,7 +64,7 @@ def field2text(value, nl=re.compile('\r\n|\n\r').search):
 
 
 def field2required(v):
-    v = convert_single_value_to_string(v)
+    v = field2string(v)
     if v.strip():
         return v
     raise ValueError('No input for required field<p>')
@@ -78,7 +73,7 @@ def field2required(v):
 def field2int(v):
     if isinstance(v, (list, tuple)):
         return list(map(field2int, v))
-    v = convert_single_value_to_string(v)
+    v = field2string(v)
     if v:
         try:
             return int(v)
@@ -94,7 +89,7 @@ def field2int(v):
 def field2float(v):
     if isinstance(v, (list, tuple)):
         return list(map(field2float, v))
-    v = convert_single_value_to_string(v)
+    v = field2string(v)
     if v:
         try:
             return float(v)
@@ -110,7 +105,7 @@ def field2float(v):
 def field2long(v):
     if isinstance(v, (list, tuple)):
         return list(map(field2long, v))
-    v = convert_single_value_to_string(v)
+    v = field2string(v)
     # handle trailing 'L' if present.
     if v[-1:] in ('L', 'l'):
         v = v[:-1]
@@ -126,18 +121,18 @@ def field2long(v):
 
 
 def field2tokens(v):
-    v = convert_single_value_to_string(v)
+    v = field2string(v)
     return v.split()
 
 
 def field2lines(v):
     if isinstance(v, (list, tuple)):
-        return [convert_single_value_to_string(item) for item in v]
-    return convert_single_value_to_string(v).splitlines()
+        return [field2string(item) for item in v]
+    return field2string(v).splitlines()
 
 
 def field2date(v):
-    v = convert_single_value_to_string(v)
+    v = field2string(v)
     try:
         v = DateTime(v)
     except SyntaxError:
@@ -146,7 +141,7 @@ def field2date(v):
 
 
 def field2date_international(v):
-    v = convert_single_value_to_string(v)
+    v = field2string(v)
     try:
         v = DateTime(v, datefmt="international")
     except SyntaxError:

--- a/src/ZPublisher/Converters.py
+++ b/src/ZPublisher/Converters.py
@@ -13,6 +13,7 @@
 
 import html
 import re
+import warnings
 
 from DateTime import DateTime
 from DateTime.interfaces import SyntaxError
@@ -22,12 +23,17 @@ from DateTime.interfaces import SyntaxError
 default_encoding = 'utf-8'
 
 
-def field2string(v):
-    """Converts value to string."""
+def convert_single_value_to_string(v):
+    """Converts a single value to string."""
     if isinstance(v, bytes):
         return v.decode(default_encoding)
     else:
         return str(v)
+
+
+def field2string(v):
+    """Converts value to string."""
+    return convert_single_value_to_string(v)
 
 
 def field2bytes(v):
@@ -41,7 +47,7 @@ def field2bytes(v):
 
 
 def field2text(value, nl=re.compile('\r\n|\n\r').search):
-    value = field2string(value)
+    value = convert_single_value_to_string(value)
     match_object = nl(value)
     if match_object is None:
         return value
@@ -63,7 +69,7 @@ def field2text(value, nl=re.compile('\r\n|\n\r').search):
 
 
 def field2required(v):
-    v = field2string(v)
+    v = convert_single_value_to_string(v)
     if v.strip():
         return v
     raise ValueError('No input for required field<p>')
@@ -72,7 +78,7 @@ def field2required(v):
 def field2int(v):
     if isinstance(v, (list, tuple)):
         return list(map(field2int, v))
-    v = field2string(v)
+    v = convert_single_value_to_string(v)
     if v:
         try:
             return int(v)
@@ -88,7 +94,7 @@ def field2int(v):
 def field2float(v):
     if isinstance(v, (list, tuple)):
         return list(map(field2float, v))
-    v = field2string(v)
+    v = convert_single_value_to_string(v)
     if v:
         try:
             return float(v)
@@ -104,7 +110,7 @@ def field2float(v):
 def field2long(v):
     if isinstance(v, (list, tuple)):
         return list(map(field2long, v))
-    v = field2string(v)
+    v = convert_single_value_to_string(v)
     # handle trailing 'L' if present.
     if v[-1:] in ('L', 'l'):
         v = v[:-1]
@@ -120,21 +126,18 @@ def field2long(v):
 
 
 def field2tokens(v):
-    v = field2string(v)
+    v = convert_single_value_to_string(v)
     return v.split()
 
 
 def field2lines(v):
     if isinstance(v, (list, tuple)):
-        result = []
-        for item in v:
-            result.append(field2bytes(item))
-        return result
-    return field2bytes(v).splitlines()
+        return [convert_single_value_to_string(item) for item in v]
+    return convert_single_value_to_string(v).splitlines()
 
 
 def field2date(v):
-    v = field2string(v)
+    v = convert_single_value_to_string(v)
     try:
         v = DateTime(v)
     except SyntaxError:
@@ -143,7 +146,7 @@ def field2date(v):
 
 
 def field2date_international(v):
-    v = field2string(v)
+    v = convert_single_value_to_string(v)
     try:
         v = DateTime(v, datefmt="international")
     except SyntaxError:
@@ -157,68 +160,47 @@ def field2boolean(v):
     return bool(v)
 
 
-class _unicode_converter:
-
-    def __call__(self, v):
-        # Convert a regular python string. This probably doesn't do
-        # what you want, whatever that might be. If you are getting
-        # exceptions below, you probably missed the encoding tag
-        # from a form field name. Use:
-        #       <input name="description:utf8:ustring" .....
-        # rather than
-        #       <input name="description:ustring" .....
-        v = str(v)
-        return self.convert_unicode(v)
-
-    def convert_unicode(self, v):
-        raise NotImplementedError('convert_unicode')
+def field2ustring(v):
+    warnings.warn(
+        "The converter `(field2)ustring` is deprecated "
+        "and will be removed in Zope 6. "
+        "Please use `(field2)string` instead.",
+        DeprecationWarning)
+    return field2string(v)
 
 
-class field2ustring(_unicode_converter):
-    def convert_unicode(self, v):
-        return v
+def field2utokens(v):
+    warnings.warn(
+        "The converter `(field2)utokens` is deprecated "
+        "and will be removed in Zope 6. "
+        "Please use `(field2)tokens` instead.",
+        DeprecationWarning)
+    return field2tokens(v)
 
 
-field2ustring = field2ustring()
+def field2utext(v):
+    warnings.warn(
+        "The converter `(field2)utext` is deprecated "
+        "and will be removed in Zope 6. "
+        "Please use `(field2)text` instead.",
+        DeprecationWarning)
+    return field2text(v)
 
 
-class field2utokens(_unicode_converter):
-    def convert_unicode(self, v):
-        return v.split()
-
-
-field2utokens = field2utokens()
-
-
-class field2utext(_unicode_converter):
-    def convert_unicode(self, v):
-        if isinstance(v, bytes):
-            return str(field2text(v.encode('utf8')), 'utf8')
-        return v
-
-
-field2utext = field2utext()
-
-
-class field2ulines:
-    def __call__(self, v):
-        if isinstance(v, (list, tuple)):
-            return [field2ustring(x) for x in v]
-        v = str(v)
-        return self.convert_unicode(v)
-
-    def convert_unicode(self, v):
-        return field2utext.convert_unicode(v).splitlines()
-
-
-field2ulines = field2ulines()
+def field2ulines(v):
+    warnings.warn(
+        "The converter `(field2u)lines` is deprecated "
+        "and will be removed in Zope 6. "
+        "Please use `(field2)lines` instead.",
+        DeprecationWarning)
+    return field2lines(v)
 
 
 type_converters = {
     'float': field2float,
     'int': field2int,
     'long': field2long,
-    'string': field2string,  # to native str
+    'string': field2string,
     'bytes': field2bytes,
     'date': field2date,
     'date_international': field2date_international,

--- a/src/ZPublisher/tests/testHTTPRequest.py
+++ b/src/ZPublisher/tests/testHTTPRequest.py
@@ -13,6 +13,7 @@
 
 import sys
 import unittest
+import warnings
 from contextlib import contextmanager
 from io import BytesIO
 
@@ -305,7 +306,7 @@ class HTTPRequestTests(unittest.TestCase, HTTPRequestFactoryMixin):
         self.assertEqual(req['bign'], 45)
         self.assertEqual(req['fract'], 4.2)
         self.assertEqual(req['morewords'], 'one\ntwo\n')
-        self.assertEqual(req['multiline'], [b'one', b'two'])
+        self.assertEqual(req['multiline'], ['one', 'two'])
         self.assertEqual(req['num'], 42)
         self.assertEqual(req['words'], 'Some words')
 
@@ -323,7 +324,11 @@ class HTTPRequestTests(unittest.TestCase, HTTPRequestFactoryMixin):
                   ('ulines:ulines:utf8',
                    'test' + reg_char + '\ntest' + reg_char),
                   ('nouconverter:string:utf8', 'test' + reg_char))
-        req = self._processInputs(inputs)
+        # unicode converters will go away with Zope 6
+        # ignore deprecation warning for test run
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            req = self._processInputs(inputs)
 
         formkeys = list(req.form.keys())
         formkeys.sort()
@@ -539,7 +544,12 @@ class HTTPRequestTests(unittest.TestCase, HTTPRequestFactoryMixin):
 
             ('tnouconverter:string:utf8', '<test\xc2\xae>'),
         )
-        req = self._processInputs(inputs)
+
+        # unicode converters will go away with Zope 6
+        # ignore deprecation warning for test run
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            req = self._processInputs(inputs)
 
         taintedformkeys = list(req.taintedform.keys())
         taintedformkeys.sort()
@@ -717,7 +727,11 @@ class HTTPRequestTests(unittest.TestCase, HTTPRequestFactoryMixin):
         from ZPublisher.Converters import type_converters
         for type, convert in list(type_converters.items()):
             try:
-                convert('<html garbage>')
+                # unicode converters will go away with Zope 6
+                # ignore deprecation warning for test run
+                with warnings.catch_warnings():
+                    warnings.simplefilter('ignore')
+                    convert('<html garbage>')
             except Exception as e:
                 self.assertFalse(
                     '<' in e.args,

--- a/src/ZPublisher/tests/test_Converters.py
+++ b/src/ZPublisher/tests/test_Converters.py
@@ -12,6 +12,7 @@
 ##############################################################################
 
 import unittest
+import warnings
 
 
 class ConvertersTests(unittest.TestCase):
@@ -173,13 +174,13 @@ class ConvertersTests(unittest.TestCase):
     def test_field2lines_with_list(self):
         from ZPublisher.Converters import field2lines
         to_convert = ['one', b'two']
-        expected = [b'one', b'two']
+        expected = ['one', 'two']
         self.assertEqual(field2lines(to_convert), expected)
 
     def test_field2lines_with_tuple(self):
         from ZPublisher.Converters import field2lines
         to_convert = ('one', b'two')
-        expected = [b'one', b'two']
+        expected = ['one', 'two']
         self.assertEqual(field2lines(to_convert), expected)
 
     def test_field2lines_with_empty_string(self):
@@ -190,13 +191,13 @@ class ConvertersTests(unittest.TestCase):
     def test_field2lines_with_string_no_newlines(self):
         from ZPublisher.Converters import field2lines
         to_convert = 'abc def ghi'
-        expected = [b'abc def ghi']
+        expected = ['abc def ghi']
         self.assertEqual(field2lines(to_convert), expected)
 
     def test_field2lines_with_string_with_newlines(self):
         from ZPublisher.Converters import field2lines
         to_convert = 'abc\ndef\nghi'
-        expected = [b'abc', b'def', b'ghi']
+        expected = ['abc', 'def', 'ghi']
         self.assertEqual(field2lines(to_convert), expected)
 
     def test_field2text_with_string_with_newlines(self):
@@ -208,26 +209,46 @@ class ConvertersTests(unittest.TestCase):
     def test_field2ulines_with_list(self):
         from ZPublisher.Converters import field2ulines
         to_convert = ['one', 'two']
-        self.assertEqual(field2ulines(to_convert),
-                         [str(x) for x in to_convert])
+        # unicode converters will go away with Zope 6
+        # ignore deprecation warning for test run
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            self.assertEqual(field2ulines(to_convert),
+                             [str(x) for x in to_convert])
 
     def test_field2ulines_with_tuple(self):
         from ZPublisher.Converters import field2ulines
         to_convert = ('one', 'two')
-        self.assertEqual(field2ulines(to_convert),
-                         [str(x) for x in to_convert])
+        # unicode converters will go away with Zope 6
+        # ignore deprecation warning for test run
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            self.assertEqual(field2ulines(to_convert),
+                             [str(x) for x in to_convert])
 
     def test_field2ulines_with_empty_string(self):
         from ZPublisher.Converters import field2ulines
         to_convert = ''
-        self.assertEqual(field2ulines(to_convert), [])
+        # unicode converters will go away with Zope 6
+        # ignore deprecation warning for test run
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            self.assertEqual(field2ulines(to_convert), [])
 
     def test_field2ulines_with_string_no_newlines(self):
         from ZPublisher.Converters import field2ulines
         to_convert = 'abc def ghi'
-        self.assertEqual(field2ulines(to_convert), [to_convert])
+        # unicode converters will go away with Zope 6
+        # ignore deprecation warning for test run
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            self.assertEqual(field2ulines(to_convert), [to_convert])
 
     def test_field2ulines_with_string_with_newlines(self):
         from ZPublisher.Converters import field2ulines
         to_convert = 'abc\ndef\nghi'
-        self.assertEqual(field2ulines(to_convert), to_convert.splitlines())
+        # unicode converters will go away with Zope 6
+        # ignore deprecation warning for test run
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            self.assertEqual(field2ulines(to_convert), to_convert.splitlines())


### PR DESCRIPTION
After dropping Python 2, there is no more use of `unicode` converters.

This means, after a deprecation period, that e.g. field2utext will be
removed and only field2text should be used any more.

P.S.: This PR currently fails - for reasons see https://github.com/zopefoundation/Zope/issues/962#issuecomment-835357220

Also, please keep the discussion in https://github.com/zopefoundation/Zope/issues/962