### PR TITLE
Use UTF-8 charset for WWW-Authenticate headers in challenge responses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,7 +20,7 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 
 - Use UTF-8 charset for WWW-Authenticate headers in challenge responses,
   as described in `RFC7617 <https://datatracker.ietf.org/doc/html/draft-ietf-httpauth-basicauth-update-07#section-2.1>`_
-  ( #1065 <https://github.com/zopefoundation/Zope/pull/1065>`_).
+  ( `#1065 <https://github.com/zopefoundation/Zope/pull/1065>`_).
 
 
 5.6 (2022-09-09)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,10 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 - Decode basic authentication header as utf-8, not latin1 anymore
   (`#1061 <https://github.com/zopefoundation/Zope/issues/1061>`_).
 
+- Use UTF-8 charset for WWW-Authenticate headers in challenge responses,
+  as described in `RFC7617 <https://datatracker.ietf.org/doc/html/draft-ietf-httpauth-basicauth-update-07#section-2.1>`_
+  ( #1065 <https://github.com/zopefoundation/Zope/pull/1065>`_).
+
 
 5.6 (2022-09-09)
 ----------------

--- a/src/ZPublisher/HTTPResponse.py
+++ b/src/ZPublisher/HTTPResponse.py
@@ -732,7 +732,10 @@ class HTTPBaseResponse(BaseResponse):
     def _unauthorized(self):
         realm = self.realm
         if realm:
-            self.setHeader('WWW-Authenticate', 'basic realm="%s"' % realm, 1)
+            self.setHeader(
+                'WWW-Authenticate',
+                'basic realm="%s", charset="UTF-8"' % realm,
+                1)
 
     @staticmethod
     def _html(title, body):

--- a/src/ZPublisher/tests/testHTTPResponse.py
+++ b/src/ZPublisher/tests/testHTTPResponse.py
@@ -966,7 +966,7 @@ class HTTPResponseTests(unittest.TestCase):
         response._unauthorized()
         self.assertTrue('WWW-Authenticate' in response.headers)  # literal
         self.assertEqual(response.headers['WWW-Authenticate'],
-                         'basic realm="Zope"')
+                         'basic realm="Zope", charset="UTF-8"')
 
     def test__unauthorized_w_realm(self):
         response = self._makeOne()
@@ -974,7 +974,7 @@ class HTTPResponseTests(unittest.TestCase):
         response._unauthorized()
         self.assertTrue('WWW-Authenticate' in response.headers)  # literal
         self.assertEqual(response.headers['WWW-Authenticate'],
-                         'basic realm="Folly"')
+                         'basic realm="Folly", charset="UTF-8"')
 
     def test_unauthorized_no_debug_mode(self):
         response = self._makeOne()


### PR DESCRIPTION
This tells user agents that we expect the user-pass to be UTF-8 encoded, as per section "2.1.  The 'charset' auth-param" of RFC7617.

https://datatracker.ietf.org/doc/html/draft-ietf-httpauth-basicauth-update-07#section-2.1