### PR TITLE
Scripts/Signature: keep setting func_code and func_defaults

### DIFF
--- a/src/Shared/DC/Scripts/Signature.py
+++ b/src/Shared/DC/Scripts/Signature.py
@@ -49,7 +49,7 @@ def _setFuncSignature(self, defaults=None, varnames=(), argcount=-1):
         argcount = len(varnames)
     # Generate a change only if we have to.
     if self.__defaults__ != defaults:
-        self.__defaults__ = self.__defaults__ = defaults
+        self.__defaults__ = self.func_defaults = defaults
     code = FuncCode(varnames, argcount)
     if self.__code__ != code:
-        self.__code__ = self.__code__ = code
+        self.__code__ = self.func_code = code


### PR DESCRIPTION
`_setFuncSignature` was accidentally setting `__code__` and
`__defaults__` twice.

On Zope 4 it should also support the old python 2 names `func_code`
and `func_defaults`, because Zope 4 supports python 2

Fixes https://github.com/zopefoundation/Products.PythonScripts/issues/55