### PR TITLE
Remove requirements badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,10 +16,6 @@
         :target: https://pypi.org/project/Zope/
         :alt: Supported Python versions
 
-.. image:: https://requires.io/github/zopefoundation/Zope/requirements.svg?branch=master
-        :target: https://requires.io/github/zopefoundation/Zope/requirements/?branch=master
-        :alt: Requirements Status
-
 .. |nbsp| unicode:: 0xA0 
         :trim:
 


### PR DESCRIPTION
It is not telling the truth for Python versions > 3.6.

Fixes #1051.