### PR TITLE
fix cookie path parameter handling --> #1052

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,13 @@ https://zope.readthedocs.io/en/2.13/CHANGES.html
 
 - Update dependencies to the latest releases for each supported Python version.
 
+- Fix cookie path parameter handling:
+  If the cookie path value contains only characters allowed
+  in URL path components (with the exception of ``;``) including ``%``,
+  it is used as is; otherwise, it is quoted using Python's
+  ``urllib.parse.quote``
+  (`#1052 <https://github.com/zopefoundation/Zope/issues/1052>`_).
+
 
 4.8.2 (2022-06-01)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,8 +12,10 @@ https://zope.readthedocs.io/en/2.13/CHANGES.html
 - Update dependencies to the latest releases for each supported Python version.
 
 - Fix cookie path parameter handling:
-  If the cookie path value contains only characters allowed
-  in URL path components (with the exception of ``;``) including ``%``,
+  If the cookie path value contains ``%`` it is assumed to be
+  fully quoted and used as is;
+  if it contains only characters allowed (unquoted)
+  in an URL path (with the exception of ``;``),
   it is used as is; otherwise, it is quoted using Python's
   ``urllib.parse.quote``
   (`#1052 <https://github.com/zopefoundation/Zope/issues/1052>`_).

--- a/src/ZPublisher/HTTPResponse.py
+++ b/src/ZPublisher/HTTPResponse.py
@@ -317,11 +317,7 @@ class HTTPBaseResponse(BaseResponse):
             name = str(name)
             value = str(value)
 
-        cookies = self.cookies
-        if name in cookies:
-            cookie = cookies[name]
-        else:
-            cookie = cookies[name] = {}
+        cookie = {}
         for k, v in kw.items():
             k, v = convertCookieParameter(k, v)
             cookie[k] = v
@@ -329,6 +325,13 @@ class HTTPBaseResponse(BaseResponse):
         # RFC6265 makes quoting obsolete
         # cookie['quoted'] = quoted
         getCookieParamPolicy().check_consistency(name, cookie)
+
+        # update ``self.cookies`` only if there have been no exceptions
+        cookies = self.cookies
+        if name in cookies:
+            cookies[name].update(cookie)
+        else:
+            cookies[name] = cookie
 
     def appendCookie(self, name, value):
         """ Set an HTTP cookie.

--- a/src/ZPublisher/cookie.py
+++ b/src/ZPublisher/cookie.py
@@ -255,17 +255,35 @@ registerCookieParameter("Domain", domain_converter)
 
 
 # ``Path``
-# we include "%" to handle the case that the path has already been quoted
-path_safe = compile(r"[a-zA-Z0-9_/%]*$").match
+path_safe = compile("["
+                    "-_.!~*'()"  # RFC 2396 section 2.3 (unreserved)
+                    "a-zA-Z0-9"  # letters and digits
+                    "/:@&=+$,"   # RFC 2396 section 3.3 (path reserved)
+                                 # excluding ``;``
+                    "%"          # assume already quoted
+                    "]*$").match
 
 
 def path_converter(value):
-    """convert *value* to a path.
+    """convert *value* to a cookie path.
 
     The convertion is based on ``absolute_url_path``.
     If *value* lacks this method, it is assumed to be a string.
     If the string contains ``%``, it is assumed that it is already
     quoted.
+
+    **Note**:
+    According to RFC 6265 section 5.1.4 a cookie path match **does not**
+    unquote its arguments. It is therefore important to use
+    the same quoting algorithm for the URL and the cookie path.
+    If the cookie path contains only allowed characters
+    (RFC 2396 unreserved (section 2.3),
+    RFC 2396 path special (section 3.3) excluding ``:``
+    or `%`), the value is taken verbatim; otherwise it is quoted
+    by Python's `urllib.parse.quote` (which
+    is used by `OFS.Traversable` as its ULR quoting). It quotes
+    all special characters apart from ``-_./``.
+    Quote yourself if this does not match your URL quoting.
     """
     ap = getattr(aq_base(value), "absolute_url_path", None)
     if ap is not None:

--- a/src/ZPublisher/tests/test_cookie.py
+++ b/src/ZPublisher/tests/test_cookie.py
@@ -170,9 +170,9 @@ class CookieParameterRegistryTests(TestCase):
         # check quote
         _, v = convertCookieParameter("path", "/a/ /c")
         self.assertEqual(v, "/a/%20/c")
-        # check incomplete quoting
-        with self.assertRaises(ValueError):
-            convertCookieParameter("path", "/a/%20/ ")
+        # check ``%`` dominates
+        _,v = convertCookieParameter("path", "/a/%20/ ")
+        self.assertEqual(v, "/a/%20/ ")
 
     def test_http_only(self):
         # test true

--- a/src/ZPublisher/tests/test_cookie.py
+++ b/src/ZPublisher/tests/test_cookie.py
@@ -171,7 +171,7 @@ class CookieParameterRegistryTests(TestCase):
         _, v = convertCookieParameter("path", "/a/ /c")
         self.assertEqual(v, "/a/%20/c")
         # check ``%`` dominates
-        _,v = convertCookieParameter("path", "/a/%20/ ")
+        _, v = convertCookieParameter("path", "/a/%20/ ")
         self.assertEqual(v, "/a/%20/ ")
 
     def test_http_only(self):


### PR DESCRIPTION
Fixes #1052.

RFC 6265 section 5.1.4 ("https://www.rfc-editor.org/rfc/rfc6265#section-5.1.4") specifies how browsers should match the cookie path parameter to the request URI: it does not involve unquoting. As a consequence it is vital that the quoting used in the URL construction and in the cookie path computation is identical.

Zope (--> `OFS.Traversable`) uses Python's `urllib.parse.quote` as the usual URL quoting. This quotes all special characters with the exception of `-_./`. To match the requirement of the preceding paragraph for the standard case of an URL path, the cookie path handling, too, uses `quote` as its quoting. A check tried to ensure that partially quoted path values are rejected: if a path value contains `%` (indication that is is partially quoted), it must not contain other characters which would be transformed by `quote`.

#1052 describes a case where the URL does not follow Zope's standard URL quoting:
it contains `+`. For such an URL, we must not use `quote` as quoting in a corresponding cookie path parameter. #1052 observed an exception because the URL also contained `%`, i.e. seemed partially encoded.

This PR changes the logic: it assumes that a string presented as cookie path value is usually ready for use. More specifically:
 * if a cookie path value contains `%`, it is assumed to be already quoted and used unchanged
 * if it contains only characters allowed (unquoted) in an URL path (with the exception of `;`), it is used unchanged
 * otherwise, it is quoted via Python's `urllib.parse.quote`.
The first 2 cases ensure that an application can take full control over the cookie path value. The final case implements the URL quoting applied elsewhere by Zope.

Note that the logic cannot guarantee identical quoting for the URL (handled independently elsewhere) and the cookie path value.
Assume for example (Python 3) that an `str` *prefix* contains a non ASCII character and that we append `/++add++...` to get a cookie path value. In this case, the non ASCII character will cause `quote` quoting which will replace `+`. If this same replacement will not happen for the URL construction, the cookie might not be delivered.