### PR TITLE
Add function ZPublisher.utils.fix_properties.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,12 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 5.4 (unreleased)
 ----------------
 
+- Add function ``ZPublisher.utils.fix_properties``.
+  You can call this to fix lines properties to only contain strings, not bytes.
+  It also replaces the deprecated property types ulines, utext, utoken, and ustring
+  with their non-unicode variants.
+  See `issue 987 <https://github.com/zopefoundation/Zope/issues/987>`_.
+
 - Add support for Python 3.10.
 
 - Update to newest compatible versions of dependencies.

--- a/src/ZPublisher/tests/test_utils.py
+++ b/src/ZPublisher/tests/test_utils.py
@@ -34,3 +34,71 @@ class SafeUnicodeTests(unittest.TestCase):
     def test_utf_8(self):
         self.assertEqual(self._makeOne('test\xc2\xae'), 'test\xc2\xae')
         self.assertEqual(self._makeOne(b'test\xc2\xae'), 'test\xae')
+
+
+class FixPropertiesTests(unittest.TestCase):
+
+    def _makeOne(self):
+        from OFS.PropertyManager import PropertyManager
+
+        return PropertyManager()
+
+    def test_lines(self):
+        from ZPublisher.utils import fix_properties
+
+        obj = self._makeOne()
+        obj._setProperty("mixed", ["text and", b"bytes"], "lines")
+        self.assertEqual(obj.getProperty("mixed"), ("text and", b"bytes"))
+        self.assertEqual(obj.getPropertyType("mixed"), "lines")
+
+        fix_properties(obj)
+        self.assertEqual(obj.getProperty("mixed"), ("text and", "bytes"))
+        self.assertEqual(obj.getPropertyType("mixed"), "lines")
+
+    def test_ulines(self):
+        from ZPublisher.utils import fix_properties
+
+        obj = self._makeOne()
+        obj._setProperty("mixed", ["text and", b"bytes"], "ulines")
+        self.assertEqual(obj.getProperty("mixed"), ("text and", b"bytes"))
+        self.assertEqual(obj.getPropertyType("mixed"), "ulines")
+
+        fix_properties(obj)
+        self.assertEqual(obj.getProperty("mixed"), ("text and", "bytes"))
+        self.assertEqual(obj.getPropertyType("mixed"), "lines")
+
+    def test_utokens(self):
+        from ZPublisher.utils import fix_properties
+
+        obj = self._makeOne()
+        obj._setProperty("mixed", ["text", "and", b"bytes"], "utokens")
+        self.assertEqual(obj.getProperty("mixed"), ("text", "and", b"bytes"))
+        self.assertEqual(obj.getPropertyType("mixed"), "utokens")
+
+        fix_properties(obj)
+        self.assertEqual(obj.getProperty("mixed"), ("text", "and", "bytes"))
+        self.assertEqual(obj.getPropertyType("mixed"), "tokens")
+
+    def test_utext(self):
+        from ZPublisher.utils import fix_properties
+
+        obj = self._makeOne()
+        obj._setProperty("prop1", "multiple\nlines", "utext")
+        self.assertEqual(obj.getProperty("prop1"), "multiple\nlines")
+        self.assertEqual(obj.getPropertyType("prop1"), "utext")
+
+        fix_properties(obj)
+        self.assertEqual(obj.getProperty("prop1"), "multiple\nlines")
+        self.assertEqual(obj.getPropertyType("prop1"), "text")
+
+    def test_ustring(self):
+        from ZPublisher.utils import fix_properties
+
+        obj = self._makeOne()
+        obj._setProperty("prop1", "single line", "ustring")
+        self.assertEqual(obj.getProperty("prop1"), "single line")
+        self.assertEqual(obj.getPropertyType("prop1"), "ustring")
+
+        fix_properties(obj)
+        self.assertEqual(obj.getProperty("prop1"), "single line")
+        self.assertEqual(obj.getPropertyType("prop1"), "string")

--- a/src/ZPublisher/utils.py
+++ b/src/ZPublisher/utils.py
@@ -185,8 +185,7 @@ def fix_properties(obj, path=None):
             for prop in obj._properties:
                 if prop.get("id") == prop_id:
                     prop["type"] = new_type
-                    # This is a tuple, so force an object update to be sure
-                    obj._properties = obj._properties
+                    obj._p_changed = True
                     break
             else:
                 # This probably cannot happen.

--- a/src/ZPublisher/utils.py
+++ b/src/ZPublisher/utils.py
@@ -185,7 +185,7 @@ def fix_properties(obj, path=None):
             for prop in obj._properties:
                 if prop.get("id") == prop_id:
                     prop["type"] = new_type
-                    # This is a tuple, so force an object update, just to be sure.
+                    # This is a tuple, so force an object update to be sure
                     obj._properties = obj._properties
                     break
             else:

--- a/src/ZPublisher/utils.py
+++ b/src/ZPublisher/utils.py
@@ -185,7 +185,7 @@ def fix_properties(obj, path=None):
             for prop in obj._properties:
                 if prop.get("id") == prop_id:
                     prop["type"] = new_type
-                    # This is a tuple, so force a safe, just to be sure.
+                    # This is a tuple, so force an object update, just to be sure.
                     obj._properties = obj._properties
                     break
             else:


### PR DESCRIPTION
You can call this to fix lines properties to only contain strings, not bytes.
It also replaces the deprecated property types ulines, utext, utoken, and ustring with their non-unicode variants.
See https://github.com/zopefoundation/Zope/issues/987 for why this is needed.

Note: the code is not called by Zope itself. The idea is that integrators who think they need this in their database, can call it.
Sample use:

    app.ZopeFindAndApply(app, apply_func=fix_properties)

I intend to use this (or a temporary copy) in the Plone 6 upgrade code.
See https://github.com/plone/Products.CMFPlone/issues/3305

I tried it on a few databases, and it works there, although only very little is changed.