### PR TITLE
Fix version pin specifications for Python 3.6 compatibility

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 5.5.2 (unreleased)
 ------------------
 
+- Fix version pin specifications for Python 3.6 compatibility.
+  (`#1036 <https://github.com/zopefoundation/Zope/issues/1036>`_)
+
 - Quote all components of a redirect URL (not only the path component)
   (`#1027 <https://github.com/zopefoundation/Zope/issues/1027>`_)
   

--- a/constraints.txt
+++ b/constraints.txt
@@ -29,7 +29,7 @@ funcsigs==1.0.2
 future==0.18.2
 ipaddress==1.0.23
 jeepney==0.7.1; python_version == '3.6'
-jeepney==0.8.0
+jeepney==0.8.0; python_version > '3.6'
 mock==4.0.3
 multipart==0.2.4
 pbr==5.8.1
@@ -40,7 +40,7 @@ shutilwhich==1.1.0
 six==1.16.0
 transaction==3.0.1
 waitress==2.0.0; python_version == '3.6'
-waitress==2.1.1
+waitress==2.1.1; python_version > '3.6'
 z3c.pt==3.3.1
 zExceptions==4.2
 zc.lockfile==2.0

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -30,7 +30,7 @@ funcsigs==1.0.2
 future==0.18.2
 ipaddress==1.0.23
 jeepney==0.7.1; python_version == '3.6'
-jeepney==0.8.0
+jeepney==0.8.0; python_version > '3.6'
 mock==4.0.3
 multipart==0.2.4
 pbr==5.8.1
@@ -41,7 +41,7 @@ shutilwhich==1.1.0
 six==1.16.0
 transaction==3.0.1
 waitress==2.0.0; python_version == '3.6'
-waitress==2.1.1
+waitress==2.1.1; python_version > '3.6'
 z3c.pt==3.3.1
 zExceptions==4.2
 zc.lockfile==2.0


### PR DESCRIPTION
Fixes #1036 

I have changed the `util.py` script so it will always emit a `python_version` specifier for all dependencies that depend on specific Python versions. The "default", meaning the version pin for "all unspecified Python versions" will now show "larger than the highest `python_version` specifier seen before".

The outcome is illustrated by the fixed requirements and constraints files that are part of this PR.