### PR TITLE
Use string representation of response data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,7 +13,8 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 
 - Update to newest compatible versions of dependencies.
 
-- Use string representation of response data that has no ``__bytes__``
+- Use intermediate ``str`` representation for complex response data (i.e. not
+  ``str`` or ``bytes`` like)
   (`#1006 <https://github.com/zopefoundation/Zope/issues/1006>`_)
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,9 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 
 - Update to newest compatible versions of dependencies.
 
+- Use string representation of response data that has no ``__bytes__``
+  (`#1006 <https://github.com/zopefoundation/Zope/issues/1006>`_)
+
 
 5.4 (2022-01-09)
 ----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,8 +13,8 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 
 - Update to newest compatible versions of dependencies.
 
-- Use intermediate ``str`` representation for complex response data (i.e. not
-  ``str`` or ``bytes`` like)
+- Use intermediate ``str`` representation for non-bytelike response data unless
+  indicated differently by the content type.
   (`#1006 <https://github.com/zopefoundation/Zope/issues/1006>`_)
 
 

--- a/src/ZPublisher/HTTPResponse.py
+++ b/src/ZPublisher/HTTPResponse.py
@@ -528,6 +528,8 @@ class HTTPBaseResponse(BaseResponse):
             body = self._encode_unicode(body)
         elif isinstance(body, bytes):
             pass
+        elif not hasattr(body, '__bytes__') and hasattr(body, '__str__'):
+            body = self._encode_unicode(str(body))
         else:
             try:
                 body = bytes(body)

--- a/src/ZPublisher/HTTPResponse.py
+++ b/src/ZPublisher/HTTPResponse.py
@@ -498,11 +498,13 @@ class HTTPBaseResponse(BaseResponse):
         If the body is a 2-element tuple, then it will be treated
         as (title,body)
 
-        If body is unicode, encode it.
+        If body has an 'asHTML' method, replace it by the result of that
+        method.
 
-        If body is not a string or unicode, but has an 'asHTML' method, use
-        the result of that method as the body;  otherwise, use the 'str'
-        of body.
+        If body is unicode, encode it. If it is more complex (no str or bytes
+        and no '__bytes__' method), use its 'str' representation and encode the
+        result. Else, convert it to bytes, falling back to the encoded 'str'
+        representation if this yields an error.
 
         If is_error is true, format the HTML as a Zope error message instead
         of a generic HTML page.

--- a/src/ZPublisher/tests/testHTTPResponse.py
+++ b/src/ZPublisher/tests/testHTTPResponse.py
@@ -650,7 +650,7 @@ class HTTPResponseTests(unittest.TestCase):
         regardless of if the values are in byte range."""
         response = self._makeOne()
         for body in ([1, 2, 3], [1, 2, 500]):
-            result = response.setBody(body)
+            response.setBody(body)
             self.assertEqual(response.body, str(body).encode('utf-8'))
 
     def test_setBody_w_bogus_pseudo_HTML(self):

--- a/src/ZPublisher/tests/testHTTPResponse.py
+++ b/src/ZPublisher/tests/testHTTPResponse.py
@@ -645,6 +645,14 @@ class HTTPResponseTests(unittest.TestCase):
         self.assertEqual(response.getHeader('Content-Length'),
                          str(len(ENCODED)))
 
+    def test_setBody_list(self):
+        """Test that setBody casts lists of ints into their str representation,
+        regardless of if the values are in byte range."""
+        response = self._makeOne()
+        for body in ([1, 2, 3], [1, 2, 500]):
+            result = response.setBody(body)
+            self.assertEqual(response.body, str(body).encode('utf-8'))
+
     def test_setBody_w_bogus_pseudo_HTML(self):
         # The 2001 checkin message which added the path-under-test says:
         # (r19315): "merged content type on error fixes from 2.3


### PR DESCRIPTION
Response data that has no `__bytes__` method but a `__str__` method,
like lists, dicts and similar, can now be handled by the publisher as it
was handled in Zope 2, by returning the string representation.

Fixes https://github.com/zopefoundation/Zope/issues/1006