### PR TITLE
4.x: Fix version pin specifications for Python 3.5 compatibility.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ https://zope.readthedocs.io/en/2.13/CHANGES.html
 - Fix version pin specifications for Python 3.6 compatibility.
   (`#1036 <https://github.com/zopefoundation/Zope/issues/1036>`_)
 
+- Fix version pin specifications for Python 3.5 compatibility.
+
 - Add more notices to the documentation urging users to migrate to Zope 5.
 
 - Quote all components of a redirect URL (not only the path component)

--- a/constraints.txt
+++ b/constraints.txt
@@ -5,7 +5,8 @@ BTrees==4.10.0
 Chameleon==3.9.1
 DateTime==4.4
 DocumentTemplate==3.4; python_version == '2.7'
-DocumentTemplate==4; python_version > '2.7'
+DocumentTemplate==3.4; python_version == '3.5'
+DocumentTemplate==4; python_version > '3.5'
 ExtensionClass==4.6
 Missing==4.1
 MultiMapping==4.1

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -6,7 +6,8 @@ BTrees==4.10.0
 Chameleon==3.9.1
 DateTime==4.4
 DocumentTemplate==3.4; python_version == '2.7'
-DocumentTemplate==4; python_version > '2.7'
+DocumentTemplate==3.4; python_version == '3.5'
+DocumentTemplate==4; python_version > '3.5'
 ExtensionClass==4.6
 Missing==4.1
 MultiMapping==4.1

--- a/versions-prod.cfg
+++ b/versions-prod.cfg
@@ -114,6 +114,8 @@ multipart = 0.1.1
 waitress = 1.4.4
 
 [versions:python35]
+# DocumentTemplate 4+ cannot be installed on Zope 4 for Python 3.5
+DocumentTemplate = 3.4
 # WSGIProxy 0.5 and up requires Python 3.7 and up
 WSGIProxy2 = 0.4.6
 # WebTest 3.0 and up requires Python 3.6 and up


### PR DESCRIPTION
Testing Zope products on Python 3.5 breaks because DocumentTemlate 4 cannot be installed because of version constraints.

In https://github.com/zopefoundation/Products.PluggableAuthService/runs/6146524828?check_suite_focus=true we get:

```
Version and requirements information containing documenttemplate:
  [versions] constraint on documenttemplate: 4
  Requirement of Zope>=4.2.1: DocumentTemplate<4.0,>=3.0
  Requirement of Zope>=4.0b5: DocumentTemplate<4.0,>=3.0
  Requirement of Zope>=4.0b4: DocumentTemplate<4.0,>=3.0
  Requirement of Products.ZCatalog: DocumentTemplate
  Requirement of Products.PythonScripts: DocumentTemplate
While:
  Installing test.
Error: The requirement ('DocumentTemplate<4.0,>=3.0') is not allowed by your [versions] constraint (4)
```

This also happens locally.
I do not fully understand why this happens. The requirement `DocumentTemplate<4.0,>=3.0` in Zope 4's `setup.py` does not seem to be released, yet.

This PR hopefully will fix this after `gh_pages` is updated.

Locally it fixes the Python 3.5 tests of `Products.PluggableAuthService` when I pin `DocumentTemplate = 3.4` in `buildout4.cfg`.