### PR TITLE
Remove deprecated ulines, utext, utokens, ustring from more code.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 5.4 (unreleased)
 ----------------
 
+- Remove deprecated ulines, utext, utokens, ustring from more code.
+  In the properties form, show a deprecation warning.
+
 - Add function ``ZPublisher.utils.fix_properties``.
   You can call this to fix lines properties to only contain strings, not bytes.
   It also replaces the deprecated property types ulines, utext, utoken, and ustring

--- a/src/OFS/dtml/properties.dtml
+++ b/src/OFS/dtml/properties.dtml
@@ -129,7 +129,10 @@
 								</td>
 							<!-- Value column end -->
 							<!-- Type column -->
-								<td>&dtml-type;</td>
+								<td>
+									&dtml-type;
+									<dtml-if "type in ['ulines', 'utext', 'utokens', 'ustring']"><strong><a href="https://github.com/zopefoundation/Zope/issues/962">deprecated</a></strong></dtml-if>
+                </td>
 							</tr>
 						</dtml-let>
 					</dtml-in>

--- a/src/OFS/tests/export.xml
+++ b/src/OFS/tests/export.xml
@@ -270,7 +270,7 @@ DFWKRHmyY8mRKStmXJhzp04AEllSfBgUZsOWPk+2HFqwaYCAAAA7</string></value>
                   <dictionary id="482504664188191746.57">
                     <item>
                         <key><reference id="482504664188191746.37"/></key>
-                        <value><string id="482504664188191746.58" encoding="">ulines</string></value>
+                        <value><string id="482504664188191746.58" encoding="">lines</string></value>
                     </item>
                     <item>
                         <key><reference id="482504664188191746.39"/></key>

--- a/src/Products/PageTemplates/ZopePageTemplate.py
+++ b/src/Products/PageTemplates/ZopePageTemplate.py
@@ -90,7 +90,7 @@ class ZopePageTemplate(Script, PageTemplate, Historical, Cacheable,
         Cacheable.manage_options
 
     _properties = (
-        {'id': 'title', 'type': 'ustring', 'mode': 'w'},
+        {'id': 'title', 'type': 'string', 'mode': 'w'},
         {'id': 'content_type', 'type': 'string', 'mode': 'w'},
         {'id': 'output_encoding', 'type': 'string', 'mode': 'w'},
         {'id': 'expand', 'type': 'boolean', 'mode': 'w'},

--- a/src/ZTUtils/Zope.py
+++ b/src/ZTUtils/Zope.py
@@ -298,10 +298,6 @@ def simple_marshal(v):
     if isinstance(v, bytes):
         # Py 3 only
         return ':bytes'
-    if isinstance(v, str):
-        # Py 2 only
-        encoding = _default_encoding()
-        return f':{encoding}:ustring'
     if isinstance(v, bool):
         return ':boolean'
     if isinstance(v, int):

--- a/src/ZTUtils/Zope.py
+++ b/src/ZTUtils/Zope.py
@@ -296,7 +296,6 @@ def simple_marshal(v):
     if isinstance(v, str):
         return ''
     if isinstance(v, bytes):
-        # Py 3 only
         return ':bytes'
     if isinstance(v, bool):
         return ':boolean'


### PR DESCRIPTION
- Zope PageTemplate still created a title property with type ustring.
  Strangely, after this commit, for existing Page Templates it is automatically a string, without needing to change anything.
- OFS tests had an export.xml with a ulines.
- ZTUtils/Zope.py had unreachable code that used ustring:
  the condition `if isinstance(v, str)` was already handled a few lines up

Also, in the properties form, show deprecation for ulines, utext, utokens, ustring.
Add a link to https://github.com/zopefoundation/Zope/issues/962 where they got deprecated.
Note: you can still add these properties in this form.
I would almost be inclined to remove them, but we should probably keep them in Zope 5.