### PR TITLE
Serve MessageDialogs and exception views as text/html (4.x)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ https://zope.readthedocs.io/en/2.13/CHANGES.html
 4.8.6 (unreleased)
 ------------------
 
+- Adjust the old ``App.Dialogs.MessageDialog`` to be served as HTML after
+  from PR https://github.com/zopefoundation/Zope/pull/1075 .
 
 4.8.5 (2022-12-17)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,8 +10,10 @@ https://zope.readthedocs.io/en/2.13/CHANGES.html
 4.8.6 (unreleased)
 ------------------
 
-- Adjust the old ``App.Dialogs.MessageDialog`` to be served as HTML after
-  from PR https://github.com/zopefoundation/Zope/pull/1075 .
+- Explicitly serve ``App.Dialogs.MessageDialog`` and exception views as HTML
+  due to the changed default content type from `#1075
+  <https://github.com/zopefoundation/Zope/pull/1075>`_.
+
 
 4.8.5 (2022-12-17)
 ------------------

--- a/src/App/Dialogs.py
+++ b/src/App/Dialogs.py
@@ -34,7 +34,20 @@
 from App.special_dtml import HTML
 
 
-MessageDialog = HTML("""
+class MessageDialogHTML(HTML):
+    """An special version of HTML which is always published as text/html
+    """
+    def __call__(self, *args, **kw):
+        class _HTMLString(str):
+            """A special string that will be published as text/html
+            """
+            def asHTML(self):
+                return self
+        return _HTMLString(
+            super(MessageDialogHTML, self).__call__(*args, **kw))
+
+
+MessageDialog = MessageDialogHTML("""
 <HTML>
 <HEAD>
 <TITLE>&dtml-title;</TITLE>

--- a/src/App/Dialogs.py
+++ b/src/App/Dialogs.py
@@ -35,7 +35,7 @@ from App.special_dtml import HTML
 
 
 class MessageDialogHTML(HTML):
-    """An special version of HTML which is always published as text/html
+    """A special version of HTML which is always published as text/html
     """
     def __call__(self, *args, **kw):
         class _HTMLString(str):

--- a/src/App/tests/testManagement.py
+++ b/src/App/tests/testManagement.py
@@ -94,21 +94,3 @@ class TestManagePages(Testing.ZopeTestCase.ZopeTestCase):
 
         self.folder.manage(req)
         self.assertIn('text/html', req.RESPONSE.getHeader('Content-Type'))
-
-
-class TestDialogsMessageDialog(Testing.ZopeTestCase.ZopeTestCase):
-
-    def test_publish_set_content_type(self):
-        from App.Dialogs import MessageDialog
-
-        md = MessageDialog(
-            title='dialog title',
-            message='dialog message',
-            action='action'
-        )
-        self.assertIn('dialog title', md)
-        self.assertIn('dialog message', md)
-        self.assertIn('action', md)
-        req = self.app.REQUEST
-        req.RESPONSE.setBody(md)
-        self.assertIn('text/html', req.RESPONSE.getHeader('Content-Type'))

--- a/src/App/tests/testManagement.py
+++ b/src/App/tests/testManagement.py
@@ -94,3 +94,21 @@ class TestManagePages(Testing.ZopeTestCase.ZopeTestCase):
 
         self.folder.manage(req)
         self.assertIn('text/html', req.RESPONSE.getHeader('Content-Type'))
+
+
+class TestDialogsMessageDialog(Testing.ZopeTestCase.ZopeTestCase):
+
+    def test_publish_set_content_type(self):
+        from App.Dialogs import MessageDialog
+
+        md = MessageDialog(
+            title='dialog title',
+            message='dialog message',
+            action='action'
+        )
+        self.assertIn('dialog title', md)
+        self.assertIn('dialog message', md)
+        self.assertIn('action', md)
+        req = self.app.REQUEST
+        req.RESPONSE.setBody(md)
+        self.assertIn('text/html', req.RESPONSE.getHeader('Content-Type'))

--- a/src/App/tests/test_Dialogs.py
+++ b/src/App/tests/test_Dialogs.py
@@ -1,0 +1,19 @@
+import Testing.ZopeTestCase
+
+
+class TestMessageDialog(Testing.ZopeTestCase.ZopeTestCase):
+
+    def test_publish_set_content_type(self):
+        from App.Dialogs import MessageDialog
+
+        md = MessageDialog(
+            title='dialog title',
+            message='dialog message',
+            action='action'
+        )
+        self.assertIn('dialog title', md)
+        self.assertIn('dialog message', md)
+        self.assertIn('action', md)
+        req = self.app.REQUEST
+        req.RESPONSE.setBody(md)
+        self.assertIn('text/html', req.RESPONSE.getHeader('Content-Type'))

--- a/src/ZPublisher/WSGIPublisher.py
+++ b/src/ZPublisher/WSGIPublisher.py
@@ -144,6 +144,11 @@ def _exc_view_created_response(exc, request, response):
             for key, value in exc.headers.items():
                 response.setHeader(key, value)
 
+        # Explicitly set the content type header if it's not there yet so
+        # the response doesn't get served with the text/plain default
+        if not response.getHeader('Content-Type'):
+            response.setHeader('Content-Type', 'text/html')
+
         # Set the response body to the result of calling the view.
         response.setBody(view())
         return True

--- a/src/ZPublisher/tests/test_WSGIPublisher.py
+++ b/src/ZPublisher/tests/test_WSGIPublisher.py
@@ -671,7 +671,7 @@ class TestPublishModule(ZopeTestCase):
             'Exception View: ConflictError'))
         self.assertEqual(_request.retry_count, _request.retry_max_count)
 
-        # The Content-Type response heade should be set to text/html
+        # The Content-Type response header should be set to text/html
         self.assertIn('text/html', _request.response.getHeader('Content-Type'))
 
         unregisterExceptionView(Exception)


### PR DESCRIPTION
Now that Zope uses text/plain by default, MessageDialogs were served as text/plain. Keep compatibility by returning a special string with `asHTML` method, that ZPublisher.HTTPResponse.HTTPResponse.setBody understands.

MessageDialogs are deprecated and do not integrate well in Zope >= 4 ZMI, but they are used in some old products.