### PR TITLE
No Content-Type text/html on empty exception views [4.x]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,9 @@ https://zope.readthedocs.io/en/2.13/CHANGES.html
 4.8.7 (unreleased)
 ------------------
 
-- Only set response header Content-Type as text/html on exception views when the response has content.
+- Only set response header Content-Type as text/html on exception views when
+  the response has content.
+  (`#1089 <https://github.com/zopefoundation/Zope/issues/1089>`_)
 
 - Update dependencies to the latest releases for each supported Python version.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ https://zope.readthedocs.io/en/2.13/CHANGES.html
 4.8.7 (unreleased)
 ------------------
 
+- Only set response header Content-Type as text/html on exception views when the response has content.
+
 - Update dependencies to the latest releases for each supported Python version.
 
 

--- a/src/App/tests/test_ApplicationManager.py
+++ b/src/App/tests/test_ApplicationManager.py
@@ -464,6 +464,7 @@ class DebugManagerTests(unittest.TestCase):
     def _makeModuleClasses(self):
         import sys
         import types
+
         from ExtensionClass import Base
 
         class Foo(Base):
@@ -513,6 +514,7 @@ class DebugManagerTests(unittest.TestCase):
 
     def test_rcsnapshot(self):
         import sys
+
         import App.ApplicationManager
         from DateTime.DateTime import DateTime
         dm = self._makeOne('test')

--- a/src/App/tests/test_getZopeVersion.py
+++ b/src/App/tests/test_getZopeVersion.py
@@ -15,9 +15,8 @@
 
 import unittest
 
-from pkg_resources import get_distribution
-
 from App.version_txt import getZopeVersion
+from pkg_resources import get_distribution
 
 
 class Test(unittest.TestCase):

--- a/src/OFS/Application.py
+++ b/src/OFS/Application.py
@@ -295,8 +295,8 @@ class AppInitializer(object):
     def install_virtual_hosting(self):
         app = self.getApp()
         if 'virtual_hosting' not in app:
-            from Products.SiteAccess.VirtualHostMonster \
-                import VirtualHostMonster
+            from Products.SiteAccess.VirtualHostMonster import \
+                VirtualHostMonster
             any_vhm = [obj for obj in app.values()
                        if isinstance(obj, VirtualHostMonster)]
             if not any_vhm:
@@ -308,8 +308,8 @@ class AppInitializer(object):
     def install_root_view(self):
         app = self.getApp()
         if 'index_html' not in app:
-            from Products.PageTemplates.ZopePageTemplate \
-                import ZopePageTemplate
+            from Products.PageTemplates.ZopePageTemplate import \
+                ZopePageTemplate
             root_pt = ZopePageTemplate('index_html')
             root_pt.pt_setTitle(u'Auto-generated default page')
             app._setObject('index_html', root_pt)

--- a/src/OFS/ObjectManager.py
+++ b/src/OFS/ObjectManager.py
@@ -799,6 +799,7 @@ class ObjectManager(
                  u'Zope 5.', DeprecationWarning, stacklevel=2)
             mode = 0o0040000
             from AccessControl.User import nobody
+
             # check to see if we are acquiring our objectValues or not
             parents = REQUEST.PARENTS
             if not (len(parents) > 1

--- a/src/OFS/bbb.py
+++ b/src/OFS/bbb.py
@@ -12,7 +12,6 @@
 ##############################################################################
 
 import pkg_resources
-
 from zope.deferredimport import deprecated
 
 

--- a/src/OFS/tests/applicationproduct/__init__.py
+++ b/src/OFS/tests/applicationproduct/__init__.py
@@ -5,8 +5,8 @@
 
 
 def initialize(context):
-    from OFS.Folder import Folder
     import transaction
+    from OFS.Folder import Folder
 
     app = context.getApplication()
     folder = Folder('some_folder')

--- a/src/OFS/tests/testApplication.py
+++ b/src/OFS/tests/testApplication.py
@@ -93,8 +93,9 @@ class ApplicationTests(unittest.TestCase):
         self.assertRaises(KeyError, app.__bobo_traverse__, request, 'NONESUCH')
 
     def test_bobo_traverse_attribute_key_miss_R_M_not_GET_POST(self):
+        from Acquisition import aq_inner
+        from Acquisition import aq_parent
         from webdav.NullResource import NullResource
-        from Acquisition import aq_inner, aq_parent
 
         app = self._makeOne()
         app._getOb = _noWay

--- a/src/OFS/tests/testCopySupport.py
+++ b/src/OFS/tests/testCopySupport.py
@@ -362,8 +362,9 @@ class TestCopySupportSecurity(CopySupportTestBase):
     def _assertCopyErrorUnauth(self, callable, *args, **kw):
 
         import re
-        from zExceptions import Unauthorized
+
         from OFS.CopySupport import CopyError
+        from zExceptions import Unauthorized
 
         ce_regex = kw.get('ce_regex')
         if ce_regex is not None:

--- a/src/OFS/tests/testEtagSupport.py
+++ b/src/OFS/tests/testEtagSupport.py
@@ -4,8 +4,8 @@ import unittest
 class TestEtagSupport(unittest.TestCase):
 
     def test_interfaces(self):
-        from zope.interface.verify import verifyClass
         from OFS.EtagSupport import EtagBaseInterface
         from OFS.EtagSupport import EtagSupport
+        from zope.interface.verify import verifyClass
 
         verifyClass(EtagBaseInterface, EtagSupport)

--- a/src/OFS/tests/testFileAndImage.py
+++ b/src/OFS/tests/testFileAndImage.py
@@ -314,9 +314,9 @@ class FileTests(unittest.TestCase):
         self.assertEqual(self.file.manage_DAVget(), text)
 
     def test_interfaces(self):
-        from zope.interface.verify import verifyClass
         from OFS.Image import File
         from OFS.interfaces import IWriteLock
+        from zope.interface.verify import verifyClass
         from ZPublisher.HTTPRangeSupport import HTTPRangeInterface
 
         verifyClass(HTTPRangeInterface, File)
@@ -370,9 +370,9 @@ class ImageTests(FileTests):
         self.assertEqual(result, self.data)
 
     def test_interfaces(self):
-        from zope.interface.verify import verifyClass
         from OFS.Image import Image
         from OFS.interfaces import IWriteLock
+        from zope.interface.verify import verifyClass
 
         verifyClass(IWriteLock, Image)
 

--- a/src/OFS/tests/testObjectManager.py
+++ b/src/OFS/tests/testObjectManager.py
@@ -608,9 +608,9 @@ class ObjectManagerTests(PlacelessSetup, unittest.TestCase):
 
         from OFS.Folder import Folder
         from OFS.Image import File
-        from ZODB.DemoStorage import DemoStorage
-        from ZODB.DB import DB
         from transaction import commit
+        from ZODB.DB import DB
+        from ZODB.DemoStorage import DemoStorage
         try:
             tf = None  # temporary file required for export/import
             # export/import needs the object manager in ZODB

--- a/src/OFS/tests/testRanges.py
+++ b/src/OFS/tests/testRanges.py
@@ -49,6 +49,7 @@ class TestRequestRange(unittest.TestCase):
     def setUp(self):
         import io
         import string
+
         import transaction
         from OFS.Application import Application
         from OFS.Folder import manage_addFolder
@@ -168,9 +169,9 @@ class TestRequestRange(unittest.TestCase):
         self.assertEqual(body, self.data[start:end])
 
     def expectMultipleRanges(self, range, sets, draft=0):
+        import email
         import io
         import re
-        import email
         rangeParse = re.compile(r'bytes\s*(\d+)-(\d+)/(\d+)')
         req = self.app.REQUEST
         rsp = req.RESPONSE

--- a/src/OFS/tests/testTraverse.py
+++ b/src/OFS/tests/testTraverse.py
@@ -45,8 +45,8 @@ class ProtectedMethodSecurityPolicy(object):
     """Check security strictly on bound methods.
     """
     def validate(self, accessed, container, name, value, *args):
-        from Acquisition import aq_base
         from AccessControl import Unauthorized
+        from Acquisition import aq_base
         if getattr(aq_base(value), '__self__', None) is None:
             return 1
 
@@ -65,6 +65,7 @@ class TestTraverse(unittest.TestCase):
 
     def setUp(self):
         import io
+
         import transaction
         from AccessControl import SecurityManager
         from AccessControl.SecurityManagement import newSecurityManager
@@ -393,9 +394,10 @@ class TestTraverse(unittest.TestCase):
             self.root.folder1.restrictedTraverse('stuff', 42), 42)
 
     def testNotFoundIsRaised(self):
+        from operator import getitem
+
         from OFS.SimpleItem import SimpleItem
         from zExceptions import NotFound
-        from operator import getitem
         self.folder1._setObject('foo', SimpleItem('foo'))
         self.assertRaises(AttributeError, getitem, self.folder1.foo,
                           'doesntexist')

--- a/src/OFS/tests/test_DTMLDocument.py
+++ b/src/OFS/tests/test_DTMLDocument.py
@@ -15,8 +15,8 @@ class DTMLDocumentTests(unittest.TestCase):
         return self._getTargetClass()(*args, **kw)
 
     def test_class_conforms_to_IWriteLock(self):
-        from zope.interface.verify import verifyClass
         from OFS.interfaces import IWriteLock
+        from zope.interface.verify import verifyClass
         verifyClass(IWriteLock, self._getTargetClass())
 
     def test_manage_upload__bytes(self):
@@ -70,8 +70,8 @@ class FactoryTests(unittest.TestCase):
 
     def test_defaults_no_standard_html_header(self):
         # see LP #496961
-        from OFS.DTMLDocument import addDTMLDocument
         from OFS.DTMLDocument import DTMLDocument
+        from OFS.DTMLDocument import addDTMLDocument
         dispatcher = DummyDispatcher()
         addDTMLDocument(dispatcher, 'id')
         method = dispatcher._set['id']

--- a/src/OFS/tests/test_DTMLMethod.py
+++ b/src/OFS/tests/test_DTMLMethod.py
@@ -15,8 +15,8 @@ from Testing.makerequest import makerequest
 
 
 def _lock_item(item):
-    from OFS.LockItem import LockItem
     from AccessControl.users import nobody
+    from OFS.LockItem import LockItem
     item.wl_setLock('token', LockItem(nobody, token='token'))
 
 
@@ -30,8 +30,8 @@ class DTMLMethodTests(unittest.TestCase):
         return self._getTargetClass()(*args, **kw)
 
     def test_class_conforms_to_IWriteLock(self):
-        from zope.interface.verify import verifyClass
         from OFS.interfaces import IWriteLock
+        from zope.interface.verify import verifyClass
         verifyClass(IWriteLock, self._getTargetClass())
 
     def test_edit_taintedstring(self):
@@ -264,8 +264,8 @@ class FactoryTests(unittest.TestCase):
 
     def test_defaults_no_standard_html_header(self):
         # see LP #496961
-        from OFS.DTMLMethod import addDTMLMethod
         from OFS.DTMLMethod import DTMLMethod
+        from OFS.DTMLMethod import addDTMLMethod
         dispatcher = DummyDispatcher()
         addDTMLMethod(dispatcher, 'id')
         method = dispatcher._set['id']

--- a/src/OFS/tests/test_Uninstalled.py
+++ b/src/OFS/tests/test_Uninstalled.py
@@ -112,10 +112,10 @@ class TestsOfBroken(unittest.TestCase):
 class TestsIntegratedBroken(base.TestCase):
 
     def test_Broken_instance___getstate___gives_access_to_its_state(self):
-        from Acquisition import aq_base
-        from OFS.Uninstalled import BrokenClass
-        from OFS.tests import test_Uninstalled
         import transaction
+        from Acquisition import aq_base
+        from OFS.tests import test_Uninstalled
+        from OFS.Uninstalled import BrokenClass
 
         # store an instance
         tr = ToBreak()

--- a/src/OFS/tests/test_metaconfigure.py
+++ b/src/OFS/tests/test_metaconfigure.py
@@ -21,8 +21,9 @@ class TestRegisterClass(unittest.TestCase):
         OFS.metaconfigure._meta_type_regs[:] = []
 
     def tearDown(self):
-        from zope.component.testing import tearDown
         import OFS.metaconfigure
+        from zope.component.testing import tearDown
+
         # restore registrations
         OFS.metaconfigure._meta_type_regs[:] = self._old_mt_regs
         OFS.metaconfigure._register_monkies[:] = self._old_monkies

--- a/src/OFS/userfolder.py
+++ b/src/OFS/userfolder.py
@@ -18,7 +18,7 @@ import os
 from AccessControl import ClassSecurityInfo
 from AccessControl import userfolder as accesscontrol_userfolder
 from AccessControl.class_init import InitializeClass
-from AccessControl.Permissions import manage_users as ManageUsers  # NOQA
+from AccessControl.Permissions import manage_users as ManageUsers
 from AccessControl.requestmethod import requestmethod
 from AccessControl.rolemanager import DEFAULTMAXLISTUSERS
 from AccessControl.users import _remote_user_mode

--- a/src/Products/Five/browser/adding.py
+++ b/src/Products/Five/browser/adding.py
@@ -36,7 +36,7 @@ from zope.component import queryUtility
 from zope.component.interfaces import IFactory
 from zope.container.constraints import checkFactory
 from zope.container.constraints import checkObject
-from zope.container.i18n import ZopeMessageFactory as _  # NOQA
+from zope.container.i18n import ZopeMessageFactory as _
 from zope.container.interfaces import IContainerNamesContainer
 from zope.container.interfaces import INameChooser
 from zope.event import notify

--- a/src/Products/Five/browser/tests/test_i18n.py
+++ b/src/Products/Five/browser/tests/test_i18n.py
@@ -83,7 +83,8 @@ def test_zpt_i18n():
 
 
 def test_suite():
-    from Testing.ZopeTestCase import FunctionalDocTestSuite
     import doctest
+
+    from Testing.ZopeTestCase import FunctionalDocTestSuite
     return FunctionalDocTestSuite(
         optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE)

--- a/src/Products/Five/browser/tests/test_pagetemplatefile.py
+++ b/src/Products/Five/browser/tests/test_pagetemplatefile.py
@@ -35,14 +35,14 @@ class ViewPageTemplateFileTests(unittest.TestCase):
         self.assertEqual(vptf.id, 'dirpage1.pt')
 
     def test_pt_getEngine(self):
+        from Products.PageTemplates.Expressions import SecureModuleImporter
+        from Products.PageTemplates.Expressions import TrustedZopePathExpr
+        from Products.PageTemplates.Expressions import UnicodeAwareStringExpr
+        from zope.contentprovider.tales import TALESProviderExpression
         from zope.tales.expressions import DeferExpr
         from zope.tales.expressions import LazyExpr
         from zope.tales.expressions import NotExpr
         from zope.tales.pythonexpr import PythonExpr
-        from zope.contentprovider.tales import TALESProviderExpression
-        from Products.PageTemplates.Expressions import TrustedZopePathExpr
-        from Products.PageTemplates.Expressions import SecureModuleImporter
-        from Products.PageTemplates.Expressions import UnicodeAwareStringExpr
 
         vptf = self._makeOne('seagull.pt')
         engine = vptf.pt_getEngine()
@@ -59,9 +59,9 @@ class ViewPageTemplateFileTests(unittest.TestCase):
         self.assertEqual(engine.base_names['modules'], SecureModuleImporter)
 
     def test_pt_getContext_no_kw_no_physicalRoot(self):
+        from AccessControl.SecurityManagement import newSecurityManager
         from Products.Five.browser.pagetemplatefile import ViewMapper
         from Products.PageTemplates.Expressions import SecureModuleImporter
-        from AccessControl.SecurityManagement import newSecurityManager
         newSecurityManager(None, DummyUser('a_user'))
         context = DummyContext()
         request = DummyRequest()
@@ -191,8 +191,8 @@ class ViewMapperTests(unittest.TestCase):
         self.assertRaises(ComponentLookupError, mapper.__getitem__, 'nonesuch')
 
     def test___getitem___hit(self):
-        from zope.interface import Interface
         from zope.component import provideAdapter
+        from zope.interface import Interface
 
         def _adapt(context, request):
             return self

--- a/src/Products/Five/browser/tests/test_zope3security.py
+++ b/src/Products/Five/browser/tests/test_zope3security.py
@@ -152,6 +152,7 @@ def test_allowed_interface():
 
 
 def test_suite():
-    from Testing.ZopeTestCase import FunctionalDocTestSuite
     from doctest import ELLIPSIS
+
+    from Testing.ZopeTestCase import FunctionalDocTestSuite
     return FunctionalDocTestSuite(optionflags=ELLIPSIS)

--- a/src/Products/PageTemplates/tests/testExpressions.py
+++ b/src/Products/PageTemplates/tests/testExpressions.py
@@ -197,11 +197,11 @@ class EngineTestsBase(PlacelessSetup):
                           ec.evaluate, expr)
         # But registering an appropriate IUnicodeEncodingConflictResolver
         # should fix it
+        from Products.PageTemplates.interfaces import \
+            IUnicodeEncodingConflictResolver
+        from Products.PageTemplates.unicodeconflictresolver import \
+            StrictUnicodeEncodingConflictResolver
         from zope.component import provideUtility
-        from Products.PageTemplates.unicodeconflictresolver \
-            import StrictUnicodeEncodingConflictResolver
-        from Products.PageTemplates.interfaces \
-            import IUnicodeEncodingConflictResolver
         provideUtility(StrictUnicodeEncodingConflictResolver,
                        IUnicodeEncodingConflictResolver)
         self.assertEqual(ec.evaluate(expr), u'äüö')
@@ -264,12 +264,12 @@ class TrustedEngineTests(EngineTestsBase, unittest.TestCase):
 class UnicodeEncodingConflictResolverTests(PlacelessSetup, unittest.TestCase):
 
     def testDefaultResolver(self):
+        from Products.PageTemplates.interfaces import \
+            IUnicodeEncodingConflictResolver
+        from Products.PageTemplates.unicodeconflictresolver import \
+            DefaultUnicodeEncodingConflictResolver
         from zope.component import getUtility
         from zope.component import provideUtility
-        from Products.PageTemplates.interfaces \
-            import IUnicodeEncodingConflictResolver
-        from Products.PageTemplates.unicodeconflictresolver \
-            import DefaultUnicodeEncodingConflictResolver
         provideUtility(DefaultUnicodeEncodingConflictResolver,
                        IUnicodeEncodingConflictResolver)
         resolver = getUtility(IUnicodeEncodingConflictResolver)
@@ -277,12 +277,12 @@ class UnicodeEncodingConflictResolverTests(PlacelessSetup, unittest.TestCase):
                           resolver.resolve, None, b'\xe4\xfc\xf6', None)
 
     def testStrictResolver(self):
+        from Products.PageTemplates.interfaces import \
+            IUnicodeEncodingConflictResolver
+        from Products.PageTemplates.unicodeconflictresolver import \
+            StrictUnicodeEncodingConflictResolver
         from zope.component import getUtility
         from zope.component import provideUtility
-        from Products.PageTemplates.interfaces \
-            import IUnicodeEncodingConflictResolver
-        from Products.PageTemplates.unicodeconflictresolver \
-            import StrictUnicodeEncodingConflictResolver
         provideUtility(StrictUnicodeEncodingConflictResolver,
                        IUnicodeEncodingConflictResolver)
         resolver = getUtility(IUnicodeEncodingConflictResolver)
@@ -290,24 +290,24 @@ class UnicodeEncodingConflictResolverTests(PlacelessSetup, unittest.TestCase):
         self.assertEqual(resolver.resolve(None, text, None), text)
 
     def testIgnoringResolver(self):
+        from Products.PageTemplates.interfaces import \
+            IUnicodeEncodingConflictResolver
+        from Products.PageTemplates.unicodeconflictresolver import \
+            IgnoringUnicodeEncodingConflictResolver
         from zope.component import getUtility
         from zope.component import provideUtility
-        from Products.PageTemplates.interfaces \
-            import IUnicodeEncodingConflictResolver
-        from Products.PageTemplates.unicodeconflictresolver \
-            import IgnoringUnicodeEncodingConflictResolver
         provideUtility(IgnoringUnicodeEncodingConflictResolver,
                        IUnicodeEncodingConflictResolver)
         resolver = getUtility(IUnicodeEncodingConflictResolver)
         self.assertEqual(resolver.resolve(None, b'\xe4\xfc\xf6', None), '')
 
     def testReplacingResolver(self):
+        from Products.PageTemplates.interfaces import \
+            IUnicodeEncodingConflictResolver
+        from Products.PageTemplates.unicodeconflictresolver import \
+            ReplacingUnicodeEncodingConflictResolver
         from zope.component import getUtility
         from zope.component import provideUtility
-        from Products.PageTemplates.interfaces \
-            import IUnicodeEncodingConflictResolver
-        from Products.PageTemplates.unicodeconflictresolver \
-            import ReplacingUnicodeEncodingConflictResolver
         provideUtility(ReplacingUnicodeEncodingConflictResolver,
                        IUnicodeEncodingConflictResolver)
         resolver = getUtility(IUnicodeEncodingConflictResolver)

--- a/src/Products/PageTemplates/tests/testZopePageTemplate.py
+++ b/src/Products/PageTemplates/tests/testZopePageTemplate.py
@@ -249,8 +249,8 @@ class ZopePageTemplateFileTests(ZopeTestCase):
         useChameleonEngine()
 
     def test_class_conforms_to_IWriteLock(self):
-        from zope.interface.verify import verifyClass
         from OFS.interfaces import IWriteLock
+        from zope.interface.verify import verifyClass
         verifyClass(IWriteLock, ZopePageTemplate)
 
     def testPT_RenderWithAscii(self):

--- a/src/Products/PageTemplates/tests/test_ptfile.py
+++ b/src/Products/PageTemplates/tests/test_ptfile.py
@@ -19,11 +19,12 @@ class TypeSniffingTestCase(unittest.TestCase):
     TEMPFILENAME = tempfile.mktemp(".zpt")
 
     def setUp(self):
-        from zope.component import provideUtility
         from Products.PageTemplates.interfaces import \
             IUnicodeEncodingConflictResolver
         from Products.PageTemplates.unicodeconflictresolver import \
             DefaultUnicodeEncodingConflictResolver
+        from zope.component import provideUtility
+
         # Make sure we use the new default chameleon engine
         useChameleonEngine()
         provideUtility(DefaultUnicodeEncodingConflictResolver,

--- a/src/Products/SiteAccess/AccessRule.py
+++ b/src/Products/SiteAccess/AccessRule.py
@@ -1,2 +1,2 @@
 # BBB
-from ZPublisher.BeforeTraverse import NameCaller as AccessRule  # noqa: F401
+from ZPublisher.BeforeTraverse import NameCaller as AccessRule

--- a/src/Products/SiteAccess/AccessRule.py
+++ b/src/Products/SiteAccess/AccessRule.py
@@ -1,2 +1,6 @@
 # BBB
 from ZPublisher.BeforeTraverse import NameCaller as AccessRule
+
+
+# Use the import, to please both flake8 and isort.  'noqa' did not help.
+AccessRule

--- a/src/Products/SiteAccess/VirtualHostMonster.py
+++ b/src/Products/SiteAccess/VirtualHostMonster.py
@@ -3,7 +3,7 @@
 Defines the VirtualHostMonster class
 """
 from AccessControl.class_init import InitializeClass
-from AccessControl.Permissions import view as View  # NOQA
+from AccessControl.Permissions import view as View
 from AccessControl.SecurityInfo import ClassSecurityInfo
 from Acquisition import Implicit
 from App.special_dtml import DTMLFile

--- a/src/Products/SiteAccess/tests/testVirtualHostMonster.py
+++ b/src/Products/SiteAccess/tests/testVirtualHostMonster.py
@@ -17,8 +17,8 @@ class VHMRegressions(unittest.TestCase):
         if 'virtual_hosting' not in self.app.objectIds():
             # If ZopeLite was imported, we have no default virtual
             # host monster
-            from Products.SiteAccess.VirtualHostMonster \
-                import manage_addVirtualHostMonster
+            from Products.SiteAccess.VirtualHostMonster import \
+                manage_addVirtualHostMonster
             manage_addVirtualHostMonster(self.app, 'virtual_hosting')
         self.app.manage_addFolder('folder')
         self.app.folder.manage_addDTMLMethod('doc', '')
@@ -170,8 +170,8 @@ class VHMPort(unittest.TestCase):
         if 'virtual_hosting' not in self.app.objectIds():
             # If ZopeLite was imported, we have no default virtual
             # host monster
-            from Products.SiteAccess.VirtualHostMonster \
-                import manage_addVirtualHostMonster
+            from Products.SiteAccess.VirtualHostMonster import \
+                manage_addVirtualHostMonster
             manage_addVirtualHostMonster(self.app, 'virtual_hosting')
         self.app.manage_addFolder('folder')
         self.app.folder.manage_addDTMLMethod('doc', '')
@@ -271,9 +271,9 @@ class VHMAddingTests(unittest.TestCase):
         self.assertTrue(queryBeforeTraverse(self.root, vhm1.meta_type))
 
     def test_add_manage_addVirtualHostMonster(self):
+        from Products.SiteAccess.VirtualHostMonster import VirtualHostMonster
         from Products.SiteAccess.VirtualHostMonster import \
             manage_addVirtualHostMonster
-        from Products.SiteAccess.VirtualHostMonster import VirtualHostMonster
         from ZPublisher.BeforeTraverse import queryBeforeTraverse
         manage_addVirtualHostMonster(self.root)
 

--- a/src/Testing/ZopeTestCase/ZopeLite.py
+++ b/src/Testing/ZopeTestCase/ZopeLite.py
@@ -38,6 +38,9 @@ import Products  # NOQA
 import ZODB  # NOQA
 import Zope2  # NOQA
 import Zope2.Startup.run  # NOQA
+# Allow test authors to install Zope products into the test environment. Note
+# that installProduct() must be called at module level -- never from tests.
+from OFS.Application import get_folder_permissions  # NOQA; NOQA
 from OFS.Application import get_products
 from OFS.Application import install_package
 from OFS.Application import install_product
@@ -45,11 +48,6 @@ from OFS.Folder import Folder  # NOQA
 from Testing.ZopeTestCase import layer
 # ZODB sandbox factory
 from ZODB.DemoStorage import DemoStorage  # NOQA
-
-
-# Allow test authors to install Zope products into the test environment. Note
-# that installProduct() must be called at module level -- never from tests.
-from OFS.Application import get_folder_permissions  # NOQA; NOQA
 
 
 # Allow code to tell it is run by the test framework

--- a/src/Testing/ZopeTestCase/functional.py
+++ b/src/Testing/ZopeTestCase/functional.py
@@ -63,6 +63,7 @@ class Functional(sandbox.Sandboxed):
         '''Publishes the object at 'path' returning a response object.'''
 
         from io import BytesIO
+
         from ZPublisher.HTTPRequest import WSGIRequest as Request
         from ZPublisher.HTTPResponse import WSGIResponse
         from ZPublisher.WSGIPublisher import publish_module

--- a/src/Testing/ZopeTestCase/testBaseTestCase.py
+++ b/src/Testing/ZopeTestCase/testBaseTestCase.py
@@ -451,7 +451,8 @@ class TestRequestGarbage3(sandbox.Sandboxed, base.TestCase):
 
 
 def test_suite():
-    from unittest import TestSuite, makeSuite
+    from unittest import TestSuite
+    from unittest import makeSuite
     suite = TestSuite()
     suite.addTest(makeSuite(TestTestCase))
     suite.addTest(makeSuite(TestSetUpRaises))

--- a/src/Testing/ZopeTestCase/testFunctional.py
+++ b/src/Testing/ZopeTestCase/testFunctional.py
@@ -162,7 +162,8 @@ class TestFunctional(ZopeTestCase.FunctionalTestCase):
 
 
 def test_suite():
-    from unittest import TestSuite, makeSuite
+    from unittest import TestSuite
+    from unittest import makeSuite
     suite = TestSuite()
     suite.addTest(makeSuite(TestFunctional))
     return suite

--- a/src/Testing/ZopeTestCase/testInterfaces.py
+++ b/src/Testing/ZopeTestCase/testInterfaces.py
@@ -91,7 +91,8 @@ class TestPortalTestCase(PortalTestCase):
 
 
 def test_suite():
-    from unittest import TestSuite, makeSuite
+    from unittest import TestSuite
+    from unittest import makeSuite
     suite = TestSuite()
     suite.addTest(makeSuite(TestAbstractClasses))
     suite.addTest(makeSuite(TestBaseTestCase))

--- a/src/Testing/ZopeTestCase/testPlaceless.py
+++ b/src/Testing/ZopeTestCase/testPlaceless.py
@@ -117,7 +117,8 @@ class TestPlacelessSetUp(ZopeTestCase.ZopeTestCase):
 
 
 def test_suite():
-    from unittest import TestSuite, makeSuite
+    from unittest import TestSuite
+    from unittest import makeSuite
     suite = TestSuite()
     suite.addTest(makeSuite(TestPlacelessSetUp))
     return suite

--- a/src/Testing/ZopeTestCase/testPortalTestCase.py
+++ b/src/Testing/ZopeTestCase/testPortalTestCase.py
@@ -518,7 +518,8 @@ class TestSetUpRaises(HookTest):
 
 
 def test_suite():
-    from unittest import TestSuite, makeSuite
+    from unittest import TestSuite
+    from unittest import makeSuite
     suite = TestSuite()
     suite.addTest(makeSuite(TestPortalTestCase))
     suite.addTest(makeSuite(TestPlainUserFolder))

--- a/src/Testing/ZopeTestCase/testSkeleton.py
+++ b/src/Testing/ZopeTestCase/testSkeleton.py
@@ -30,7 +30,8 @@ class TestSomeProduct(ZopeTestCase.ZopeTestCase):
 
 
 def test_suite():
-    from unittest import TestSuite, makeSuite
+    from unittest import TestSuite
+    from unittest import makeSuite
     suite = TestSuite()
     suite.addTest(makeSuite(TestSomeProduct))
     return suite

--- a/src/Testing/ZopeTestCase/testZODBCompat.py
+++ b/src/Testing/ZopeTestCase/testZODBCompat.py
@@ -308,7 +308,8 @@ class TestTransactionAbort(ZopeTestCase.ZopeTestCase):
 
 
 def test_suite():
-    from unittest import TestSuite, makeSuite
+    from unittest import TestSuite
+    from unittest import makeSuite
     suite = TestSuite()
     suite.addTest(makeSuite(TestCopyPaste))
     suite.addTest(makeSuite(TestImportExport))

--- a/src/Testing/ZopeTestCase/testZopeTestCase.py
+++ b/src/Testing/ZopeTestCase/testZopeTestCase.py
@@ -391,7 +391,8 @@ class TestWrappingUserFolder(ZopeTestCase.ZopeTestCase):
 
 
 def test_suite():
-    from unittest import TestSuite, makeSuite
+    from unittest import TestSuite
+    from unittest import makeSuite
     suite = TestSuite()
     suite.addTest(makeSuite(TestZopeTestCase))
     suite.addTest(makeSuite(TestPlainUserFolder))

--- a/src/Testing/ZopeTestCase/utils.py
+++ b/src/Testing/ZopeTestCase/utils.py
@@ -32,7 +32,8 @@ deprecated(
 
 def appcall(func, *args, **kw):
     '''Calls a function passing 'app' as first argument.'''
-    from .base import app, close
+    from .base import app
+    from .base import close
     app = app()
     args = (app,) + args
     try:

--- a/src/Testing/ZopeTestCase/zopedoctest/testFunctionalDocTest.py
+++ b/src/Testing/ZopeTestCase/zopedoctest/testFunctionalDocTest.py
@@ -21,8 +21,8 @@ from Testing.ZopeTestCase import FunctionalDocTestSuite
 class HTTPHeaderOutputTests(unittest.TestCase):
 
     def _getTargetClass(self):
-        from Testing.ZopeTestCase.zopedoctest.functional \
-            import HTTPHeaderOutput
+        from Testing.ZopeTestCase.zopedoctest.functional import \
+            HTTPHeaderOutput
         return HTTPHeaderOutput
 
     def _makeOne(self, protocol, omit):

--- a/src/Testing/tests/test_testbrowser.py
+++ b/src/Testing/tests/test_testbrowser.py
@@ -192,7 +192,8 @@ class TestTestbrowser(FunctionalTestCase):
 
 
 def test_suite():
-    from unittest import TestSuite, makeSuite
+    from unittest import TestSuite
+    from unittest import makeSuite
     suite = TestSuite()
     suite.addTest(makeSuite(TestTestbrowser))
     return suite

--- a/src/ZPublisher/WSGIPublisher.py
+++ b/src/ZPublisher/WSGIPublisher.py
@@ -150,9 +150,9 @@ def _exc_view_created_response(exc, request, response):
         # Explicitly set the content type header if it's not there yet so
         # the response does not get served with the text/plain default.
         # But only do this when there is a body.
-        # An empty body may indicate a 304 NotModified from Plone,
+        # An empty body may indicate a 304 NotModified response,
         # and setting a content type header will change the stored header
-        # in for example Varnish.
+        # in caching servers such as Varnish.
         # See https://github.com/zopefoundation/Zope/pull/1088
         if body and not response.getHeader('Content-Type'):
             response.setHeader('Content-Type', 'text/html')

--- a/src/ZPublisher/WSGIPublisher.py
+++ b/src/ZPublisher/WSGIPublisher.py
@@ -144,13 +144,19 @@ def _exc_view_created_response(exc, request, response):
             for key, value in exc.headers.items():
                 response.setHeader(key, value)
 
+        # Set the response body to the result of calling the view.
+        body = view()
+        response.setBody(body)
+
         # Explicitly set the content type header if it's not there yet so
-        # the response doesn't get served with the text/plain default
-        if not response.getHeader('Content-Type'):
+        # the response does not get served with the text/plain default.
+        # But only do this when there is a body.
+        # An empty body may indicate a 304 NotModified from Plone,
+        # and setting a content type header will change the stored header
+        # in for example Varnish.
+        if body and not response.getHeader('Content-Type'):
             response.setHeader('Content-Type', 'text/html')
 
-        # Set the response body to the result of calling the view.
-        response.setBody(view())
         return True
 
     return False

--- a/src/ZPublisher/WSGIPublisher.py
+++ b/src/ZPublisher/WSGIPublisher.py
@@ -144,9 +144,8 @@ def _exc_view_created_response(exc, request, response):
             for key, value in exc.headers.items():
                 response.setHeader(key, value)
 
-        # Set the response body to the result of calling the view.
+        # Call the view so we can use it as the response body.
         body = view()
-        response.setBody(body)
 
         # Explicitly set the content type header if it's not there yet so
         # the response does not get served with the text/plain default.
@@ -154,9 +153,13 @@ def _exc_view_created_response(exc, request, response):
         # An empty body may indicate a 304 NotModified from Plone,
         # and setting a content type header will change the stored header
         # in for example Varnish.
+        # See https://github.com/zopefoundation/Zope/pull/1088
         if body and not response.getHeader('Content-Type'):
             response.setHeader('Content-Type', 'text/html')
 
+        # Note: setBody would set the Content-Type header to text/plain
+        # if it is not set yet, except when the body is empty.
+        response.setBody(body)
         return True
 
     return False

--- a/src/ZPublisher/WSGIPublisher.py
+++ b/src/ZPublisher/WSGIPublisher.py
@@ -153,7 +153,7 @@ def _exc_view_created_response(exc, request, response):
         # An empty body may indicate a 304 NotModified response,
         # and setting a content type header will change the stored header
         # in caching servers such as Varnish.
-        # See https://github.com/zopefoundation/Zope/pull/1088
+        # See https://github.com/zopefoundation/Zope/issues/1089
         if body and not response.getHeader('Content-Type'):
             response.setHeader('Content-Type', 'text/html')
 

--- a/src/ZPublisher/tests/testBaseRequest.py
+++ b/src/ZPublisher/tests/testBaseRequest.py
@@ -484,8 +484,8 @@ class TestRequestViewsBase(unittest.TestCase, BaseRequest_factory):
         return request
 
     def _makeDummyAclUsers(self):
-        from Acquisition import Implicit
         from AccessControl.ZopeSecurityPolicy import _noroles
+        from Acquisition import Implicit
 
         class AclUsers(Implicit):
             def validate(self, request, auth='', roles=_noroles):
@@ -625,8 +625,8 @@ class TestRequestViewsBase(unittest.TestCase, BaseRequest_factory):
 
     def _setDefaultViewName(self, name):
         from zope.component import getGlobalSiteManager
-        from zope.publisher.interfaces import IDefaultViewName
         from zope.publisher.browser import IBrowserRequest
+        from zope.publisher.interfaces import IDefaultViewName
         gsm = getGlobalSiteManager()
         gsm.registerAdapter(name, (self._dummyInterface(), IBrowserRequest),
                             IDefaultViewName, '')

--- a/src/ZPublisher/tests/testHTTPRequest.py
+++ b/src/ZPublisher/tests/testHTTPRequest.py
@@ -137,6 +137,7 @@ class HTTPRequestTests(unittest.TestCase, HTTPRequestFactoryMixin):
 
     def _processInputs(self, inputs):
         from six.moves.urllib.parse import quote_plus
+
         # Have the inputs processed, and return a HTTPRequest object
         # holding the result.
         # inputs is expected to be a list of (key, value) tuples, no CGI
@@ -163,8 +164,8 @@ class HTTPRequestTests(unittest.TestCase, HTTPRequestFactoryMixin):
         # when one is found.
         # Also raises an Assertion if a string which *should* have been
         # tainted is found, or when a tainted string is not deemed dangerous.
-        from ZPublisher.HTTPRequest import record
         from AccessControl.tainted import TaintedString
+        from ZPublisher.HTTPRequest import record
 
         retval = 0
 
@@ -911,6 +912,7 @@ class HTTPRequestTests(unittest.TestCase, HTTPRequestFactoryMixin):
 
     def test_debug_not_in_qs_still_gets_attr(self):
         from zope.publisher.base import DebugFlags
+
         # when accessing request.debug we will see the DebugFlags instance
         request = self._makeOne()
         self.assertIsInstance(request.debug, DebugFlags)
@@ -1163,8 +1165,8 @@ class HTTPRequestTests(unittest.TestCase, HTTPRequestFactoryMixin):
         self.assertIsInstance(clone, SubRequest)
 
     def test_clone_preserves_direct_interfaces(self):
-        from zope.interface import directlyProvides
         from zope.interface import Interface
+        from zope.interface import directlyProvides
 
         class IFoo(Interface):
             pass

--- a/src/ZPublisher/tests/test_WSGIPublisher.py
+++ b/src/ZPublisher/tests/test_WSGIPublisher.py
@@ -100,8 +100,8 @@ class WSGIResponseTests(unittest.TestCase):
         self.assertIn(('Date', whenstr), headers)
 
     def test_setBody_IUnboundStreamIterator(self):
-        from ZPublisher.Iterators import IUnboundStreamIterator
         from zope.interface import implementer
+        from ZPublisher.Iterators import IUnboundStreamIterator
 
         @implementer(IUnboundStreamIterator)
         class TestStreamIterator(object):
@@ -125,8 +125,8 @@ class WSGIResponseTests(unittest.TestCase):
         self.assertEqual(response._streaming, 1)
 
     def test_setBody_IStreamIterator(self):
-        from ZPublisher.Iterators import IStreamIterator
         from zope.interface import implementer
+        from ZPublisher.Iterators import IStreamIterator
 
         @implementer(IStreamIterator)
         class TestStreamIterator(object):
@@ -273,10 +273,10 @@ class TestPublishModule(ZopeTestCase):
         return publish_module(environ, start_response)
 
     def _registerView(self, factory, name, provides=None):
+        from OFS.interfaces import IApplication
         from zope.component import provideAdapter
         from zope.interface import Interface
         from zope.publisher.browser import IDefaultBrowserLayer
-        from OFS.interfaces import IApplication
         if provides is None:
             provides = Interface
         requires = (IApplication, IDefaultBrowserLayer)
@@ -425,8 +425,8 @@ class TestPublishModule(ZopeTestCase):
         self.assertTrue(app_iter is body)
 
     def test_response_is_stream(self):
-        from ZPublisher.Iterators import IStreamIterator
         from zope.interface import implementer
+        from ZPublisher.Iterators import IStreamIterator
 
         @implementer(IStreamIterator)
         class TestStreamIterator(object):
@@ -453,8 +453,8 @@ class TestPublishModule(ZopeTestCase):
         self.assertTrue(app_iter is body)
 
     def test_response_is_unboundstream(self):
-        from ZPublisher.Iterators import IUnboundStreamIterator
         from zope.interface import implementer
+        from ZPublisher.Iterators import IUnboundStreamIterator
 
         @implementer(IUnboundStreamIterator)
         class TestUnboundStreamIterator(object):
@@ -480,9 +480,9 @@ class TestPublishModule(ZopeTestCase):
         self.assertTrue(app_iter is body)
 
     def test_stream_file_wrapper(self):
-        from ZPublisher.Iterators import IStreamIterator
         from zope.interface import implementer
         from ZPublisher.HTTPResponse import WSGIResponse
+        from ZPublisher.Iterators import IStreamIterator
 
         @implementer(IStreamIterator)
         class TestStreamIterator(object):
@@ -515,9 +515,9 @@ class TestPublishModule(ZopeTestCase):
         self.assertEqual(_response.status, 200)
 
     def test_unboundstream_file_wrapper(self):
-        from ZPublisher.Iterators import IUnboundStreamIterator
         from zope.interface import implementer
         from ZPublisher.HTTPResponse import WSGIResponse
+        from ZPublisher.Iterators import IUnboundStreamIterator
 
         @implementer(IUnboundStreamIterator)
         class TestUnboundStreamIterator(object):
@@ -553,9 +553,9 @@ class TestPublishModule(ZopeTestCase):
         self.assertEqual(_response.status, 200)
 
     def test_stream_file_wrapper_without_read(self):
-        from ZPublisher.Iterators import IStreamIterator
         from zope.interface import implementer
         from ZPublisher.HTTPResponse import WSGIResponse
+        from ZPublisher.Iterators import IStreamIterator
 
         @implementer(IStreamIterator)
         class TestStreamIterator(object):
@@ -1029,8 +1029,8 @@ class CustomExceptionView(object):
 
 def registerExceptionView(for_, factory=CustomExceptionView,
                           name=u'index.html'):
-    from zope.interface import Interface
     from zope.component import getGlobalSiteManager
+    from zope.interface import Interface
     from zope.publisher.interfaces.browser import IDefaultBrowserLayer
     gsm = getGlobalSiteManager()
     gsm.registerAdapter(
@@ -1043,8 +1043,8 @@ def registerExceptionView(for_, factory=CustomExceptionView,
 
 def unregisterExceptionView(for_, factory=CustomExceptionView,
                             name=u'index.html'):
-    from zope.interface import Interface
     from zope.component import getGlobalSiteManager
+    from zope.interface import Interface
     from zope.publisher.interfaces.browser import IDefaultBrowserLayer
     gsm = getGlobalSiteManager()
     gsm.unregisterAdapter(

--- a/src/ZPublisher/tests/test_WSGIPublisher.py
+++ b/src/ZPublisher/tests/test_WSGIPublisher.py
@@ -921,6 +921,26 @@ class ExcViewCreatedTests(ZopeTestCase):
         # After rendering the response content-type header is set
         self.assertIn('text/html', response.getHeader('Content-Type'))
 
+    def testWithEmptyErrorMessage(self):
+        from OFS.DTMLMethod import addDTMLMethod
+        from zExceptions import NotFound
+        self._registerStandardErrorView()
+        response = self.app.REQUEST.RESPONSE
+        addDTMLMethod(self.app, 'standard_error_message', file='')
+        self.app.standard_error_message.raw = ''
+
+        # The response content-type header is not set before rendering
+        # the standard error template
+        self.assertFalse(response.getHeader('Content-Type'))
+
+        try:
+            self.assertTrue(self._callFUT(NotFound))
+        finally:
+            self._unregisterStandardErrorView()
+
+        # After rendering the response still no content-type header is set
+        self.assertFalse(response.getHeader('Content-Type'))
+
 
 class WSGIPublisherTests(FunctionalTestCase):
 

--- a/src/ZPublisher/tests/test_cookie.py
+++ b/src/ZPublisher/tests/test_cookie.py
@@ -107,7 +107,8 @@ class CookieParameterRegistryTests(TestCase):
         _, v = convertCookieParameter("expires", 1643714434.9)
         self.assertEqual(v, "Tue, 01 Feb 2022 11:20:34 GMT")
         # check naive datetime
-        from datetime import datetime, timedelta
+        from datetime import datetime
+        from datetime import timedelta
         tt = 2022, 2, 1, 11, 20, 34, 1, 32, -1
         _, v = convertCookieParameter("expires", datetime(*tt[:6]))
         self.assertEqual(v, "Tue, 01 Feb 2022 11:20:34 GMT")
@@ -210,6 +211,7 @@ class CookieParameterRegistryTests(TestCase):
 class GetCookiePolicyTests(TestCase):
     def tearDown(self):
         from zope.testing.cleanup import cleanUp
+
         # clear the component registry
         cleanUp()
 

--- a/src/ZTUtils/tests/testLazy.py
+++ b/src/ZTUtils/tests/testLazy.py
@@ -76,7 +76,8 @@ class TestLazyCat(unittest.TestCase, BaseSequenceTest):
         self.assertEqual(lcat.actual_result_count, 20)
 
     def test_init_multiple(self):
-        from string import hexdigits, ascii_letters
+        from string import ascii_letters
+        from string import hexdigits
         seq1 = list(range(10))
         seq2 = list(hexdigits)
         seq3 = list(ascii_letters)
@@ -84,7 +85,8 @@ class TestLazyCat(unittest.TestCase, BaseSequenceTest):
         self._compare(lcat, seq1 + seq2 + seq3)
 
     def test_init_nested(self):
-        from string import hexdigits, ascii_letters
+        from string import ascii_letters
+        from string import hexdigits
         seq1 = list(range(10))
         seq2 = list(hexdigits)
         seq3 = list(ascii_letters)
@@ -93,7 +95,8 @@ class TestLazyCat(unittest.TestCase, BaseSequenceTest):
         self._compare(lcat, seq1 + seq2 + seq3)
 
     def test_slicing(self):
-        from string import hexdigits, ascii_letters
+        from string import ascii_letters
+        from string import hexdigits
         seq1 = list(range(10))
         seq2 = list(hexdigits)
         seq3 = list(ascii_letters)
@@ -152,7 +155,8 @@ class TestLazyMap(TestLazyCat):
         return LazyMap(mapfunc, totalseq)
 
     def test_map(self):
-        from string import hexdigits, ascii_letters
+        from string import ascii_letters
+        from string import hexdigits
         seq1 = list(range(10))
         seq2 = list(hexdigits)
         seq3 = list(ascii_letters)
@@ -189,7 +193,8 @@ class TestLazyFilter(TestLazyCat):
         return LazyFilter(filter, totalseq)
 
     def test_filter(self):
-        from string import hexdigits, ascii_letters
+        from string import ascii_letters
+        from string import hexdigits
         seq1 = list(range(10))
         seq2 = list(hexdigits)
         seq3 = list(ascii_letters)
@@ -235,7 +240,8 @@ class TestLazyMop(TestLazyCat):
         return LazyMop(mapfunc, totalseq)
 
     def test_mop(self):
-        from string import hexdigits, ascii_letters
+        from string import ascii_letters
+        from string import hexdigits
         seq1 = list(range(10))
         seq2 = list(hexdigits)
         seq3 = list(ascii_letters)

--- a/src/ZTUtils/tests/testTree.py
+++ b/src/ZTUtils/tests/testTree.py
@@ -448,6 +448,7 @@ class TreeTests(unittest.TestCase):
 
     def testDecodeDecompressedSizeLimit(self):
         import zlib
+
         from ZTUtils.Tree import b2a
         big = b2a(zlib.compress(b'x' * (1024 * 1100)))
         self.assertTrue(len(big) < 8192)  # Must be under the input size limit

--- a/src/Zope2/App/patches/persistence.py
+++ b/src/Zope2/App/patches/persistence.py
@@ -8,6 +8,6 @@ def apply_patches():
         return
     _patched = True
 
-    from Persistence import Persistent
     from AccessControl.class_init import InitializeClass
+    from Persistence import Persistent
     Persistent.__class_init__ = InitializeClass

--- a/src/Zope2/App/tests/test_safe_formatter.py
+++ b/src/Zope2/App/tests/test_safe_formatter.py
@@ -5,8 +5,9 @@ from zExceptions import Unauthorized
 
 
 try:
-    from html import escape
     import functools
+    from html import escape
+
     # We do not want escaped " and ', as PageTemplate neither does it:
     escape = functools.partial(escape, quote=False)
 except ImportError:  # PY2
@@ -135,6 +136,7 @@ class FormatterFunctionalTest(FunctionalTestCase):
 
     def test_access_to_private_content_not_allowed_via_any_attribute(self):
         from Products.PageTemplates.ZopePageTemplate import ZopePageTemplate
+
         # If access to _delObject would be allowed, it would still only say
         # something like 'bound method _delObject', without actually deleting
         # anything, because methods are not executed in str.format, but there
@@ -150,10 +152,10 @@ class FormatterFunctionalTest(FunctionalTestCase):
             str(err.exception))
 
     def assert_is_checked_via_security_manager(self, pt_content):
-        from Products.PageTemplates.ZopePageTemplate import ZopePageTemplate
-        from AccessControl.SecurityManager import setSecurityPolicy
-        from AccessControl.SecurityManagement import noSecurityManager
         from AccessControl.SecurityManagement import getSecurityManager
+        from AccessControl.SecurityManagement import noSecurityManager
+        from AccessControl.SecurityManager import setSecurityPolicy
+        from Products.PageTemplates.ZopePageTemplate import ZopePageTemplate
 
         pt = ZopePageTemplate('mytemplate', pt_content)
         noSecurityManager()

--- a/src/Zope2/Startup/datatypes.py
+++ b/src/Zope2/Startup/datatypes.py
@@ -213,7 +213,9 @@ def default_zpublisher_encoding(value):
     if PY2:
         # unicode is not acceptable as encoding in HTTP headers:
         value = str(value)
-    from ZPublisher import Converters, HTTPRequest, HTTPResponse
+    from ZPublisher import Converters
+    from ZPublisher import HTTPRequest
+    from ZPublisher import HTTPResponse
     Converters.default_encoding = value
     HTTPRequest.default_encoding = value
     HTTPRequest.HTTPRequest.charset = value

--- a/src/Zope2/Startup/run.py
+++ b/src/Zope2/Startup/run.py
@@ -43,7 +43,8 @@ def _set_wsgi_config(configfile=None):
     """ Configure a Zope instance based on ZopeWSGIOptions.
     Optionally accept a configfile argument (string path) in order
     to specify where the configuration file exists. """
-    from Zope2.Startup import options, handlers
+    from Zope2.Startup import handlers
+    from Zope2.Startup import options
     opts = options.ZopeWSGIOptions(configfile=configfile)()
     handlers.handleWSGIConfig(opts.configroot, opts.confighandlers)
     import App.config

--- a/src/Zope2/utilities/finder.py
+++ b/src/Zope2/utilities/finder.py
@@ -27,9 +27,10 @@ class ZopeFinder(object):
         # given a config file, return a Zope application object
         if config_file is None:
             config_file = self.get_zope_conf()
-        from Zope2.Startup import options, handlers
         import App.config
         import Zope2
+        from Zope2.Startup import handlers
+        from Zope2.Startup import options
         opts = options.ZopeWSGIOptions(configfile=config_file)()
         handlers.handleWSGIConfig(opts.configroot, opts.confighandlers)
         App.config.setConfiguration(opts.configroot)

--- a/src/webdav/tests/testResource.py
+++ b/src/webdav/tests/testResource.py
@@ -11,6 +11,7 @@ MS_DAV_AGENT = "Microsoft Data Access Internet Publishing Provider DAV"
 
 def make_request_response(environ=None):
     from io import StringIO
+
     from ZPublisher.HTTPRequest import HTTPRequest
     from ZPublisher.HTTPResponse import HTTPResponse
 

--- a/src/zmi/styles/tests.py
+++ b/src/zmi/styles/tests.py
@@ -10,8 +10,8 @@ basic_auth = "{0.user_name}:{0.user_password}".format(Testing.ZopeTestCase)
 def setupZCML():
     """Set up the ZCML needed to render the ZMI and the assets."""
     import AccessControl
-    import Zope2.App
     import zmi.styles
+    import Zope2.App
     zcml.load_config('meta.zcml', Zope2.App)
     zcml.load_config('permissions.zcml', AccessControl)
     zcml.load_config('traversing.zcml', Zope2.App)

--- a/tox.ini
+++ b/tox.ini
@@ -71,7 +71,7 @@ commands =
     isort {toxinidir}/src {toxinidir}/setup.py []
 
 [testenv:docs]
-basepython = python3
+basepython = python3.8
 skip_install = false
 deps =
     jinja2

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ allowlist_externals =
 commands_pre =
     mkdir -p {toxinidir}/parts/flake8
 commands =
-    isort --check-only --recursive --diff {toxinidir}/src {toxinidir}/setup.py
+    isort --check-only --diff {toxinidir}/src {toxinidir}/setup.py
     flake8 {toxinidir}/src {toxinidir}/setup.py
     check-manifest
     check-python-versions
@@ -56,7 +56,7 @@ deps =
     check-manifest
     check-python-versions
     flake8
-    isort <5
+    isort
     # Useful flake8 plugins that are Python and Plone specific:
     flake8-coding
     flake8-debugger


### PR DESCRIPTION
Only set response header Content-Type as text/html on exception views when the response has content.

This fixes a problem in Plone with caching and 304 NotModified.
I need to describe this more, and fix the tests. Need to go now though.