### PR TITLE
fix path expressions for the `chameleon.tales` expression engine

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 5.2 (unreleased)
 ----------------
 
+- Fix path expressions for the ``chameleon.tales`` expression engine.
+
 - Provide friendlier ZMI error message for the Transaction Undo form
   (`#964 <https://github.com/zopefoundation/Zope/issues/964>`_)
 

--- a/src/Products/PageTemplates/expression.py
+++ b/src/Products/PageTemplates/expression.py
@@ -62,7 +62,7 @@ class BoboAwareZopeTraverse:
         while path_items:
             name = path_items.pop()
             if ITraversable.providedBy(base):
-                base = getattr(base, cls.traverseMethod)(name)
+                base = getattr(base, cls.traverse_method)(name)
             else:
                 base = traversePathElement(base, name, path_items,
                                            request=request)

--- a/src/Products/PageTemplates/tests/input/CheckPathTraverse.html
+++ b/src/Products/PageTemplates/tests/input/CheckPathTraverse.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+   <div tal:content="context/laf"></div>
+</body>
+</html>

--- a/src/Products/PageTemplates/tests/output/CheckPathTraverse.html
+++ b/src/Products/PageTemplates/tests/output/CheckPathTraverse.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+   <div>ok</div>
+</body>
+</html>

--- a/src/Products/PageTemplates/tests/testHTMLTests.py
+++ b/src/Products/PageTemplates/tests/testHTMLTests.py
@@ -155,6 +155,15 @@ class HTMLTests(zope.component.testing.PlacelessSetup, unittest.TestCase):
     def testPathAlt(self):
         self.assert_expected(self.folder.t, 'CheckPathAlt.html')
 
+    def testPathTraverse(self):
+        # need to perform this test with a "real" folder
+        from OFS.Folder import Folder
+        f = self.folder
+        self.folder = Folder()
+        self.folder.t, self.folder.laf = f.t, f.laf
+        self.folder.laf.write('ok')
+        self.assert_expected(self.folder.t, 'CheckPathTraverse.html')
+
     def testBatchIteration(self):
         self.assert_expected(self.folder.t, 'CheckBatchIteration.html')
 


### PR DESCRIPTION
Fixes the attribute name bug (`traverseMethod` instead of `traverse_method`) reported by @mauritsvanrees 

Also adds a test to verify path expressions when implemented via `[un]restrictedTraverse`.