### PR TITLE
Zope4: ZPublisher/utils: fix encoding in basic_auth_encode and basic_auth_decode

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,11 @@ https://zope.readthedocs.io/en/2.13/CHANGES.html
 - Change functional testing utilities to support percent encoded and unicode
   paths (`#1058 <https://github.com/zopefoundation/Zope/issues/1058>`_).
 
+- Decode basic authentication header as utf-8, not latin1 anymore
+  (`#1061 <https://github.com/zopefoundation/Zope/issues/1061>`_).
+
+- Make ``ZPublisher.utils.basic_auth_encode`` support non-ascii strings on Python 2
+  (`#1062 <https://github.com/zopefoundation/Zope/issues/1062>`_).
 
 4.8.2 (2022-06-01)
 ------------------

--- a/src/ZPublisher/tests/testHTTPRequest.py
+++ b/src/ZPublisher/tests/testHTTPRequest.py
@@ -1,4 +1,5 @@
 ##############################################################################
+# coding: utf-8
 #
 # Copyright (c) 2002 Zope Foundation and Contributors.
 #
@@ -885,6 +886,19 @@ class HTTPRequestTests(unittest.TestCase, HTTPRequestFactoryMixin):
     def test__authUserPW_with_embedded_colon(self):
         user_id = 'user'
         password = 'embedded:colon'
+        auth_header = basic_auth_encode(user_id, password)
+
+        environ = {'HTTP_AUTHORIZATION': auth_header}
+        request = self._makeOne(environ=environ)
+
+        user_id_x, password_x = request._authUserPW()
+
+        self.assertEqual(user_id_x, user_id)
+        self.assertEqual(password_x, password)
+
+    def test__authUserPW_non_ascii(self):
+        user_id = 'usèr'
+        password = 'pàssword'
         auth_header = basic_auth_encode(user_id, password)
 
         environ = {'HTTP_AUTHORIZATION': auth_header}

--- a/src/ZPublisher/utils.py
+++ b/src/ZPublisher/utils.py
@@ -88,9 +88,11 @@ def basic_auth_encode(user, password=None):
     value = user
     if password is not None:
         value = value + ':' + password
-    header = b'Basic ' + base64.b64encode(value.encode('latin-1'))
     if PY3:
-        header = header.decode('latin-1')
+        value = value.encode()
+    header = b'Basic ' + base64.b64encode(value)
+    if PY3:
+        header = header.decode()
     return header
 
 
@@ -103,6 +105,6 @@ def basic_auth_decode(token):
     value = token.split()[-1]  # Strip 'Basic '
     plain = base64.b64decode(value)
     if PY3:
-        plain = plain.decode('latin-1')
+        plain = plain.decode()
     user, password = plain.split(':', 1)  # Split at most once
     return (user, password)


### PR DESCRIPTION
Fixes #1062

and backports #1063 for 4.x

Basic authentication header charset is unspecified, but in practice these days user agents use UTF-8.

On python 2 we also don't want basic_auth_encode to encode the str because we don't expect an unicode but a native string.