### PR TITLE
quote all components of redirect URL (not only path)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,9 @@ https://zope.readthedocs.io/en/2.13/CHANGES.html
 4.8.2 (unreleased)
 ------------------
 
+- Quote all components of a redirect URL (not only the path component)
+  (`#1027 <https://github.com/zopefoundation/Zope/issues/1027>`_)
+  
 - Drop the convenience script generation from the buildout configuration
   in order to get rid of a lot of dependency version pins.
   These were only needed for maintainers who can install them manually.

--- a/src/ZPublisher/tests/testHTTPResponse.py
+++ b/src/ZPublisher/tests/testHTTPResponse.py
@@ -765,6 +765,11 @@ class HTTPResponseTests(unittest.TestCase):
         exc = HTTPMovedPermanently(BYTES_URL)
         self._redirectURLCheck(exc, expected=ENC_URL)
 
+    def test_redirect_nonascii_everywhere(self):
+        URL = u"http://uä:pä@sä:80/pä?qä#fä"
+        ENC_URL = "http://u%C3%A4:p%C3%A4@s%C3%A4:80/p%C3%A4?q%C3%A4#f%C3%A4"
+        self._redirectURLCheck(URL, ENC_URL)
+
     def test_redirect_alreadyquoted(self):
         # If a URL is already quoted, don't double up on the quoting
         ENC_URL = 'http://example.com/M%C3%A4H'


### PR DESCRIPTION
Fixes #1027.

All components of a redirect URL are properly quoted (not just the path component).