### PR TITLE
Testing: make `publish` utility functions handle PATH_INFO

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,9 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 
 - Update to newest compatible versions of dependencies.
 
+- Change functional testing utilities to support percent encoded and unicode
+  paths (`#1058 <https://github.com/zopefoundation/Zope/issues/1058>`_).
+
 
 5.6 (2022-09-09)
 ----------------

--- a/src/Testing/ZopeTestCase/functional.py
+++ b/src/Testing/ZopeTestCase/functional.py
@@ -17,6 +17,7 @@ After Marius Gedminas' functional.py module for Zope3.
 
 import sys
 from functools import partial
+from urllib.parse import unquote_to_bytes
 
 import transaction
 from Testing.ZopeTestCase import interfaces
@@ -80,13 +81,11 @@ class Functional(sandbox.Sandboxed):
         env['SERVER_PROTOCOL'] = 'HTTP/1.1'
         env['REQUEST_METHOD'] = request_method
 
-        p = path.split('?')
-        if len(p) == 1:
-            env['PATH_INFO'] = p[0]
-        elif len(p) == 2:
-            [env['PATH_INFO'], env['QUERY_STRING']] = p
-        else:
-            raise TypeError('')
+        query = ''
+        if '?' in path:
+            path, query = path.split("?", 1)
+        env['PATH_INFO'] = unquote_to_bytes(path).decode('latin-1')
+        env['QUERY_STRING'] = query
 
         if basic:
             env['HTTP_AUTHORIZATION'] = basic_auth_encode(basic)
@@ -97,12 +96,16 @@ class Functional(sandbox.Sandboxed):
 
         if stdin is None:
             stdin = BytesIO()
+        env['wsgi.input'] = stdin
 
         outstream = BytesIO()
         response = WSGIResponse(stdout=outstream, stderr=sys.stderr)
-        request = Request(stdin, env, response)
-        for k, v in extra.items():
-            request[k] = v
+
+        def request_factory(*args):
+            request = Request(*args)
+            for k, v in extra.items():
+                request[k] = v
+            return request
 
         wsgi_headers = BytesIO()
 
@@ -120,7 +123,10 @@ class Functional(sandbox.Sandboxed):
             wsgi_headers.write(headers)
             wsgi_headers.write(b'\r\n\r\n')
 
-        publish = partial(publish_module, _request=request, _response=response)
+        publish = partial(
+            publish_module,
+            _request_factory=request_factory,
+            _response=response)
         if handle_errors:
             publish = HTTPExceptionHandler(publish)
 

--- a/src/Testing/ZopeTestCase/testFunctional.py
+++ b/src/Testing/ZopeTestCase/testFunctional.py
@@ -60,6 +60,9 @@ class TestFunctional(ZopeTestCase.FunctionalTestCase):
         # A method changing the title property of an object
         self.folder.addDTMLMethod('change_title', file=CHANGE_TITLE_DTML)
 
+        # A method with a non-ascii path
+        self.folder.addDTMLMethod('täst', file=b'test')
+
     def testPublishFolder(self):
         response = self.publish(self.folder_path)
         self.assertEqual(response.getStatus(), 200)
@@ -69,6 +72,16 @@ class TestFunctional(ZopeTestCase.FunctionalTestCase):
         response = self.publish(self.folder_path + '/index_html')
         self.assertEqual(response.getStatus(), 200)
         self.assertEqual(response.getBody(), b'index')
+
+    def testPublishDocumentNonAscii(self):
+        response = self.publish(self.folder_path + '/täst')
+        self.assertEqual(response.getStatus(), 200)
+        self.assertEqual(response.getBody(), b'test')
+
+    def testPublishDocumentNonAsciiUrlEncoded(self):
+        response = self.publish(self.folder_path + '/t%C3%A4st')
+        self.assertEqual(response.getStatus(), 200)
+        self.assertEqual(response.getBody(), b'test')
 
     def testUnauthorized(self):
         response = self.publish(self.folder_path + '/secret_html')


### PR DESCRIPTION
Fixes #1058

This applies to `Testing.ZopeTestCase.FunctionalTestCase.publish` and `html` from zopedoctest, both were using Zope's WSGI application, but were not preparing `PATH_INFO` in environ like a WSGI server is supposed to do.

As a result, it was not possible to use these utility with %-encoded paths or paths with non-ascii characters.

This fixes the issue by encoding the PATH_INFO and also changes the internals a bit not to pass a request, but using the request factory, so that the request environ is also set by WSGIPublisher, which does its own handling of encoded paths.