### PR TITLE
backport waitress version pins to Zope 4

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,14 @@ https://zope.readthedocs.io/en/2.13/CHANGES.html
 
 - Update dependencies to the latest releases that still support Python 2.
 
+- Update ``waitress`` to version 2.1.1 to mitigate a vulnerability in that
+  package. As ``waitress`` no longer supports Python versions less than
+  3.7 it is not advised to run Zope 4 on Python 2.7, 3.5 or 3.6 any longer,
+  even though they are still supported by Zope 4 itself.
+
+- To run ``bin/buildout`` inside the Zope project now ``zc.buildout >= 2.13.7``
+  or ``zc.buildout >= 3.0.0b1`` is required.
+
 
 4.8 (2022-03-10)
 ----------------

--- a/README.rst
+++ b/README.rst
@@ -48,6 +48,15 @@ Please visit the installation documentation at
 https://zope.readthedocs.io/en/4.x/INSTALL.html for detailed installation
 guidance.
 
+**Security warning:** The WSGI server Zope uses by default, waitress, was
+affected by `an important security issue
+<https://github.com/Pylons/waitress/security/advisories/GHSA-4f7p-27jc-3c36>`_.
+The fixed version 2.1.1 is not compatible with Python versions less than 3.7.
+We strongly advise you to either upgrade your Zope 4 installation to Python
+3.7 or 3.8, move to Zope 5 on Python 3.7 or higher, or `switch to a different
+WSGI server
+<https://zope.readthedocs.io/en/latest/operation.html#recommended-wsgi-servers>`_.
+
 
 License
 =======

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -17,7 +17,6 @@ parts =
     allpy
     sphinx
     checkversions
-    requirements
 sources-dir = develop
 auto-checkout =
 

--- a/constraints.txt
+++ b/constraints.txt
@@ -37,7 +37,10 @@ roman==3.3
 shutilwhich==1.1.0
 six==1.16.0
 transaction==3.0.1
-waitress==1.4.4
+waitress==2.1.1
+waitress==1.4.4; python_version == '2.7'
+waitress==1.4.4; python_version == '3.5'
+waitress==2.0.0; python_version == '3.6'
 z3c.pt==3.3.1
 zExceptions==4.2
 zc.lockfile==2.0

--- a/docs/INSTALL.rst
+++ b/docs/INSTALL.rst
@@ -19,6 +19,17 @@ available:
   * 2.7
   * 3.5 - 3.8
 
+  .. warning::
+
+     The WSGI server Zope uses by default, waitress, was
+     affected by `an important security issue
+     <https://github.com/Pylons/waitress/security/advisories/GHSA-4f7p-27jc-3c36>`_.
+     The fixed version 2.1.1 is only compatible with Python 3.7 and higher. We
+     strongly advise you to either upgrade your Zope 4 installation to at least
+     Python 3.7, move to Zope 5 on Python 3.7 or higher, or `switch to a
+     different WSGI server
+     <https://zope.readthedocs.io/en/latest/operation.html#recommended-wsgi-servers>`_.
+
 - Zope needs the Python ``zlib`` module to be importable.  If you are
   building your own Python from source, please be sure that you have the
   headers installed which correspond to your system's ``zlib``.

--- a/docs/wsgi.rst
+++ b/docs/wsgi.rst
@@ -153,6 +153,17 @@ up for you will be sufficient for most applications. See the `waitress
 documentation <https://docs.pylonsproject.org/projects/waitress/>`_ for
 additional information.
 
+.. warning::
+
+   The WSGI server Zope uses by default, waitress, was
+   affected by `an important security issue
+   <https://github.com/Pylons/waitress/security/advisories/GHSA-4f7p-27jc-3c36>`_.
+   The fixed version 2.1.1 is only compatible with Python 3.7 and higher. We
+   strongly advise you to either upgrade your Zope 4 installation to at least
+   Python 3.7, move to Zope 5 on Python 3.7 or higher, or `switch to a
+   different WSGI server
+   <https://zope.readthedocs.io/en/latest/operation.html#recommended-wsgi-servers>`_.
+
 Here's a very simple configuration using ``plone.recipe.zope2instance``:
 
 .. code-block:: ini

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -37,7 +37,10 @@ roman==3.3
 shutilwhich==1.1.0
 six==1.16.0
 transaction==3.0.1
-waitress==1.4.4
+waitress==2.1.1
+waitress==1.4.4; python_version == '2.7'
+waitress==1.4.4; python_version == '3.5'
+waitress==2.0.0; python_version == '3.6'
 z3c.pt==3.3.1
 zExceptions==4.2
 zc.lockfile==2.0

--- a/versions-prod.cfg
+++ b/versions-prod.cfg
@@ -49,8 +49,7 @@ roman = 3.3
 shutilwhich = 1.1.0
 six = 1.16.0
 transaction = 3.0.1
-# waitress 2 requires Python 3.6 or higher
-waitress = 1.4.4
+waitress = 2.1.1
 z3c.pt = 3.3.1
 zExceptions = 4.2
 zc.lockfile = 2.0
@@ -104,3 +103,15 @@ zope.testing = 4.7
 zope.testrunner = 5.4.0
 zope.traversing = 4.4.1
 zope.viewlet = 4.2.1
+
+[versions:python27]
+# waitress 2 requires Python 3.6 or higher
+waitress = 1.4.4
+
+[versions:python35]
+# waitress 2 requires Python 3.6 or higher
+waitress = 1.4.4
+
+[versions:python36]
+# waitress 2.1 requires Python 3.7 or higher
+waitress = 2.0.0


### PR DESCRIPTION
This PR backports new Python version-dependent waitress version pins to the 4.x branch.

I have not ported the requirements file generator script as that's completely incompatible with Python 2 now and I have removed its invocation in `buildout.cfg`. I am inclined to remove that script on this branch and manually maintain the requirements files instead, that seems less work than porting the convenience script.