### PR TITLE
Try out ZOPE_INTERFACE_STRICT_IRO=1

### DIFF
--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/zope-product
 [meta]
 template = "zope-product"
-commit-id = "10891b6cf9212ecd48f9bc70138aa14324d6a2b0"
+commit-id = "f9baadf16d8091d825297dc11596d4c736ffa908"
 
 [python]
 with-appveyor = false
@@ -37,6 +37,9 @@ testenv-commands-pre = [
     ]
 testenv-commands = [
     "{envdir}/bin/alltests {posargs:-vc}",
+    ]
+testenv-setenv = [
+    "ZOPE_INTERFACE_STRICT_IRO=1",
     ]
 coverage-basepython = "python3.8"
 coverage-command = "coverage run {envdir}/bin/alltests {posargs:-vc}"

--- a/src/OFS/Application.py
+++ b/src/OFS/Application.py
@@ -29,7 +29,6 @@ from App.ApplicationManager import ApplicationManager
 from App.ProductContext import ProductContext
 from App.version_txt import getZopeVersion
 from DateTime import DateTime
-from OFS.FindSupport import FindSupport
 from OFS.metaconfigure import get_packages_to_initialize
 from OFS.metaconfigure import package_initialized
 from OFS.userfolder import UserFolder
@@ -50,7 +49,7 @@ APP_MANAGER = None
 
 
 @implementer(IApplication)
-class Application(ApplicationDefaultPermissions, Folder.Folder, FindSupport):
+class Application(ApplicationDefaultPermissions, Folder.Folder):
     """Top-level system object"""
 
     security = ClassSecurityInfo()

--- a/src/OFS/Folder.py
+++ b/src/OFS/Folder.py
@@ -19,7 +19,6 @@ from AccessControl.class_init import InitializeClass
 from App.special_dtml import DTMLFile
 from OFS.FindSupport import FindSupport
 from OFS.interfaces import IFolder
-from OFS.Lockable import LockableItem
 from OFS.ObjectManager import ObjectManager
 from OFS.PropertyManager import PropertyManager
 from OFS.role import RoleManager
@@ -57,7 +56,6 @@ class Folder(
     PropertyManager,
     RoleManager,
     Collection,
-    LockableItem,
     Item,
     FindSupport
 ):

--- a/src/OFS/SimpleItem.py
+++ b/src/OFS/SimpleItem.py
@@ -44,7 +44,6 @@ from OFS.CopySupport import CopySource
 from OFS.interfaces import IItem
 from OFS.interfaces import IItemWithName
 from OFS.interfaces import ISimpleItem
-from OFS.Lockable import LockableItem
 from OFS.owner import Owned
 from OFS.role import RoleManager
 from OFS.Traversable import Traversable
@@ -92,10 +91,8 @@ class PathReprProvider(Base):
 @implementer(IItem)
 class Item(
     PathReprProvider,
-    Base,
     Navigation,
     Resource,
-    LockableItem,
     CopySource,
     Tabs,
     Traversable,

--- a/src/OFS/userfolder.py
+++ b/src/OFS/userfolder.py
@@ -26,8 +26,6 @@ from AccessControl.users import emergency_user
 from AccessControl.users import readUserAccessFile
 from AccessControl.users import reqattr
 from Acquisition import aq_base
-from App.Management import Navigation
-from App.Management import Tabs
 from App.special_dtml import DTMLFile
 from OFS.role import RoleManager
 from OFS.SimpleItem import Item
@@ -35,8 +33,6 @@ from zExceptions import BadRequest
 
 
 class BasicUserFolder(
-    Navigation,
-    Tabs,
     Item,
     RoleManager,
     accesscontrol_userfolder.BasicUserFolder

--- a/src/Products/Five/viewlet/tests.py
+++ b/src/Products/Five/viewlet/tests.py
@@ -18,12 +18,9 @@ import unittest
 
 from OFS.SimpleItem import SimpleItem
 from Testing.ZopeTestCase import FunctionalDocFileSuite
-from zope.interface import Interface
-from zope.interface import implementer
 from zope.viewlet import interfaces
 
 
-@implementer(Interface)
 class Content(SimpleItem):
     pass
 

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,8 @@ skip_install = true
 deps =
     setuptools < 52
     zc.buildout
+setenv =
+    ZOPE_INTERFACE_STRICT_IRO=1
 commands_pre =
     {envbindir}/buildout -c {toxinidir}/buildout.cfg buildout:directory={envdir} buildout:develop={toxinidir} install alltests
 commands =


### PR DESCRIPTION
`zope.interface 5` introduced the ability to: Adopt Python’s standard C3 resolution order to compute the `__iro__` and `__sro__` of interfaces, with tweaks to support additional cases that are common in interfaces but disallowed for Python classes.

It is currently enabled by the environment variable `ZOPE_INTERFACE_STRICT_IRO=1`.