### PR TITLE
enhanced cookie support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,9 @@ https://zope.readthedocs.io/en/2.13/CHANGES.html
 4.7.1 (unreleased)
 ------------------
 
+- Enhance cookie support. For details, see
+  `#1010 <https://github.com/zopefoundation/Zope/issues/1010>`_
+
 - Update dependencies to the latest releases that still support Python 2.
 
 

--- a/src/Testing/ZopeTestCase/testFunctional.py
+++ b/src/Testing/ZopeTestCase/testFunctional.py
@@ -91,7 +91,7 @@ class TestFunctional(ZopeTestCase.FunctionalTestCase):
         response = self.publish(self.folder_path + '/set_cookie')
         self.assertEqual(response.getStatus(), 200)
         self.assertEqual(response.getCookie('foo').get('value'), 'Bar')
-        self.assertEqual(response.getCookie('foo').get('path'), '/')
+        self.assertEqual(response.getCookie('foo').get('Path'), '/')
 
     def testChangeTitle(self):
         # Change the title of a document

--- a/src/Testing/ZopeTestCase/zopedoctest/FunctionalDocTest.txt
+++ b/src/Testing/ZopeTestCase/zopedoctest/FunctionalDocTest.txt
@@ -145,7 +145,7 @@ Test setting cookies
   >>> response.status
   200
 
-  >>> b'Set-Cookie: foo="Bar"; Path=/' in response.getOutput()
+  >>> b'Set-Cookie: foo=Bar; Path=/' in response.getOutput()
   True
 
 Test reading cookies

--- a/src/Testing/tests/test_testbrowser.py
+++ b/src/Testing/tests/test_testbrowser.py
@@ -89,7 +89,7 @@ class TestTestbrowser(FunctionalTestCase):
 
         browser = Browser()
         browser.open('http://localhost/test_folder_1_/stub')
-        self.assertEqual(browser.cookies.get('evil'), '"cookie"')
+        self.assertEqual(browser.cookies.get('evil'), 'cookie')
 
     def test_handle_errors_true(self):
         self.folder._setObject('stub', ExceptionStub())

--- a/src/ZPublisher/HTTPRequest.py
+++ b/src/ZPublisher/HTTPRequest.py
@@ -50,6 +50,8 @@ from ZPublisher.Converters import get_converter
 from ZPublisher.interfaces import IXmlrpcChecker
 from ZPublisher.utils import basic_auth_decode
 
+from .cookie import getCookieValuePolicy
+
 
 if PY3:
     from html import escape
@@ -1769,7 +1771,7 @@ def parse_cookie(text,
                 return result
 
     if name not in result:
-        result[name] = unquote(value)
+        result[name] = getCookieValuePolicy().load(name, value)
 
     return parse_cookie(text[c_len:], result)
 

--- a/src/ZPublisher/cookie.py
+++ b/src/ZPublisher/cookie.py
@@ -32,6 +32,7 @@ from time import time
 from six.moves.urllib.parse import quote
 from six.moves.urllib.parse import unquote
 
+from Acquisition import aq_base
 from DateTime import DateTime
 from zope.component import getGlobalSiteManager
 from zope.component import queryUtility
@@ -46,7 +47,7 @@ class DefaultCookieParamPolicy(object):
     """Default ``ICookieParamPolicy``.
 
     It adds ``Expires`` when it sees ``Max-Age`` (for compatibility
-    with HTTP/1.0) and urlquotes cookie values.
+    with HTTP/1.0).
     """
 
     @staticmethod
@@ -264,9 +265,9 @@ def path_converter(value):
     If the string contains ``%``, it is assumed that it is already
     quoted.
     """
-    ap = getattr(value, "absolute_url_path", None)
+    ap = getattr(aq_base(value), "absolute_url_path", None)
     if ap is not None:
-        return ap()
+        return value.absolute_url_path()
     if path_safe(value):
         return value
     if "%" in value:

--- a/src/ZPublisher/cookie.py
+++ b/src/ZPublisher/cookie.py
@@ -237,16 +237,13 @@ def domain_converter(value):
     the registration to get IDNA2008 if you observe domain
     related problems.
     """
-    if isinstance(value, bytes):
-        value = value.decode("utf-8")
-    if "xn--" in value:  # already encoded
-        # ATT: under Python 2, this returns unicode
-        # this may pose problems should other parameters
-        # provide encoded non-ASCII
+    # Python 2 requires unicode
+    u_value = value.decode("utf-8") if isinstance(value, bytes) else value
+    if "xn--" in u_value:  # already encoded
         return value
     from encodings.idna import ToASCII
     from encodings.idna import nameprep
-    return ".".join(to_str(ToASCII(nameprep(c))) for c in value.split("."))
+    return ".".join(to_str(ToASCII(nameprep(c))) for c in u_value.split("."))
 
 
 registerCookieParameter("Domain", domain_converter)

--- a/src/ZPublisher/cookie.py
+++ b/src/ZPublisher/cookie.py
@@ -1,0 +1,337 @@
+##############################################################################
+#
+# Copyright (c) 2022 Zope Foundation and Contributors.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+"""HTTP cookie support.
+
+The implementation is based on
+`RFC6265 <https://www.rfc-editor.org/rfc/rfc6265.html>`_.
+
+The module introduces 2 features:
+
+ 1. default ``ICookieParamPolicy`` and ``ICookieValuePolicy``
+ 2. a cookie parameter registry
+
+and exports the functions ``getCookieParamPolicy``, ``getCookieValuePolicy``
+``registerCookieParameter``,
+``normalizeCookieParameterName`` and ``convertCookieParameter``.
+"""
+import datetime
+from itertools import chain
+from re import compile
+from time import time
+
+from six.moves.urllib.parse import quote
+from six.moves.urllib.parse import unquote
+
+from DateTime import DateTime
+from zope.component import getGlobalSiteManager
+from zope.component import queryUtility
+from zope.interface import implementer
+
+from .interfaces import ICookieParamPolicy
+from .interfaces import ICookieValuePolicy
+
+
+@implementer(ICookieParamPolicy)
+class DefaultCookieParamPolicy(object):
+    """Default ``ICookieParamPolicy``.
+
+    It adds ``Expires`` when it sees ``Max-Age`` (for compatibility
+    with HTTP/1.0) and urlquotes cookie values.
+    """
+
+    @staticmethod
+    def parameters(name, attrs):
+        """adds ``Expires`` if not present and ``Max-Age`` is set."""
+        for pn, pv in attrs.items():
+            if pn != "value":
+                yield (pn, pv)
+        if "Expires" not in attrs and attrs.get("Max-Age") is not None:
+            max_age = int(attrs["Max-Age"])
+            expires = "Wed, 31 Dec 1997 23:59:59 GMT" if max_age <= 0 \
+                      else time() + max_age
+            yield convertCookieParameter("Expires", expires)
+
+    @staticmethod
+    def check_consistency(name, attrs):
+        return  # does not enforce any consistency rules
+
+
+defaultCookieParamPolicy = DefaultCookieParamPolicy()
+
+
+@implementer(ICookieValuePolicy)
+class DefaultCookieValuePolicy(object):
+    """Default ``ICookieValuePolicy``.
+
+    It adds ``Expires`` when it sees ``Max-Age`` (for compatibility
+    with HTTP/1.0) and urlquotes cookie values.
+    """
+
+    @staticmethod
+    def dump(name, value):
+        """simply quote *value*."""
+        return quote(value)
+
+    @staticmethod
+    def load(name, value):
+        """simply unquote *value*."""
+        return unquote(value)
+
+
+defaultCookieValuePolicy = DefaultCookieValuePolicy()
+
+
+def getCookieParamPolicy():
+    return queryUtility(ICookieParamPolicy, default=defaultCookieParamPolicy)
+
+
+def getCookieValuePolicy():
+    # we look this utility up only in the global component registry
+    # as at the time of cookie parsing (when ``load`` is used),
+    # it is the only component registry available
+    return getGlobalSiteManager().queryUtility(
+        ICookieValuePolicy, default=defaultCookieValuePolicy)
+
+
+class CookieParameterRegistry(object):
+    """The cookie parameter registry maps parameter names.
+
+    It maintains 2 maps: one to normalize parameter names
+    and one to check and convert parameter values.
+    """
+    def __init__(self):
+        self._normalize = {}
+        self._convert = {}
+
+    def register(self, name, converter, aliases=()):
+        """register cookie parameter *name* with *converter* and *aliases*.
+
+        *converter* is a function which will be applied to
+        parameter values and which is expected to either
+        raise an exception or convert the value into
+        either ``None``, ``True``
+        or an ASCII string without control characters and ``;``.
+        ``None`` means "drop the parameter",
+        ``True`` menas "drop the parameter value",
+        otherwise, the return value is used as value representation.
+
+        Some aliases are automatically derived from *name*:
+        convertion to lower, ``-`` to ``_`` conversion.
+        Further aliases can be defined via *aliases*.
+
+        It is not an error to override existing registrations.
+        """
+        self._convert[name] = converter
+        for n in chain((name,), aliases):
+            for ln in (n, n.lower()):
+                for a in (ln, ln.replace("-", "_")):
+                    self._normalize[a] = name
+
+    def convert(self, name, value):
+        """check and convert *name* and *value* for parameter *name*.
+
+        Raises an exception in case of errors; otherwise,
+        returns *normalized name*, *converted value*.
+
+        The normalized name is the official parameter name.
+        The converted (or normalized) value is either ``None``
+        (drop the parameter), ``True`` (drop the parameter value)
+        or an ASCII string (use as parameter value).
+        """
+        nn = self.normalizeName(name)
+        return nn, (value if value is None else self[nn](value))
+
+    def normalizeName(self, name):
+        return self._normalize[name.lower()]
+
+    def __getitem__(self, name):
+        return self._convert[name]
+
+
+cookieParameterRegistry = CookieParameterRegistry()
+registerCookieParameter = cookieParameterRegistry.register
+convertCookieParameter = cookieParameterRegistry.convert
+normalizeCookieParameterName = cookieParameterRegistry.normalizeName
+
+
+###############################################################################
+# Cookie parameter converters
+
+# ``Expires``
+class UTC(datetime.tzinfo):
+    ZERO = datetime.timedelta(0)
+
+    def utcoffset(self, dt):
+        return self.ZERO
+
+    def tzname(self, dt):
+        return "UTC"
+
+    dst = utcoffset
+
+
+utc = UTC()
+
+wdmap = dict(enumerate("Mon Tue Wed Thu Fri Sat Sun".split()))
+mmap = dict((i + 1, m) for (i, m) in enumerate(
+    "Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec".split()))
+
+
+def rfc1123_converter(value):
+    """convert *value* into an RFC1123 date.
+
+    *value* can be a string (assumed already in the required form),
+    a Python `datetime` (assumed to be in the UTC time zone, if naive),
+    a float (interpreted as time stamp),
+    or a `DateTime` object.
+    """
+    if isinstance(value, str):
+        return value
+    if isinstance(value, (int, float)):
+        value = datetime.datetime.utcfromtimestamp(value)
+    elif isinstance(value, DateTime):
+        value = value.toZone("GMT").asdatetime()
+    if not isinstance(value, datetime.datetime):
+        raise ValueError("unsupported type: %s" % type(value))
+    if value.utcoffset() is not None:
+        value = value.astimezone(utc)
+    tt = value.timetuple()
+    # we cannot use ``strftime`` because it depends on locale
+    return "%s, %02d %s %04d %02d:%02d:%02d GMT" % (
+        wdmap[tt.tm_wday],
+        tt.tm_mday, mmap[tt.tm_mon], tt.tm_year,
+        tt.tm_hour, tt.tm_min, tt.tm_sec)
+
+
+registerCookieParameter("Expires", rfc1123_converter)
+
+
+# ``Max-Age``
+def int_converter(value):
+    """check for *int* value."""
+    int(value)
+    return str(value)
+
+
+registerCookieParameter("Max-Age", int_converter)
+
+
+# ``Domain``
+def domain_converter(value):
+    """convert *value* into an internationalized domain name.
+
+    Note: The Python infrastructure supports IDNA2003, but
+    RFC6265 calls for IDNA2008. IDNA2008 is implemented by
+    a third party module. You might want to override
+    the registration to get IDNA2008 if you observe domain
+    related problems.
+    """
+    if isinstance(value, bytes):
+        value = value.decode("utf-8")
+    if "xn--" in value:  # already encoded
+        # ATT: under Python 2, this returns unicode
+        # this may pose problems should other parameters
+        # provide encoded non-ASCII
+        return value
+    from encodings.idna import ToASCII
+    from encodings.idna import nameprep
+    return ".".join(to_str(ToASCII(nameprep(c))) for c in value.split("."))
+
+
+registerCookieParameter("Domain", domain_converter)
+
+
+# ``Path``
+# we include "%" to handle the case that the path has already been quoted
+path_safe = compile(r"[a-zA-Z0-9_/%]*$").match
+
+
+def path_converter(value):
+    """convert *value* to a path.
+
+    The convertion is based on ``absolute_url_path``.
+    If *value* lacks this method, it is assumed to be a string.
+    If the string contains ``%``, it is assumed that it is already
+    quoted.
+    """
+    ap = getattr(value, "absolute_url_path", None)
+    if ap is not None:
+        return ap()
+    if path_safe(value):
+        return value
+    if "%" in value:
+        raise ValueError("not path safe but apparently quoted")
+    return quote(value)
+
+
+registerCookieParameter("Path", path_converter)
+
+
+# boolean parameters: ``httpOnly``, ``Secure``
+def bool_converter(value):
+    return bool(value) or None
+
+
+registerCookieParameter("HttpOnly", bool_converter, ("http_only",))
+registerCookieParameter("Secure", bool_converter)
+
+
+# selection paramters
+class SelectionConverter(object):
+    def __init__(self, *valid):
+        self.valid = valid
+        self.check = [v.lower() for v in valid]
+
+    def __call__(self, value):
+        i = self.check.index(value.lower())
+        return self.valid[i]
+
+
+registerCookieParameter("SameSite",
+                        SelectionConverter("None", "Lax", "Strict"),
+                        ("same_site",))
+
+
+# comment -- string converter
+contains_bad_char = compile("[\x00-\x1f;]").search
+
+
+def str_converter(value):
+    """*value* should contain only ASCII characters."""
+    if not isinstance(value, str):
+        if hasattr(value, "encode"):  # Python 2 unicode
+            value = value.encode("iso-8859-1", "replace")
+        else:
+            value = str(value)
+    # RFC 6265 requires ASCII characters excluding controls and ``;``.
+    # We do not enforce ASCII; if `str` contains non iso-8859-1 characters
+    # we will get an exception later on
+    # If necessary, we might use the ``header_encoding_registry``
+    # to remove this restriction.
+    if contains_bad_char(value):
+        raise ValueError(
+            "``;`` and controls are not allowed in cookie parameters")
+    return value
+
+
+# Comment is not defined by RFC 6265; maybe something Zope special
+registerCookieParameter("Comment", str_converter)
+
+
+###########################################################################
+# Auxiliaries
+def to_str(s):
+    """convert bytes to ``str``."""
+    if not isinstance(s, str):
+        s = s.decode("utf-8")
+    return s

--- a/src/ZPublisher/interfaces.py
+++ b/src/ZPublisher/interfaces.py
@@ -98,3 +98,72 @@ class IXmlrpcChecker(Interface):
         which at this time is guaranteed (only) to contain the
         typical CGI information, such as `PATH_INFO` and `QUERY_STRING`.
         """
+
+
+###############################################################################
+# Cookie policies
+
+class ICookieParamPolicy(Interface):
+    """Utility interface to customize cookie parameter handling."""
+
+    def parameters(name, attrs):
+        """generate the parameters for the cookie with *name* and *attrs*.
+
+        Each parameter is described by a pair
+        *normalized_name*, *normalized_value*.
+        ``ZPublisher.cookie.convertCookieParameter`` can be used to achieve
+        the normalization.
+
+        *attrs* is a mapping describing the cookie's value
+        (key ``value``) and its parameters.
+        The  key and value for a parameter are its
+        "normalized name" and "normalized value".
+        The normalized name corresponds to the official
+        parameter name, usually defined by a standard such as RFC 6265.
+        You can use
+        ``ZPublisher.cookie.normalizeCookieParameterName`` to
+        normalize a parameter name.
+        The normalized value is either ``None`` (drop the parameter),
+        ``True`` (drop the parameter's value) or an ASCII string (use
+        as the parameter's value).
+
+        The policy can use ``parameters`` e.g. to add security parameters
+        such as ``HttpOnly``, ``Secure``, ``SameSite``.
+
+        Some security parameters may depend on request
+        details (e.g. whether ``https`` is used).
+        In those cases, you can use e.g. ``zope.globalrequest``
+        to access the request.
+        """
+
+    def check_consistency(name, attrs):
+        """raise ``ValueError`` if the cookie definition is inconsistent.
+
+        E.g. ``SameSite=None`` is allowed only together with ``Secure``.
+        """
+
+
+class ICookieValuePolicy(Interface):
+    """Utility interface to customize cookie value handling.
+
+    Note: cookies are processed very early during request processing.
+    At this time, only the global utility registry is available.
+    For this reason, a utility for this interface is looked up
+    only in the global component registry.
+    Local utility registrations are ignored.
+    """
+    def dump(name, value):
+        """Used to serialize *value* for cookie with name *name*.
+
+        RFC 6265 requires that the cookie value representation
+        in the response consists only of ASCII characters
+        excluding control characters, blank, double quote,
+        comma, semicolon, and backslash.
+        ``dump`` is used to ensure this.
+        """
+
+    def load(name, value):
+        """Used to deserialize *value* for cookie named *name*.
+
+        The inverse of ``dump``.
+        """

--- a/src/ZPublisher/tests/testHTTPResponse.py
+++ b/src/ZPublisher/tests/testHTTPResponse.py
@@ -185,29 +185,26 @@ class HTTPResponseTests(unittest.TestCase):
         response = self._makeOne()
         response.setCookie('foo', 'bar')
         cookie = response.cookies.get('foo', None)
-        self.assertEqual(len(cookie), 2)
+        self.assertEqual(len(cookie), 1)
         self.assertEqual(cookie.get('value'), 'bar')
-        self.assertEqual(cookie.get('quoted'), True)
 
     def test_setCookie_w_existing(self):
         response = self._makeOne()
         response.setCookie('foo', 'bar')
         response.setCookie('foo', 'baz')
         cookie = response.cookies.get('foo', None)
-        self.assertEqual(len(cookie), 2)
+        self.assertEqual(len(cookie), 1)
         self.assertEqual(cookie.get('value'), 'baz')
-        self.assertEqual(cookie.get('quoted'), True)
 
     def test_setCookie_no_attrs(self):
         response = self._makeOne()
         response.setCookie('foo', 'bar')
         cookie = response.cookies.get('foo', None)
-        self.assertEqual(len(cookie), 2)
+        self.assertEqual(len(cookie), 1)
         self.assertEqual(cookie.get('value'), 'bar')
-        self.assertEqual(cookie.get('quoted'), True)
         cookies = response._cookie_list()
         self.assertEqual(len(cookies), 1)
-        self.assertEqual(cookies[0], ('Set-Cookie', 'foo="bar"'))
+        self.assertEqual(cookies[0], ('Set-Cookie', 'foo=bar'))
 
     def test_setCookie_w_expires(self):
         EXPIRES = 'Wed, 31 Dec 1997 23:59:59 GMT'
@@ -216,127 +213,117 @@ class HTTPResponseTests(unittest.TestCase):
         cookie = response.cookies.get('foo', None)
         self.assertTrue(cookie)
         self.assertEqual(cookie.get('value'), 'bar')
-        self.assertEqual(cookie.get('expires'), EXPIRES)
-        self.assertEqual(cookie.get('quoted'), True)
+        self.assertEqual(cookie.get('Expires'), EXPIRES)
 
         cookies = response._cookie_list()
         self.assertEqual(len(cookies), 1)
         self.assertEqual(cookies[0],
-                         ('Set-Cookie', 'foo="bar"; Expires=%s' % EXPIRES))
+                         ('Set-Cookie', 'foo=bar; Expires=%s' % EXPIRES))
 
     def test_setCookie_w_domain(self):
         response = self._makeOne()
         response.setCookie('foo', 'bar', domain='example.com')
         cookie = response.cookies.get('foo', None)
-        self.assertEqual(len(cookie), 3)
+        self.assertEqual(len(cookie), 2)
         self.assertEqual(cookie.get('value'), 'bar')
-        self.assertEqual(cookie.get('domain'), 'example.com')
-        self.assertEqual(cookie.get('quoted'), True)
+        self.assertEqual(cookie.get('Domain'), 'example.com')
 
         cookies = response._cookie_list()
         self.assertEqual(len(cookies), 1)
         self.assertEqual(cookies[0],
-                         ('Set-Cookie', 'foo="bar"; Domain=example.com'))
+                         ('Set-Cookie', 'foo=bar; Domain=example.com'))
 
     def test_setCookie_w_path(self):
         response = self._makeOne()
         response.setCookie('foo', 'bar', path='/')
         cookie = response.cookies.get('foo', None)
-        self.assertEqual(len(cookie), 3)
+        self.assertEqual(len(cookie), 2)
         self.assertEqual(cookie.get('value'), 'bar')
-        self.assertEqual(cookie.get('path'), '/')
-        self.assertEqual(cookie.get('quoted'), True)
+        self.assertEqual(cookie.get('Path'), '/')
 
         cookies = response._cookie_list()
         self.assertEqual(len(cookies), 1)
-        self.assertEqual(cookies[0], ('Set-Cookie', 'foo="bar"; Path=/'))
+        self.assertEqual(cookies[0], ('Set-Cookie', 'foo=bar; Path=/'))
 
     def test_setCookie_w_comment(self):
         response = self._makeOne()
         response.setCookie('foo', 'bar', comment='COMMENT')
         cookie = response.cookies.get('foo', None)
-        self.assertEqual(len(cookie), 3)
+        self.assertEqual(len(cookie), 2)
         self.assertEqual(cookie.get('value'), 'bar')
-        self.assertEqual(cookie.get('comment'), 'COMMENT')
-        self.assertEqual(cookie.get('quoted'), True)
+        self.assertEqual(cookie.get('Comment'), 'COMMENT')
 
         cookies = response._cookie_list()
         self.assertEqual(len(cookies), 1)
         self.assertEqual(cookies[0],
-                         ('Set-Cookie', 'foo="bar"; Comment=COMMENT'))
+                         ('Set-Cookie', 'foo=bar; Comment=COMMENT'))
 
     def test_setCookie_w_secure_true_value(self):
         response = self._makeOne()
         response.setCookie('foo', 'bar', secure='SECURE')
         cookie = response.cookies.get('foo', None)
-        self.assertEqual(len(cookie), 3)
+        self.assertEqual(len(cookie), 2)
         self.assertEqual(cookie.get('value'), 'bar')
-        self.assertEqual(cookie.get('secure'), 'SECURE')
-        self.assertEqual(cookie.get('quoted'), True)
+        self.assertIs(cookie.get('Secure'), True)
 
         cookies = response._cookie_list()
         self.assertEqual(len(cookies), 1)
-        self.assertEqual(cookies[0], ('Set-Cookie', 'foo="bar"; Secure'))
+        self.assertEqual(cookies[0], ('Set-Cookie', 'foo=bar; Secure'))
 
     def test_setCookie_w_secure_false_value(self):
         response = self._makeOne()
         response.setCookie('foo', 'bar', secure='')
         cookie = response.cookies.get('foo', None)
-        self.assertEqual(len(cookie), 3)
+        self.assertEqual(len(cookie), 2)
         self.assertEqual(cookie.get('value'), 'bar')
-        self.assertEqual(cookie.get('secure'), '')
-        self.assertEqual(cookie.get('quoted'), True)
+        self.assertIsNone(cookie.get('Secure'))
 
         cookies = response._cookie_list()
         self.assertEqual(len(cookies), 1)
-        self.assertEqual(cookies[0], ('Set-Cookie', 'foo="bar"'))
+        self.assertEqual(cookies[0], ('Set-Cookie', 'foo=bar'))
 
     def test_setCookie_w_httponly_true_value(self):
         response = self._makeOne()
         response.setCookie('foo', 'bar', http_only=True)
         cookie = response.cookies.get('foo', None)
-        self.assertEqual(len(cookie), 3)
+        self.assertEqual(len(cookie), 2)
         self.assertEqual(cookie.get('value'), 'bar')
-        self.assertEqual(cookie.get('http_only'), True)
-        self.assertEqual(cookie.get('quoted'), True)
+        self.assertEqual(cookie.get('HttpOnly'), True)
 
         cookie_list = response._cookie_list()
         self.assertEqual(len(cookie_list), 1)
-        self.assertEqual(cookie_list[0], ('Set-Cookie', 'foo="bar"; HTTPOnly'))
+        self.assertEqual(cookie_list[0], ('Set-Cookie', 'foo=bar; HttpOnly'))
 
     def test_setCookie_w_httponly_false_value(self):
         response = self._makeOne()
         response.setCookie('foo', 'bar', http_only=False)
         cookie = response.cookies.get('foo', None)
-        self.assertEqual(len(cookie), 3)
+        self.assertEqual(len(cookie), 2)
         self.assertEqual(cookie.get('value'), 'bar')
-        self.assertEqual(cookie.get('http_only'), False)
-        self.assertEqual(cookie.get('quoted'), True)
+        self.assertIsNone(cookie.get('HttpOnly'))
 
         cookie_list = response._cookie_list()
         self.assertEqual(len(cookie_list), 1)
-        self.assertEqual(cookie_list[0], ('Set-Cookie', 'foo="bar"'))
+        self.assertEqual(cookie_list[0], ('Set-Cookie', 'foo=bar'))
 
     def test_setCookie_w_same_site(self):
         response = self._makeOne()
         response.setCookie('foo', 'bar', same_site='Strict')
         cookie = response.cookies.get('foo', None)
-        self.assertEqual(len(cookie), 3)
+        self.assertEqual(len(cookie), 2)
         self.assertEqual(cookie.get('value'), 'bar')
-        self.assertEqual(cookie.get('same_site'), 'Strict')
-        self.assertEqual(cookie.get('quoted'), True)
+        self.assertEqual(cookie.get('SameSite'), 'Strict')
         cookies = response._cookie_list()
         self.assertEqual(len(cookies), 1)
         self.assertEqual(cookies[0],
-                         ('Set-Cookie', 'foo="bar"; SameSite=Strict'))
+                         ('Set-Cookie', 'foo=bar; SameSite=Strict'))
 
     def test_setCookie_unquoted(self):
         response = self._makeOne()
         response.setCookie('foo', 'bar', quoted=False)
         cookie = response.cookies.get('foo', None)
-        self.assertEqual(len(cookie), 2)
+        self.assertEqual(len(cookie), 1)
         self.assertEqual(cookie.get('value'), 'bar')
-        self.assertEqual(cookie.get('quoted'), False)
 
         cookie_list = response._cookie_list()
         self.assertEqual(len(cookie_list), 1)
@@ -346,23 +333,23 @@ class HTTPResponseTests(unittest.TestCase):
         response = self._makeOne()
         response.setCookie('foo', b'bar')
         cookie = response.cookies.get('foo', None)
-        self.assertEqual(len(cookie), 2)
+        self.assertEqual(len(cookie), 1)
         self.assertEqual(cookie.get('value'), b'bar')
 
         cookie_list = response._cookie_list()
         self.assertEqual(len(cookie_list), 1)
-        self.assertEqual(cookie_list[0], ('Set-Cookie', 'foo="bar"'))
+        self.assertEqual(cookie_list[0], ('Set-Cookie', 'foo=bar'))
 
     def test_setCookie_handle_unicode_values(self):
         response = self._makeOne()
         response.setCookie('foo', u'bar')
         cookie = response.cookies.get('foo', None)
-        self.assertEqual(len(cookie), 2)
+        self.assertEqual(len(cookie), 1)
         self.assertEqual(cookie.get('value'), u'bar')
 
         cookie_list = response._cookie_list()
         self.assertEqual(len(cookie_list), 1)
-        self.assertEqual(cookie_list[0], ('Set-Cookie', 'foo="bar"'))
+        self.assertEqual(cookie_list[0], ('Set-Cookie', 'foo=bar'))
 
     def test_appendCookie_w_existing(self):
         response = self._makeOne()
@@ -371,7 +358,7 @@ class HTTPResponseTests(unittest.TestCase):
         cookie = response.cookies.get('foo', None)
         self.assertTrue(cookie)
         self.assertEqual(cookie.get('value'), 'bar:baz')
-        self.assertEqual(cookie.get('path'), '/')
+        self.assertEqual(cookie.get('Path'), '/')
 
     def test_appendCookie_no_existing(self):
         response = self._makeOne()
@@ -385,10 +372,10 @@ class HTTPResponseTests(unittest.TestCase):
         response.expireCookie('foo', path='/')
         cookie = response.cookies.get('foo', None)
         self.assertTrue(cookie)
-        self.assertEqual(cookie.get('expires'),
+        self.assertEqual(cookie.get('Expires'),
                          'Wed, 31 Dec 1997 23:59:59 GMT')
-        self.assertEqual(cookie.get('max_age'), 0)
-        self.assertEqual(cookie.get('path'), '/')
+        self.assertEqual(cookie.get('Max-Age'), '0')
+        self.assertEqual(cookie.get('Path'), '/')
 
     def test_expireCookie1160(self):
         # Verify that the cookie is expired even if an expires kw arg is passed
@@ -397,10 +384,10 @@ class HTTPResponseTests(unittest.TestCase):
                               expires='Mon, 22 Mar 2004 17:59 GMT', max_age=99)
         cookie = response.cookies.get('foo', None)
         self.assertTrue(cookie)
-        self.assertEqual(cookie.get('expires'),
+        self.assertEqual(cookie.get('Expires'),
                          'Wed, 31 Dec 1997 23:59:59 GMT')
-        self.assertEqual(cookie.get('max_age'), 0)
-        self.assertEqual(cookie.get('path'), '/')
+        self.assertEqual(cookie.get('Max-Age'), '0')
+        self.assertEqual(cookie.get('Path'), '/')
 
     def test_getHeader_nonesuch(self):
         response = self._makeOne()
@@ -1115,7 +1102,7 @@ class HTTPResponseTests(unittest.TestCase):
         self.assertEqual(headers,
                          [('X-Powered-By', 'Zope (www.zope.dev), '
                                            'Python (www.python.org)'),
-                          ('Set-Cookie', 'foo="bar%3Abaz"; Path=/'),
+                          ('Set-Cookie', 'foo=bar%3Abaz; Path=/'),
                           ])
 
     def test_listHeaders_after_expireCookie(self):
@@ -1130,7 +1117,7 @@ class HTTPResponseTests(unittest.TestCase):
         self.assertEqual(set(headers), expected)
         self.assertEqual(
             set(cookie_header.split('; ')),
-            set(['qux="deleted"', 'Path=/', 'Max-Age=0',
+            set(['qux=deleted', 'Path=/', 'Max-Age=0',
                  'Expires=Wed, 31 Dec 1997 23:59:59 GMT'])
         )
 
@@ -1262,7 +1249,7 @@ class HTTPResponseTests(unittest.TestCase):
             b'Status: 200 OK',
             b'X-Powered-By: Zope (www.zope.dev), Python (www.python.org)',
             b'Content-Length: 0',
-            b'Set-Cookie: foo="bar%3Abaz"; Path=/',
+            b'Set-Cookie: foo=bar%3Abaz; Path=/',
             b'',
         ])
         self.assertEqual(set(lines), expected)
@@ -1285,7 +1272,7 @@ class HTTPResponseTests(unittest.TestCase):
         cookie_value = cookie_line.split(b': ', 1)[-1]
         self.assertEqual(
             set(cookie_value.split(b'; ')),
-            set([b'qux="deleted"', b'Path=/', b'Max-Age=0',
+            set([b'qux=deleted', b'Path=/', b'Max-Age=0',
                  b'Expires=Wed, 31 Dec 1997 23:59:59 GMT'])
         )
 
@@ -1442,7 +1429,8 @@ class TestHeaderEncodingRegistry(unittest.TestCase):
                          1)
 
     def test_encode_words(self):
-        self.assertEqual(encode_words(u"ä"), "=?utf-8?b?w6Q=?=")
+        self.assertIn(encode_words(u"ä"),
+                      ("=?utf-8?b?w6Q=?=", "=?utf-8?q?=C3=A4?="))
 
     def test_encode_params(self):
         self.assertEqual(encode_params(u'abc; p1=1; p2="2"; p3="€"; p4=€; '

--- a/src/ZPublisher/tests/test_cookie.py
+++ b/src/ZPublisher/tests/test_cookie.py
@@ -1,0 +1,223 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+# Copyright (c) 2022 Zope Foundation and Contributors.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+"""Cookie tests."""
+
+from re import match
+from unittest import TestCase
+
+from six import PY2
+
+from ..cookie import CookieParameterRegistry
+from ..cookie import DefaultCookieParamPolicy
+from ..cookie import DefaultCookieValuePolicy
+from ..cookie import convertCookieParameter
+from ..cookie import defaultCookieParamPolicy
+from ..cookie import defaultCookieValuePolicy
+from ..cookie import getCookieParamPolicy
+from ..cookie import getCookieValuePolicy
+from ..cookie import mmap
+from ..cookie import normalizeCookieParameterName
+from ..cookie import wdmap
+
+
+def assertRfc1123(self, s):
+    """check *s* is an RFC1123 date."""
+    m = match(r"(.{3}), \d{2} (.{3}) \d{4} \d{2}:\d{2}:\d{2} GMT$", s)
+    self.assertIsNotNone(m)
+    self.assertIn(m.group(1), tuple(wdmap.values()))
+    self.assertIn(m.group(2), tuple(mmap.values()))
+
+
+class DefaultPolicyTests(TestCase):
+    def test_parameters(self):
+        parameters = defaultCookieParamPolicy.parameters
+        # normal
+        self.assertEqual(
+            tuple(parameters("n", dict(value="v", param="p"))),
+            (("param", "p"),))
+        # with ``Max-Age=-1`` without ``Expires``
+        np = dict(parameters("n", {"Max-Age": "-1"}))
+        self.assertEqual(np, {"Max-Age": "-1",
+                              "Expires": "Wed, 31 Dec 1997 23:59:59 GMT"})
+        # with ``Max-Age>0``, without ``Expires``
+        np = dict(parameters("n", {"Max-Age": "1"}))
+        assertRfc1123(self, np["Expires"])
+        # with ``Max-Age>0``, with ``Expires``
+        op = {"Max-Age": "1", "Expires": "exp"}
+        self.assertEqual(op, dict(parameters("n", op)))
+
+    def test_check_consistency(self):
+        # it does nothing -- thus, just check the correct signature
+        defaultCookieParamPolicy.check_consistency("n", {})
+
+    def test_dump_load(self):
+        dump = defaultCookieValuePolicy.dump
+        load = defaultCookieValuePolicy.load
+
+        def check(s):
+            ds = dump("name", s)
+            self.assertRegex(ds, r"[a-zA-Z0-9%_/]*$")
+            ls = load("name", ds)
+            self.assertEqual(ls, s)
+
+        check("abc")
+        check("a/b/c")
+        if not PY2:
+            check(u"äöü")
+        check("!\"§$&/()=?´´'#@+*~,;.-_")
+        check(" 	\n")
+
+
+if not hasattr(DefaultPolicyTests, "assertRegex"):  # compatibility
+    DefaultPolicyTests.assertRegex = DefaultPolicyTests.assertRegexpMatches
+
+
+class CookieParameterRegistryTests(TestCase):
+    def test_basics(self):
+        reg = CookieParameterRegistry()
+        register = reg.register
+
+        def converter(value):
+            return "pref" + value
+
+        register("Max-Age", converter)
+        for n in "Max-Age max-age Max_Age max_age".split():
+            self.assertIs(reg._normalize[n], "Max-Age")
+        self.assertIs(reg["Max-Age"], converter)
+        self.assertEqual(reg.convert("max_age", ""), ("Max-Age", "pref"))
+        self.assertEqual(normalizeCookieParameterName("http_only"),
+                         "HttpOnly")
+
+    def test_expires(self):
+        # check int/float
+        n, v = convertCookieParameter("expires", 1643714434)
+        self.assertEqual(n, "Expires")
+        self.assertEqual(v, "Tue, 01 Feb 2022 11:20:34 GMT")
+        _, v = convertCookieParameter("expires", 1643714434.9)
+        self.assertEqual(v, "Tue, 01 Feb 2022 11:20:34 GMT")
+        # check naive datetime
+        from datetime import datetime, timedelta
+        tt = 2022, 2, 1, 11, 20, 34, 1, 32, -1
+        _, v = convertCookieParameter("expires", datetime(*tt[:6]))
+        self.assertEqual(v, "Tue, 01 Feb 2022 11:20:34 GMT")
+        # check tzinfo datetime
+        from ..cookie import UTC
+
+        class CET(UTC):
+            ZERO = timedelta(hours=1)
+
+        cet = CET()
+        tt = 2022, 2, 1, 12, 20, 34, 1, 32, -1
+        _, v = convertCookieParameter("expires", datetime(*tt[:6], tzinfo=cet))
+        self.assertEqual(v, "Tue, 01 Feb 2022 11:20:34 GMT")
+        # check DateTime
+        from DateTime import DateTime
+        _, v = convertCookieParameter("expires", DateTime(1643714434, "CET"))
+        self.assertEqual(v, "Tue, 01 Feb 2022 11:20:34 GMT")
+
+    def test_max_age(self):
+        n, v = convertCookieParameter("max_age", 0)
+        self.assertEqual(n, "Max-Age")
+        self.assertEqual(v, "0")
+        with self.assertRaises(ValueError):
+            convertCookieParameter("max_age", "abc")
+
+    def test_domain(self):
+        # already encoded
+        n, v = convertCookieParameter("domain", "xn--dmin-moa0i.example")
+        self.assertEqual(n, "Domain")
+        self.assertEqual(v, "xn--dmin-moa0i.example")
+        # perform encoding
+        _, v = convertCookieParameter("domain", u"dömäin.example")
+        self.assertEqual(v, "xn--dmin-moa0i.example")
+        # check IDNA2003
+        _, v = convertCookieParameter("domain", u"Fußball.example")
+        self.assertEqual(v, "fussball.example")
+        # check ``bytes`` handling
+        _, v = convertCookieParameter("domain",
+                                      u"Fußball.example".encode("utf-8"))
+        self.assertEqual(v, "fussball.example")
+
+    def test_path(self):
+        # test object
+        class PathAware(object):
+            def absolute_url_path(self):
+                return "aup"
+        obj = PathAware()
+        n, v = convertCookieParameter("path", obj)
+        self.assertEqual(n, "Path")
+        self.assertEqual(v, "aup")
+        # check path safe
+        _, v = convertCookieParameter("path", "/a/b/c")
+        self.assertEqual(v, "/a/b/c")
+        _, v = convertCookieParameter("path", "/a/%20/c")
+        self.assertEqual(v, "/a/%20/c")
+        # check quote
+        _, v = convertCookieParameter("path", "/a/ /c")
+        self.assertEqual(v, "/a/%20/c")
+        # check incomplete quoting
+        with self.assertRaises(ValueError):
+            convertCookieParameter("path", "/a/%20/ ")
+
+    def test_http_only(self):
+        # test true
+        n, v = convertCookieParameter("Http_Only", True)
+        self.assertEqual(n, "HttpOnly")
+        self.assertIs(v, True)
+        # test false
+        _, v = convertCookieParameter("http_only", False)
+        self.assertIsNone(v)
+
+    def test_secure(self):
+        n, v = convertCookieParameter("secure", True)
+        self.assertEqual(n, "Secure")
+        self.assertIs(v, True)
+
+    def test_samesite(self):
+        for t in "None Lax Strict".split():
+            n, v = convertCookieParameter("samesite", t.lower())
+            self.assertEqual(n, "SameSite")
+            self.assertEqual(v, t)
+        # bad value
+        with self.assertRaises(ValueError):
+            convertCookieParameter("samesite", "abc")
+
+    def test_comment(self):
+        n, v = convertCookieParameter("comment", u"comment")
+        self.assertEqual(n, "Comment")
+        self.assertEqual(v, "comment")
+
+    def test_unknown_parameter(self):
+        with self.assertRaises(KeyError):
+            convertCookieParameter("xyz", "abc")
+
+
+class GetCookiePolicyTests(TestCase):
+    def tearDown(self):
+        from zope.testing.cleanup import cleanUp
+        # clear the component registry
+        cleanUp()
+
+    def test_defaults(self):
+        self.assertIs(getCookieParamPolicy(), defaultCookieParamPolicy)
+        self.assertIs(getCookieValuePolicy(), defaultCookieValuePolicy)
+
+    def test_customization(self):
+        from zope.component import provideUtility
+        pp = DefaultCookieParamPolicy()
+        provideUtility(pp)
+        vp = DefaultCookieValuePolicy()
+        provideUtility(vp)
+        self.assertIs(getCookieParamPolicy(), pp)
+        self.assertIs(getCookieValuePolicy(), vp)


### PR DESCRIPTION
fixes #600 and #1008.

This PR introduces two cookie related policies, `ICookieParamPolicy` and `ICookieValuePolicy`, and a cookie parameter registry.

The cookie policies allow customization of cookie handling. Details can be found in `ZPublisher.interfaces`.

Cookie parameter customization may be helpful  for some applications  wanting to support embedding in foreign sites because recent browser versions use `Lax` as default for the `SameSite` cookie parameter. As a consequence cookies are no longer delivered to applications embedded in a foreign site unless their definition carries the parameters `SameSite=None; Secure`.
The default cookie parameter policy automatically adds a missing `Expires` if the `Max-Age` parameter is present (to support HTTP/1.0).

The current cookie standard (i.e. RFC 6265) points out that cookies are quite easily tampered with even when transmitted over HTTPS. If an attacker gets access to the browser's host, they can typically also be analyzed. Therefore, RFC 6265 recommends to sign or even encrypt sensitive cookie values.  The cookie value policy allows applications to implement this recommendation. The default cookie value policy does not sign/encrypt because Zope lacks the respective infrastructure.

The cookie policies are looked up as utilities. However, cookie parsing happens very early during request processing, at a time when only the global component registry is available. Therefore, the `ICookieValuePolicy` utility is looked up only in this registry. To remove this restriction, cookie parsing would need to be delayed until the cookie is accessed.

The cookie parameter registry makes cookie parameter handling more flexible and extensible:
 * `ZPublisher.HTTPResponse.HTTPResponse.setCookie` can refer to a parameter either with its official name (defined by the standard) or its Zope name; case is not significant and `-` can be replaced by `_`. For example, the parameter `Max-Age` can  also be referred to by `max_age`; `HttpOnly` also by `http_only`. Internally, the official names are used.
 * parameter values used in `setCookie` need not always be ASCII strings. The value for `Expires`  can be int/float (interpreted as timestamp related to `time.time`), naive or time zone aware `datetime` (if naive, it is assumed to be an UTC `datetime`), a (Zope) `DateTime` or a string (representing an RFC 1123 date). The value for `Path` can be an object with `absolute_url_path` method or a string. The value for `Domain` is automatically IDNA2003 encoded, if necessary. Internally parameter values are represented as `None` (drop the parameter), `True` (drop the parameter value, i.e. render as boolean true parameter) or an ASCII string (as used "on the wire").
 * `registerCookieParameter` can be used to register new parameters and/or override existing ones.