### PR TITLE
Serve MessageDialogs and exception views as text/html

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,8 +11,10 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 5.7.3 (unreleased)
 ------------------
 
-- Adjust the old ``App.Dialogs.MessageDialog`` to be served as HTML after
-  from PR https://github.com/zopefoundation/Zope/pull/1075 .
+- Explicitly serve ``App.Dialogs.MessageDialog`` and exception views as HTML
+  due to the changed default content type from `#1075
+  <https://github.com/zopefoundation/Zope/pull/1075>`_.
+
 
 5.7.2 (2022-12-17)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 5.7.3 (unreleased)
 ------------------
 
+- Adjust the old ``App.Dialogs.MessageDialog`` to be served as HTML after
+  from PR https://github.com/zopefoundation/Zope/pull/1075 .
 
 5.7.2 (2022-12-17)
 ------------------

--- a/src/App/Dialogs.py
+++ b/src/App/Dialogs.py
@@ -34,7 +34,19 @@
 from App.special_dtml import HTML
 
 
-MessageDialog = HTML("""
+class MessageDialogHTML(HTML):
+    """An special version of HTML which is always published as text/html
+    """
+    def __call__(self, *args, **kw):
+        class _HTMLString(str):
+            """A special string that will be published as text/html
+            """
+            def asHTML(self):
+                return self
+        return _HTMLString(super().__call__(*args, **kw))
+
+
+MessageDialog = MessageDialogHTML("""
 <HTML>
 <HEAD>
 <TITLE>&dtml-title;</TITLE>

--- a/src/App/Dialogs.py
+++ b/src/App/Dialogs.py
@@ -35,7 +35,7 @@ from App.special_dtml import HTML
 
 
 class MessageDialogHTML(HTML):
-    """An special version of HTML which is always published as text/html
+    """A special version of HTML which is always published as text/html
     """
     def __call__(self, *args, **kw):
         class _HTMLString(str):

--- a/src/App/tests/testManagement.py
+++ b/src/App/tests/testManagement.py
@@ -81,21 +81,3 @@ class TestManagePages(Testing.ZopeTestCase.ZopeTestCase):
 
         self.folder.manage(req)
         self.assertIn('text/html', req.RESPONSE.getHeader('Content-Type'))
-
-
-class TestDialogsMessageDialog(Testing.ZopeTestCase.ZopeTestCase):
-
-    def test_publish_set_content_type(self):
-        from App.Dialogs import MessageDialog
-
-        md = MessageDialog(
-            title='dialog title',
-            message='dialog message',
-            action='action'
-        )
-        self.assertIn('dialog title', md)
-        self.assertIn('dialog message', md)
-        self.assertIn('action', md)
-        req = self.app.REQUEST
-        req.RESPONSE.setBody(md)
-        self.assertIn('text/html', req.RESPONSE.getHeader('Content-Type'))

--- a/src/App/tests/testManagement.py
+++ b/src/App/tests/testManagement.py
@@ -81,3 +81,21 @@ class TestManagePages(Testing.ZopeTestCase.ZopeTestCase):
 
         self.folder.manage(req)
         self.assertIn('text/html', req.RESPONSE.getHeader('Content-Type'))
+
+
+class TestDialogsMessageDialog(Testing.ZopeTestCase.ZopeTestCase):
+
+    def test_publish_set_content_type(self):
+        from App.Dialogs import MessageDialog
+
+        md = MessageDialog(
+            title='dialog title',
+            message='dialog message',
+            action='action'
+        )
+        self.assertIn('dialog title', md)
+        self.assertIn('dialog message', md)
+        self.assertIn('action', md)
+        req = self.app.REQUEST
+        req.RESPONSE.setBody(md)
+        self.assertIn('text/html', req.RESPONSE.getHeader('Content-Type'))

--- a/src/App/tests/test_Dialogs.py
+++ b/src/App/tests/test_Dialogs.py
@@ -1,0 +1,19 @@
+import Testing.ZopeTestCase
+
+
+class TestMessageDialog(Testing.ZopeTestCase.ZopeTestCase):
+
+    def test_publish_set_content_type(self):
+        from App.Dialogs import MessageDialog
+
+        md = MessageDialog(
+            title='dialog title',
+            message='dialog message',
+            action='action'
+        )
+        self.assertIn('dialog title', md)
+        self.assertIn('dialog message', md)
+        self.assertIn('action', md)
+        req = self.app.REQUEST
+        req.RESPONSE.setBody(md)
+        self.assertIn('text/html', req.RESPONSE.getHeader('Content-Type'))

--- a/src/ZPublisher/WSGIPublisher.py
+++ b/src/ZPublisher/WSGIPublisher.py
@@ -149,6 +149,11 @@ def _exc_view_created_response(exc, request, response):
             for key, value in exc.headers.items():
                 response.setHeader(key, value)
 
+        # Explicitly set the content type header if it's not there yet so
+        # the response doesn't get served with the text/plain default
+        if not response.getHeader('Content-Type'):
+            response.setHeader('Content-Type', 'text/html')
+
         # Set the response body to the result of calling the view.
         response.setBody(view())
         return True

--- a/src/ZPublisher/tests/test_WSGIPublisher.py
+++ b/src/ZPublisher/tests/test_WSGIPublisher.py
@@ -669,7 +669,7 @@ class TestPublishModule(ZopeTestCase):
             'Exception View: ConflictError'))
         self.assertEqual(_request.retry_count, _request.retry_max_count)
 
-        # The Content-Type response heade should be set to text/html
+        # The Content-Type response header should be set to text/html
         self.assertIn('text/html', _request.response.getHeader('Content-Type'))
 
         unregisterExceptionView(Exception)

--- a/src/ZPublisher/tests/test_WSGIPublisher.py
+++ b/src/ZPublisher/tests/test_WSGIPublisher.py
@@ -668,6 +668,10 @@ class TestPublishModule(ZopeTestCase):
         self.assertTrue(app_iter[1].startswith(
             'Exception View: ConflictError'))
         self.assertEqual(_request.retry_count, _request.retry_max_count)
+
+        # The Content-Type response heade should be set to text/html
+        self.assertIn('text/html', _request.response.getHeader('Content-Type'))
+
         unregisterExceptionView(Exception)
 
     def testCustomExceptionViewUnauthorized(self):
@@ -869,10 +873,10 @@ class ExcViewCreatedTests(ZopeTestCase):
         from zope.interface import directlyProvides
         from zope.publisher.browser import IDefaultBrowserLayer
         from ZPublisher.WSGIPublisher import _exc_view_created_response
-        req = DummyRequest()
+        req = self.app.REQUEST
         req['PARENTS'] = [self.app]
         directlyProvides(req, IDefaultBrowserLayer)
-        return _exc_view_created_response(exc, req, DummyResponse())
+        return _exc_view_created_response(exc, req, req.RESPONSE)
 
     def _registerStandardErrorView(self):
         from OFS.browser import StandardErrorMessageView
@@ -899,13 +903,21 @@ class ExcViewCreatedTests(ZopeTestCase):
         from OFS.DTMLMethod import addDTMLMethod
         from zExceptions import NotFound
         self._registerStandardErrorView()
+        response = self.app.REQUEST.RESPONSE
 
         addDTMLMethod(self.app, 'standard_error_message', file='OOPS')
+
+        # The response content-type header is not set before rendering
+        # the standard error template
+        self.assertFalse(response.getHeader('Content-Type'))
 
         try:
             self.assertTrue(self._callFUT(NotFound))
         finally:
             self._unregisterStandardErrorView()
+
+        # After rendering the response content-type header is set
+        self.assertIn('text/html', response.getHeader('Content-Type'))
 
 
 class WSGIPublisherTests(FunctionalTestCase):
@@ -1063,6 +1075,14 @@ class DummyResponse:
         self._status = status
 
     status = property(lambda self: self._status, setStatus)
+
+    def getHeader(self, header):
+        return dict(self._headers).get(header, None)
+
+    def setHeader(self, header, value):
+        headers = dict(self._headers)
+        headers[header] = value
+        self._headers = tuple(headers.items())
 
 
 class DummyCallable:


### PR DESCRIPTION
Now that Zope uses text/plain by default, MessageDialogs were served as text/plain. Keep compatibility by returning a special string with `asHTML` method, that ZPublisher.HTTPResponse.HTTPResponse.setBody understands.

MessageDialogs are deprecated and do not integrate well in Zope >= 4 ZMI, but they are used in some old products.

Fixes issues discussed in https://github.com/zopefoundation/Zope/pull/1079#issuecomment-1356246105
