### PR TITLE
fixed header spacing of copyright page

### DIFF
--- a/src/zmi/styles/resources/zmi_base.css
+++ b/src/zmi/styles/resources/zmi_base.css
@@ -953,10 +953,18 @@ header.navbar select.form-control-sm,
 
 	}
 }
+.zmi-zope_copyright {
+	margin:0;
+	padding:0;
+}
 .zmi-zope_copyright h2 {
 	font-size: 130%;
 	color: white;
 	margin: 0;
+	line-height: 1.5;
+}
+.zmi-zope_copyright header {
+	box-sizing: border-box;
 }
 
 /* EXAMPLE: IMPLANT YOUR LOGO */

--- a/src/zmi/styles/resources/zmi_base.css
+++ b/src/zmi/styles/resources/zmi_base.css
@@ -958,10 +958,12 @@ header.navbar select.form-control-sm,
 	padding:0;
 }
 .zmi-zope_copyright h2 {
-	font-size: 130%;
+	font-size: 120%;
 	color: white;
 	margin: 0;
-	line-height: 1.5;
+	line-height: 1.65;
+	font-weight:normal;
+	letter-spacing: .05rem;
 }
 .zmi-zope_copyright header {
 	box-sizing: border-box;


### PR DESCRIPTION
hi @dataflake ,
just a tiny css fix for the copyright page: 
on that page the header had some margins. 
Now it is "in line" and typography is more consistant:

![c_page](https://user-images.githubusercontent.com/29705216/122454379-9e78b480-cfab-11eb-8228-d9da7fa42553.gif)

Best regards
f
