### PR TITLE
Fix several exceptions when calling ZPublisher.utils.fix_properties.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 5.4.1 (unreleased)
 ------------------
 
+- Fix several exceptions when calling ``ZPublisher.utils.fix_properties``.
+
 - Update to newest compatible versions of dependencies.
 
 - Use intermediate ``str`` representation for non-bytelike response data unless

--- a/src/ZPublisher/utils.py
+++ b/src/ZPublisher/utils.py
@@ -145,11 +145,19 @@ def fix_properties(obj, path=None):
             # We don't care about the path then, it is only shown in logs.
             path = "/dummy"
 
+    if not hasattr(obj, "_updateProperty"):
+        # Seen with portal_url tool, most items in portal_skins,
+        # catalog lexicons, workflow states/transitions/variables, etc.
+        return
     try:
         prop_map = obj.propertyMap()
-    except AttributeError:
-        # Object does not inherit from PropertyManager.
-        # For example 'MountedObject'.
+    except (AttributeError, TypeError, KeyError, ValueError):
+        # If getting the property map fails, there is nothing we can do.
+        # Problems seen in practice:
+        # - Object does not inherit from PropertyManager,
+        #   for example 'MountedObject'.
+        # - Object is a no longer existing skin layer.
+        logger.warning("Error getting property map from %s", path)
         return
 
     for prop_info in prop_map:


### PR DESCRIPTION
I created this function in Zope 5.4 and it worked for the databases I tried it on.
But on another project I ran into several exceptions.
See tracebacks in Plone:
https://github.com/plone/plone.app.upgrade/issues/270

Note that `plone.app.upgrade` has a temporary copy of the same function.
I fixed the function there as well today:
https://github.com/plone/plone.app.upgrade/pull/271