### PR TITLE
Backport stricter traversal checks from Zope 5

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ https://zope.readthedocs.io/en/2.13/CHANGES.html
 4.6.2 (unreleased)
 ------------------
 
+- Backport stricter traversal checks from Zope 5
+
 - Update dependencies to the latest releases that still support Python 2.
 
 

--- a/src/Products/PageTemplates/Expressions.py
+++ b/src/Products/PageTemplates/Expressions.py
@@ -17,7 +17,6 @@ for Python expressions, string literals, and paths.
 """
 
 import logging
-import types
 import warnings
 
 from six import binary_type
@@ -25,7 +24,7 @@ from six import text_type
 
 import OFS.interfaces
 from AccessControl import safe_builtins
-from AccessControl.ZopeGuards import guarded_import
+from AccessControl.SecurityManagement import getSecurityManager
 from Acquisition import aq_base
 from MultiMapping import MultiMapping
 from zExceptions import NotFound
@@ -75,33 +74,43 @@ def boboAwareZopeTraverse(object, path_items, econtext):
     necessary (bobo-awareness).
     """
     request = getattr(econtext, 'request', None)
+    validate = getSecurityManager().validate
     path_items = list(path_items)
     path_items.reverse()
 
     while path_items:
         name = path_items.pop()
 
-        if name == '_':
-            warnings.warn('Traversing to the name `_` is deprecated '
-                          'and will be removed in Zope 6.',
-                          DeprecationWarning)
-        elif name.startswith('_'):
-            raise NotFound(name)
-
         if OFS.interfaces.ITraversable.providedBy(object):
             object = object.restrictedTraverse(name)
-        elif isinstance(object, types.ModuleType):
+        else:
+            found = traversePathElement(object, name, path_items,
+                                        request=request)
+
+            # Special backwards compatibility exception for the name ``_``,
+            # which was often used for translation message factories.
+            # Allow and continue traversal.
+            if name == '_':
+                warnings.warn('Traversing to the name `_` is deprecated '
+                              'and will be removed in Zope 6.',
+                              DeprecationWarning)
+                object = found
+                continue
+
+            # All other names starting with ``_`` are disallowed.
+            # This emulates what restrictedTraverse does.
+            if name.startswith('_'):
+                raise NotFound(name)
+
+            # traversePathElement doesn't apply any Zope security policy,
+            # so we validate access explicitly here.
             try:
-                # guarded_import will do all necessary security checking
-                # but will not return the imported item itself.
-                guarded_import(object.__name__, fromlist=[name])
-                object = getattr(object, name)
+                validate(object, object, name, found)
+                object = found
             except Unauthorized:
                 # Convert Unauthorized to prevent information disclosures
                 raise NotFound(name)
-        else:
-            object = traversePathElement(object, name, path_items,
-                                         request=request)
+
     return object
 
 

--- a/src/Products/PageTemplates/tests/testExpressions.py
+++ b/src/Products/PageTemplates/tests/testExpressions.py
@@ -8,6 +8,7 @@ from six import text_type
 from AccessControl import safe_builtins
 from zExceptions import NotFound
 from zope.component.testing import PlacelessSetup
+from zope.location.interfaces import LocationError
 
 
 class EngineTestsBase(PlacelessSetup):
@@ -237,10 +238,10 @@ class UntrustedEngineTests(EngineTestsBase, unittest.TestCase):
         with self.assertRaises(NotFound):
             ec.evaluate("context/__class__")
 
-        with self.assertRaises(NotFound):
+        with self.assertRaises((NotFound, LocationError)):
             ec.evaluate("nocall: random/_itertools/repeat")
 
-        with self.assertRaises(NotFound):
+        with self.assertRaises((NotFound, LocationError)):
             ec.evaluate("random/_itertools/repeat/foobar")
 
 

--- a/src/Products/PageTemplates/tests/testHTMLTests.py
+++ b/src/Products/PageTemplates/tests/testHTMLTests.py
@@ -27,14 +27,20 @@ from Products.PageTemplates.unicodeconflictresolver import \
     DefaultUnicodeEncodingConflictResolver
 from Products.PageTemplates.unicodeconflictresolver import \
     PreferredCharsetResolver
+from Products.PageTemplates.ZopePageTemplate import ZopePageTemplate
 from zExceptions import NotFound
 from zope.component import provideUtility
+from zope.location.interfaces import LocationError
 from zope.traversing.adapters import DefaultTraversable
 
 from .util import useChameleonEngine
 
 
 class AqPageTemplate(Implicit, PageTemplate):
+    pass
+
+
+class AqZopePageTemplate(Implicit, ZopePageTemplate):
     pass
 
 
@@ -75,6 +81,7 @@ class HTMLTests(zope.component.testing.PlacelessSetup, unittest.TestCase):
         self.folder = f = Folder()
         f.laf = AqPageTemplate()
         f.t = AqPageTemplate()
+        f.z = AqZopePageTemplate('testing')
         self.policy = UnitTestSecurityPolicy()
         self.oldPolicy = SecurityManager.setSecurityPolicy(self.policy)
         noSecurityManager()  # Use the new policy.
@@ -227,15 +234,15 @@ class HTMLTests(zope.component.testing.PlacelessSetup, unittest.TestCase):
             t()
 
         t.write('<p tal:define="p nocall: random/_itertools/repeat"/>')
-        with self.assertRaises(NotFound):
+        with self.assertRaises((NotFound, LocationError)):
             t()
 
         t.write('<p tal:content="random/_itertools/repeat/foobar"/>')
-        with self.assertRaises(NotFound):
+        with self.assertRaises((NotFound, LocationError)):
             t()
 
     def test_module_traversal(self):
-        t = self.folder.t
+        t = self.folder.z
 
         # Need to reset to the standard security policy so AccessControl
         # checks are actually performed. The test setup initializes


### PR DESCRIPTION
This PR backports the stricter traversal checks from Zope 5 to Zope 4 to prevent additional obscure traversal failures. Plone monkey patches the methods already so it's safe to be stricter in Zope itself.