### PR TITLE
INSTALL: fix example with plone.recipe.zope2instance

### DIFF
--- a/docs/INSTALL.rst
+++ b/docs/INSTALL.rst
@@ -135,6 +135,7 @@ options, please see the
 
     [zopeinstance]
     recipe = plone.recipe.zope2instance
+    eggs =
     user = admin:adminpassword
     http-address = 8080
     zodb-temporary-storage = off


### PR DESCRIPTION
plone.recipe.zope2instance needs eggs to be defined, otherwise it tries to install an egg with the name as the section name, which in the case of `zopeinstance` does not exist.

    Installing zopeinstance.
    Couldn't find index page for 'zopeinstance' (maybe misspelled?)
    Getting distribution for 'zopeinstance'.
    Couldn't find index page for 'zopeinstance' (maybe misspelled?)
    While:
      Installing zopeinstance.
      Getting distribution for 'zopeinstance'.
    Error: Couldn't find a distribution for 'zopeinstance'.