### PR TITLE
Strip leading `.` from cookie domain names.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,7 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 
 - Quote all components of a redirect URL (not only the path component)
   (`#1027 <https://github.com/zopefoundation/Zope/issues/1027>`_)
-  
+
 - Drop the convenience script generation from the buildout configuration
   in order to get rid of a lot of dependency version pins.
   These were only needed for maintainers who can install them manually.
@@ -27,6 +27,8 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 - Modify "manage_access" to allow users to switch from the compact view
   to the complete matrix view when more than 30 roles are defined.
   (`#1039 <https://github.com/zopefoundation/Zope/pull/1039>`_)
+
+- Allow leading ``.`` in cookie domain names.
 
 
 5.5.1 (2022-04-05)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,7 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
   (`#1039 <https://github.com/zopefoundation/Zope/pull/1039>`_)
 
 - Allow leading ``.`` in cookie domain names.
+  (`#1041 <https://github.com/zopefoundation/Zope/pull/1041>`_)
 
 
 5.5.1 (2022-04-05)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,7 +28,7 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
   to the complete matrix view when more than 30 roles are defined.
   (`#1039 <https://github.com/zopefoundation/Zope/pull/1039>`_)
 
-- Allow leading ``.`` in cookie domain names.
+- Strip leading ``.`` in cookie domain names.
   (`#1041 <https://github.com/zopefoundation/Zope/pull/1041>`_)
 
 

--- a/src/ZPublisher/cookie.py
+++ b/src/ZPublisher/cookie.py
@@ -242,7 +242,14 @@ def domain_converter(value):
         return value
     from encodings.idna import ToASCII
     from encodings.idna import nameprep
-    return ".".join(to_str(ToASCII(nameprep(c))) for c in u_value.split("."))
+    add_leading_dot = False
+    if u_value.startswith("."):
+        u_value = u_value[1:]
+        add_leading_dot = True
+    value = ".".join(to_str(ToASCII(nameprep(c))) for c in u_value.split("."))
+    if add_leading_dot:
+        value = f".{value}"
+    return value
 
 
 registerCookieParameter("Domain", domain_converter)

--- a/src/ZPublisher/cookie.py
+++ b/src/ZPublisher/cookie.py
@@ -242,8 +242,9 @@ def domain_converter(value):
         return value
     from encodings.idna import ToASCII
     from encodings.idna import nameprep
+
     # According to https://www.rfc-editor.org/rfc/rfc6265#section-4.1.2.3 a
-    # leading dot is ignored. If it is there `ToASCII` breaks on the empty
+    # leading dot is ignored. If it is there `ToASCII`, breaks on the empty
     # string:
     u_value = u_value.lstrip('.')
     return ".".join(to_str(ToASCII(nameprep(c))) for c in u_value.split("."))

--- a/src/ZPublisher/cookie.py
+++ b/src/ZPublisher/cookie.py
@@ -25,6 +25,8 @@ and exports the functions ``getCookieParamPolicy``, ``getCookieValuePolicy``
 ``normalizeCookieParameterName`` and ``convertCookieParameter``.
 """
 import datetime
+from encodings.idna import ToASCII
+from encodings.idna import nameprep
 from itertools import chain
 from re import compile
 from time import time
@@ -240,8 +242,6 @@ def domain_converter(value):
     u_value = value.decode("utf-8") if isinstance(value, bytes) else value
     if "xn--" in u_value:  # already encoded
         return value
-    from encodings.idna import ToASCII
-    from encodings.idna import nameprep
 
     # According to https://www.rfc-editor.org/rfc/rfc6265#section-4.1.2.3 a
     # leading dot is ignored. If it is there `ToASCII`, breaks on the empty

--- a/src/ZPublisher/cookie.py
+++ b/src/ZPublisher/cookie.py
@@ -242,14 +242,11 @@ def domain_converter(value):
         return value
     from encodings.idna import ToASCII
     from encodings.idna import nameprep
-    add_leading_dot = False
-    if u_value.startswith("."):
-        u_value = u_value[1:]
-        add_leading_dot = True
-    value = ".".join(to_str(ToASCII(nameprep(c))) for c in u_value.split("."))
-    if add_leading_dot:
-        value = f".{value}"
-    return value
+    # According to https://www.rfc-editor.org/rfc/rfc6265#section-4.1.2.3 a
+    # leading dot is ignored. If it is there `ToASCII` breaks on the empty
+    # string:
+    u_value = u_value.lstrip('.')
+    return ".".join(to_str(ToASCII(nameprep(c))) for c in u_value.split("."))
 
 
 registerCookieParameter("Domain", domain_converter)

--- a/src/ZPublisher/tests/testHTTPResponse.py
+++ b/src/ZPublisher/tests/testHTTPResponse.py
@@ -801,7 +801,7 @@ class HTTPResponseTests(unittest.TestCase):
         self._redirectURLCheck(exc, expected=ENC_URL)
 
     def test_redirect_nonascii_everywhere(self):
-        URL = u"http://uä:pä@sä:80/pä?qä#fä"
+        URL = "http://uä:pä@sä:80/pä?qä#fä"
         ENC_URL = "http://u%C3%A4:p%C3%A4@s%C3%A4:80/p%C3%A4?q%C3%A4#f%C3%A4"
         self._redirectURLCheck(URL, ENC_URL)
 

--- a/src/ZPublisher/tests/test_cookie.py
+++ b/src/ZPublisher/tests/test_cookie.py
@@ -145,6 +145,10 @@ class CookieParameterRegistryTests(TestCase):
         _, v = convertCookieParameter("domain",
                                       "Fußball.example".encode())
         self.assertEqual(v, "fussball.example")
+        # allow leading dot according to
+        # https://www.rfc-editor.org/rfc/rfc6265#section-4.1.2.3
+        _, v = convertCookieParameter("domain", ".zope.dev")
+        self.assertEqual(v, ".zope.dev")
 
     def test_path(self):
         # test object

--- a/src/ZPublisher/tests/test_cookie.py
+++ b/src/ZPublisher/tests/test_cookie.py
@@ -145,10 +145,10 @@ class CookieParameterRegistryTests(TestCase):
         _, v = convertCookieParameter("domain",
                                       "Fußball.example".encode())
         self.assertEqual(v, "fussball.example")
-        # allow leading dot according to
+        # a leading dot is stripped as it is ignored according to
         # https://www.rfc-editor.org/rfc/rfc6265#section-4.1.2.3
         _, v = convertCookieParameter("domain", ".zope.dev")
-        self.assertEqual(v, ".zope.dev")
+        self.assertEqual(v, "zope.dev")
 
     def test_path(self):
         # test object


### PR DESCRIPTION
If the value of the `domain` attribute in the cookie starts with `.` Zope currently breaks.
But according to https://www.rfc-editor.org/rfc/rfc6265#section-4.1.2.3 it should be allowed.

I added a test and a fix, without the fix the new test breaks with:

```
Error in test test_domain (ZPublisher.tests.test_cookie.CookieParameterRegistryTests)
Traceback (most recent call last):
  File "/.../lib/python3.7/unittest/case.py", line 59, in testPartExecutor
    yield
  File "/.../lib/python3.7/unittest/case.py", line 628, in run
    testMethod()
  File "/.../Zope/src/ZPublisher/tests/test_cookie.py", line 150, in test_domain
    _, v = convertCookieParameter("domain", ".zope.dev")
  File "/.../Zope/src/ZPublisher/cookie.py", line 152, in convert
    return nn, (value if value is None else self[nn](value))
  File "/.../Zope/src/ZPublisher/cookie.py", line 249, in domain_converter
    value = ".".join(to_str(ToASCII(nameprep(c))) for c in u_value.split("."))
  File "/.../Zope/src/ZPublisher/cookie.py", line 249, in <genexpr>
    value = ".".join(to_str(ToASCII(nameprep(c))) for c in u_value.split("."))
  File "/.../lib/python3.7/encodings/idna.py", line 73, in ToASCII
    raise UnicodeError("label empty or too long")
UnicodeError: label empty or too long
```