### PR TITLE
fix `OFS.Image.File.PUT` -- Issue 1015

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,11 @@ https://zope.readthedocs.io/en/2.13/CHANGES.html
 4.8 (unreleased)
 ----------------
 
+- Improve source documentation for methods ``_read_data`` and
+  ``get_content_type`` of ``OFS.Image.File`` and
+  fix its ``PUT``
+  (`#1015 <https://github.com/zopefoundation/Zope/issues/1015>`_).
+
 - Enhance cookie support. For details, see
   `#1010 <https://github.com/zopefoundation/Zope/issues/1010>`_
 

--- a/src/OFS/Image.py
+++ b/src/OFS/Image.py
@@ -568,6 +568,16 @@ class File(
                 self, REQUEST, manage_tabs_message=msg)
 
     def _get_content_type(self, file, body, id, content_type=None):
+        """return content type or ``None``.
+
+        *file* usually is a ``FileUpload`` (like) instance; if this
+        specifies a content type, it is used. If *file*
+        is not ``FileUpload`` like, it is ignored and the
+        content type is guessed from the other parameters.
+
+        *body* is either a ``bytes`` or a ``Pdata`` instance
+        and assumed to be the *file* data.
+        """
         headers = getattr(file, 'headers', None)
         if headers and 'content-type' in headers:
             content_type = headers['content-type']
@@ -579,6 +589,13 @@ class File(
         return content_type
 
     def _read_data(self, file):
+        """return the data and size of *file* as tuple *data*, *size*.
+
+        *file* can be a ``bytes``, ``Pdata``, ``FileUpload`` or
+        (binary) file like instance.
+
+        For large files, *data* is a ``Pdata``, otherwise a ``bytes`` instance.
+        """
         import transaction
 
         n = 1 << 16
@@ -656,13 +673,11 @@ class File(
         """Handle HTTP PUT requests"""
         self.dav__init(REQUEST, RESPONSE)
         self.dav__simpleifhandler(REQUEST, RESPONSE, refresh=1)
-        type = REQUEST.get_header('content-type', None)
 
+        type = REQUEST.get_header('content-type', None)
         file = REQUEST['BODYFILE']
 
         data, size = self._read_data(file)
-        if isinstance(data, str):
-            data = data.encode('UTF-8')
         content_type = self._get_content_type(file, data, self.__name__,
                                               type or self.content_type)
         self.update_data(data, content_type, size)

--- a/src/OFS/Image.py
+++ b/src/OFS/Image.py
@@ -694,7 +694,8 @@ class File(
                 bufsize = 1 << 16
                 while True:
                     data = file.read(bufsize)
-                    if not data: break
+                    if not data:
+                        break
                     tfile.write(data.encode(default_encoding))
                 file.seek(0, 0)
                 tfile.seek(0, 0)

--- a/versions.cfg
+++ b/versions.cfg
@@ -26,7 +26,8 @@ bleach = 3.3.1
 buildout.wheel = 0.2.0
 # Version 2020.4.5.2 and up claim no Python 2 support
 certifi = 2020.4.5.1
-cffi = 1.15.0
+# cffi 1.15 dropped support for Python 3.5
+cffi = 1.14.6
 charset-normalizer = 2.0.4
 chardet = 4.0.0
 # cmarkgfm 0.7 and up require Python 3


### PR DESCRIPTION
Fixes #1015.

This PR essentially documents that `OFS.Image.File._read_data` returns a tuple *data*, *size* with *data* either a `bytes` or `Pdata` instance. Based on this assertion, it can simply drop the buggy code in the `PUT` method referred to in #1015.

@arnaud-fontaine could you please verify if this PR resolves your issue.