### PR TITLE
ZPublisher/utils: fix encoding in basic_auth_encode and basic_auth_decode

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,9 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 - Change functional testing utilities to support percent encoded and unicode
   paths (`#1058 <https://github.com/zopefoundation/Zope/issues/1058>`_).
 
+- Decode basic authentication header as utf-8, not latin1 anymore
+  (`#1061 <https://github.com/zopefoundation/Zope/issues/1061>`_).
+
 
 5.6 (2022-09-09)
 ----------------

--- a/src/ZPublisher/tests/testHTTPRequest.py
+++ b/src/ZPublisher/tests/testHTTPRequest.py
@@ -878,6 +878,19 @@ class HTTPRequestTests(unittest.TestCase, HTTPRequestFactoryMixin):
         self.assertEqual(user_id_x, user_id)
         self.assertEqual(password_x, password)
 
+    def test__authUserPW_non_ascii(self):
+        user_id = 'usèr'
+        password = 'pàssword'
+        auth_header = basic_auth_encode(user_id, password)
+
+        environ = {'HTTP_AUTHORIZATION': auth_header}
+        request = self._makeOne(environ=environ)
+
+        user_id_x, password_x = request._authUserPW()
+
+        self.assertEqual(user_id_x, user_id)
+        self.assertEqual(password_x, password)
+
     def test_debug_not_in_qs_still_gets_attr(self):
         from zope.publisher.base import DebugFlags
 

--- a/src/ZPublisher/utils.py
+++ b/src/ZPublisher/utils.py
@@ -85,8 +85,8 @@ def basic_auth_encode(user, password=None):
     value = user
     if password is not None:
         value = value + ':' + password
-    header = b'Basic ' + base64.b64encode(value.encode('latin-1'))
-    header = header.decode('latin-1')
+    header = b'Basic ' + base64.b64encode(value.encode())
+    header = header.decode()
     return header
 
 
@@ -97,8 +97,7 @@ def basic_auth_decode(token):
     if not token[:6].lower() == 'basic ':
         return None
     value = token.split()[-1]  # Strip 'Basic '
-    plain = base64.b64decode(value)
-    plain = plain.decode('latin-1')
+    plain = base64.b64decode(value).decode()
     user, password = plain.split(':', 1)  # Split at most once
     return (user, password)
 


### PR DESCRIPTION

Fixes #1061

Basic authentication header charset is unspecified, but in practice these days user agents use UTF-8.