### PR TITLE
addzopeuser accepts custom location of zope.conf

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 5.6.1 (unreleased)
 ------------------
 
+- Script `addzopeuser` accepts now parameter '-c' or '--configuration'.
+  This allows passing in a custom location for the `zope.conf` file to use.
+  If not specified, behavior is not not altered.
+
 - Update to newest compatible versions of dependencies.
 
 - Change functional testing utilities to support percent encoded and unicode

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,7 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 
 - Script `addzopeuser` accepts now parameter '-c' or '--configuration'.
   This allows passing in a custom location for the `zope.conf` file to use.
-  If not specified, behavior is not not altered.
+  If not specified, behavior is not altered.
 
 - Update to newest compatible versions of dependencies.
 

--- a/docs/operation.rst
+++ b/docs/operation.rst
@@ -254,7 +254,12 @@ this using ``addzopeuser`` as follows:
 
   $ bin/addzopeuser user password
 
-The script expects to find the configuration file at ``etc/zope.conf``.
+The script expects to find the configuration file at ``etc/zope.conf`` by default.
+If it is located on a different location this can be specified by the `--configuration` option:
+
+.. code-block:: console
+
+  $ bin/addzopeuser --configuration /path/to/etc/zope.conf user password
 
 
 Running Zope (plone.recipe.zope2instance install)

--- a/docs/operation.rst
+++ b/docs/operation.rst
@@ -255,7 +255,7 @@ this using ``addzopeuser`` as follows:
   $ bin/addzopeuser user password
 
 The script expects to find the configuration file at ``etc/zope.conf`` by default.
-If it is located on a different location this can be specified by the `--configuration` option:
+If it is located in a different location you can specify it with the `--configuration` option:
 
 .. code-block:: console
 

--- a/src/Zope2/utilities/adduser.py
+++ b/src/Zope2/utilities/adduser.py
@@ -12,6 +12,7 @@
 ##############################################################################
 """ Add a Zope management user to the root Zope user folder """
 
+import argparse
 import sys
 
 from Zope2.utilities.finder import ZopeFinder
@@ -25,18 +26,26 @@ def adduser(app, user, pwd):
 
 
 def main(argv=sys.argv):
-    import sys
-    try:
-        user, pwd = argv[1], argv[2]
-    except IndexError:
-        print("%s <username> <password>" % argv[0])
-        sys.exit(255)
+    parser = argparse.ArgumentParser(
+        description='Add a Zope management user to the root Zope user folder.'
+    )
+    parser.add_argument(
+        "-c",
+        "--configuration",
+        help="Zope configuration file",
+        nargs="?",
+        type=str,
+        default=None,
+    )
+    parser.add_argument("user", help="name of user to be created")
+    parser.add_argument("password", help="new password for the user")
+    args = parser.parse_args(argv[1:])
     finder = ZopeFinder(argv)
     finder.filter_warnings()
-    app = finder.get_app()
-    result = adduser(app, user, pwd)
+    app = finder.get_app(config_file=args.configuration)
+    result = adduser(app, args.user, args.password)
     if result:
-        print("User %s created." % user)
+        print(f"User {args.user} created.")
     else:
         print("Got no result back. User creation may have failed.")
         print("Maybe the user already exists and nothing is done then.")

--- a/src/Zope2/utilities/adduser.py
+++ b/src/Zope2/utilities/adduser.py
@@ -32,7 +32,7 @@ def main(argv=sys.argv):
     parser.add_argument(
         "-c",
         "--configuration",
-        help="Zope configuration file",
+        help="Path to Zope configuration file",
         nargs="?",
         type=str,
         default=None,


### PR DESCRIPTION
Script `addzopeuser` accepts now parameter '-c' or '--configuration'. This allows passing in an custom location for the `zope.conf` file to use. If not specified behavior not altered.

On you request @pbauer 

I found it was possible already to specify the path setting an environment variable `ZOPE_CONF`. But I think it is more intuitive to pass it as a parameter.

While at it and because it simplifies the code and auto-documents the script I introduced usage of argparse here.
