### PR TITLE
Upgrade to zope.dottedname 5.0 where possible.

### DIFF
--- a/versions-prod.cfg
+++ b/versions-prod.cfg
@@ -64,7 +64,7 @@ zope.contenttype = 4.5.0
 zope.datetime = 4.3.0
 zope.deferredimport = 4.4
 zope.deprecation = 4.4.0
-zope.dottedname = 4.3
+zope.dottedname = 5.0
 zope.event = 4.5.0
 zope.exceptions = 4.5
 zope.filerepresentation = 5.0.0
@@ -112,6 +112,8 @@ mock = 3.0.5
 multipart = 0.1.1
 # waitress 2 requires Python 3.6 or higher
 waitress = 1.4.4
+# zope.dottedname >= 5 requires Python 3.6 or higher
+zope.dottedname = 4.3
 
 [versions:python35]
 # DocumentTemplate 4+ cannot be installed on Zope 4 for Python 3.5
@@ -124,6 +126,8 @@ WebTest = 2.0.35
 mock = 3.0.5
 # waitress 2 requires Python 3.6 or higher
 waitress = 1.4.4
+# zope.dottedname >= 5 requires Python 3.6 or higher
+zope.dottedname = 4.3
 
 [versions:python36]
 # WSGIProxy 0.5 and up requires Python 3.7 and up

--- a/versions.cfg
+++ b/versions.cfg
@@ -22,6 +22,7 @@ collective.recipe.template = 2.2
 docutils = 0.17.1
 idna = 3.3
 imagesize = 1.3.0
+importlib-metadata = 4.12.0
 mr.developer = 2.0.1
 packaging = 21.3
 plone.recipe.command = 1.1
@@ -44,11 +45,13 @@ sphinxcontrib-websupport = 1.2.4
 # ZConfig xml configurations, which still contain references to it
 tempstorage = 5.2
 typing = 3.10.0.0
+typing-extensions = 4.1.1
 urllib3 = 1.26.9
 z3c.checkversions = 1.2
 zc.recipe.egg = 2.0.7
 zc.recipe.testrunner = 2.2
 zodbupdate = 1.5
+zipp = 3.8.1
 
 [versions:python27]
 # Babel 2.10 requires Python 3.6
@@ -99,6 +102,8 @@ packaging = 20.9
 pyparsing = 2.4.7
 # soupsieve 2.2 needs Python 3.6
 soupsieve = 2.1
+# Sphinx==3.5.4 requires docutils < 0.17
+docutils = 0.16
 
 [versions:python36]
 # Jinja2 3.1 and up needs Python 3.7 or higher


### PR DESCRIPTION
Had to add some version pins needed for different Python versions so buildout could run seccessfully. (Checked with all supported Python versions.)