### PR TITLE
Make sure "Manager" users can always modify proxy roles

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,12 +11,16 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 5.3 (unreleased)
 ----------------
 
-- Update to newest compatible versions of dependencies.
+- make sure "Manager" users can always modify proxy roles
+  (`see Products.PythonScripts#50
+    <https://github.com/zopefoundation/Products.PythonScripts/issues/50>`_)
 
 - Deprecate usage of "unicode" converters. Also, the behavior of
   ``field2lines`` is now aligned to the other converters and returns a list of
   strings instead of a list of bytes.
   (`#962 <https://github.com/zopefoundation/Zope/issues/962>`_)
+
+- Update to newest compatible versions of dependencies.
 
 
 5.2.1 (2021-06-08)

--- a/src/OFS/tests/test_DTMLMethod.py
+++ b/src/OFS/tests/test_DTMLMethod.py
@@ -1,10 +1,14 @@
 import io
 import unittest
+from urllib.error import HTTPError
 
 import Testing.testbrowser
 import Testing.ZopeTestCase
 import zExceptions
 import Zope2.App.zcml
+from AccessControl.Permissions import change_proxy_roles
+from AccessControl.SecurityManagement import newSecurityManager
+from AccessControl.SecurityManagement import noSecurityManager
 from Testing.makerequest import makerequest
 
 
@@ -172,6 +176,86 @@ class DTMLMethodBrowserTests(Testing.ZopeTestCase.FunctionalTestCase):
         self.browser.getControl('Save').click()
         self.assertIn('Saved changes.', self.browser.contents)
         self.assertEqual(self.browser.getControl(name='data:text').value, code)
+
+    def test_proxyroles_manager(self):
+        test_role = 'Test Role'
+        self.app._addRole(test_role)
+
+        # Test the original state
+        self.assertFalse(self.app.dtml_meth.manage_haveProxy(test_role))
+
+        # Go to the "Proxy" ZMI tab, grab the Proxy Roles select box,
+        # select the new role and submit
+        self.browser.open('http://localhost/dtml_meth/manage_proxyForm')
+        roles_selector = self.browser.getControl(name='roles:list')
+        testrole_option = roles_selector.getControl(test_role)
+        self.assertFalse(testrole_option.selected)
+        testrole_option.selected = True
+        self.browser.getControl('Save Changes').click()
+
+        # The Python Script should now have a proxy role set
+        self.assertTrue(self.app.dtml_meth.manage_haveProxy(test_role))
+
+    def test_proxyroles_nonmanager(self):
+        # This test checks an unusual configuration where roles other than
+        # Manager are allowed to change proxy roles.
+        proxy_form_url = 'http://localhost/dtml_meth/manage_proxyForm'
+        test_role = 'Test Role'
+        self.app._addRole(test_role)
+        test_role_2 = 'Unprivileged Role'
+        self.app._addRole(test_role_2)
+        self.app.manage_permission(change_proxy_roles, ['Manager', test_role])
+
+        # Add some test users
+        uf = self.app.acl_users
+        uf.userFolderAddUser('privileged', 'priv', [test_role], [])
+        uf.userFolderAddUser('peon', 'unpriv', [test_role_2], [])
+
+        # Test the original state
+        self.assertFalse(self.app.dtml_meth.manage_haveProxy(test_role))
+        self.assertFalse(self.app.dtml_meth.manage_haveProxy(test_role_2))
+
+        # Attempt as unprivileged user will fail both in the browser and
+        # from trusted code
+        self.browser.login('peon', 'unpriv')
+        with self.assertRaises(HTTPError):
+            self.browser.open(proxy_form_url)
+
+        newSecurityManager(None, uf.getUser('peon'))
+        with self.assertRaises(zExceptions.Forbidden):
+            self.app.dtml_meth.manage_proxy(roles=(test_role,))
+        self.assertFalse(self.app.dtml_meth.manage_haveProxy(test_role))
+
+        # Now log in as privileged user and try to set a proxy role
+        # the privileged user does not have. This must fail.
+        self.browser.login('privileged', 'priv')
+        self.browser.open(proxy_form_url)
+        roles_selector = self.browser.getControl(name='roles:list')
+        bad_option = roles_selector.getControl(test_role_2)
+        self.assertFalse(bad_option.selected)
+        bad_option.selected = True
+        with self.assertRaises(HTTPError):
+            self.browser.getControl('Save Changes').click()
+        self.assertFalse(self.app.dtml_meth.manage_haveProxy(test_role_2))
+
+        newSecurityManager(None, uf.getUser('privileged'))
+        with self.assertRaises(zExceptions.Forbidden):
+            self.app.dtml_meth.manage_proxy(roles=(test_role_2,))
+        self.assertFalse(self.app.dtml_meth.manage_haveProxy(test_role_2))
+
+        # Trying again as privileged user with a proxy role the user has
+        self.browser.open(proxy_form_url)
+        roles_selector = self.browser.getControl(name='roles:list')
+        testrole_option = roles_selector.getControl(test_role)
+        self.assertFalse(testrole_option.selected)
+        testrole_option.selected = True
+        self.browser.getControl('Save Changes').click()
+
+        # The Python Script should now have a proxy role set
+        self.assertTrue(self.app.dtml_meth.manage_haveProxy(test_role))
+
+        # Cleanup
+        noSecurityManager()
 
 
 class FactoryTests(unittest.TestCase):


### PR DESCRIPTION
See https://github.com/zopefoundation/Products.PythonScripts/issues/50

It makes no sense that "Manager" users can effectively be prevented from modifying a DTML Method or DTML Document with a proxy role the Manager-level user doesn't have. This PR circumvents the proxy role check for Manager users.

This also utilizes the cleaner implementation of `_validateProxyRoles` from `Products.PythonScripts`.