### PR TITLE
Enable WebDAV PUT factories to change a newly created object's ID

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 5.4 (unreleased)
 ----------------
 
+- Enable WebDAV PUT factories to change a newly created object's ID
+  (`#997 <https://github.com/zopefoundation/Zope/issues/997>`_)
+
 - Fix potential race condition in ``App.version_txt.getZopeVersion``
   (`#999 <https://github.com/zopefoundation/Zope/issues/999>`_)
 

--- a/src/webdav/NullResource.py
+++ b/src/webdav/NullResource.py
@@ -184,6 +184,9 @@ class NullResource(Persistent, Implicit, Resource):
                    (ob.__class__, repr(parent), sys.exc_info()[1],)
             raise Unauthorized(sMsg)
 
+        # A PUT factory may have changed the object's ID
+        name = ob.getId() or name
+
         # Delegate actual PUT handling to the new object,
         # SDS: But just *after* it has been stored.
         self.__parent__._setObject(name, ob)

--- a/src/webdav/tests/testPUT_factory.py
+++ b/src/webdav/tests/testPUT_factory.py
@@ -90,3 +90,20 @@ class TestPUTFactory(unittest.TestCase):
                          'PUT factory should not acquire content')
         # check for the newly created file
         self.assertEqual(str(self.app.A.B.a), 'bar')
+
+    def testPUT_factory_changes_name(self):
+        # A custom PUT factory may want to change the object ID,
+        # for example to remove file name extensions.
+        from OFS.Image import File
+
+        def custom_put_factory(name, typ, body):
+            new_name = 'newname'
+            if not isinstance(body, bytes):
+                body = body.encode('UTF-8')
+            return File(new_name, '', body, content_type=typ)
+        self.app.folder.PUT_factory = custom_put_factory
+
+        request = self.app.REQUEST
+        put = request.traverse('/folder/doc')
+        put(request, request.RESPONSE)
+        self.assertTrue('newname' in self.folder.objectIds())


### PR DESCRIPTION
Fixes #997 partially

This PR allows a WebDAV PUT factory to change a new object ID to something other than the `PUT` URL target name.