### PR TITLE
Add pin for last version of importlib-resources that works on Python 2.

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -52,6 +52,8 @@ idna = 2.10
 imagesize = 1.3.0
 # tox and pluggy require importlib-metadata <1
 importlib-metadata = 0.23
+# tqdm 4.63+ requires importlib-resources, and 3.3.1 is the last that works on Python 2.
+importlib-resources = 3.3.1
 lxml = 4.8.0
 manuel = 1.10.1
 # Version 6+ needs Python 3.x
@@ -79,6 +81,7 @@ readme-renderer = 28.0
 requests = 2.27.1
 requests-toolbelt = 0.9.1
 scandir = 1.10.0
+singledispatch = 3.7.0
 snowballstemmer = 2.2.0
 # soupsieve 2 needs Python 3
 soupsieve = 1.9.6


### PR DESCRIPTION
The previous commit updated `tqdm` (some command line progress bar thingie) to 4.63.0, which has `importlib-resources` as new requirement. This was not pinned yet. So Plone coredev 5.2 locally failed on Python 2.7 with the latest Zope 4.x dev versions.

Also added pin for `singledispatch`, which is required by `importlib-resources`. Latest version seems fine.

Note: I am also fixing this temporarily in Plone coredev. But since these packages are pulled in by `tqdm` which is already pinned in Zope, it makes sense to add the pins here.