### PR TITLE
Updated sources.remotes.github from git protocol to https. [master]

### DIFF
--- a/sources.cfg
+++ b/sources.cfg
@@ -1,5 +1,5 @@
 [remotes]
-github = git://github.com/zopefoundation
+github = https://github.com/zopefoundation
 github_push = git@github.com:zopefoundation
 
 [sources]


### PR DESCRIPTION
The git protocol was disabled a few weeks ago.