### PR TITLE
No Content-Type text/html on empty exception views [master]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 5.8 (unreleased)
 ----------------
 
+- Only set response header Content-Type as text/html on exception views when the response has content.
+
 - Drop support for Python 3.6, it has been in end-of-life status for a while.
 
 - Update to newest compatible versions of dependencies.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,9 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 5.8 (unreleased)
 ----------------
 
-- Only set response header Content-Type as text/html on exception views when the response has content.
+- Only set response header Content-Type as text/html on exception views when
+  the response has content.
+  (`#1089 <https://github.com/zopefoundation/Zope/issues/1089>`_)
 
 - Drop support for Python 3.6, it has been in end-of-life status for a while.
 

--- a/src/ZPublisher/WSGIPublisher.py
+++ b/src/ZPublisher/WSGIPublisher.py
@@ -149,9 +149,8 @@ def _exc_view_created_response(exc, request, response):
             for key, value in exc.headers.items():
                 response.setHeader(key, value)
 
-        # Set the response body to the result of calling the view.
+        # Call the view so we can use it as the response body.
         body = view()
-        response.setBody(body)
 
         # Explicitly set the content type header if it's not there yet so
         # the response does not get served with the text/plain default.
@@ -159,9 +158,13 @@ def _exc_view_created_response(exc, request, response):
         # An empty body may indicate a 304 NotModified from Plone,
         # and setting a content type header will change the stored header
         # in for example Varnish.
+        # See https://github.com/zopefoundation/Zope/pull/1088
         if body and not response.getHeader('Content-Type'):
             response.setHeader('Content-Type', 'text/html')
 
+        # Note: setBody would set the Content-Type header to text/plain
+        # if it is not set yet, except when the body is empty.
+        response.setBody(body)
         return True
 
     return False

--- a/src/ZPublisher/WSGIPublisher.py
+++ b/src/ZPublisher/WSGIPublisher.py
@@ -149,13 +149,19 @@ def _exc_view_created_response(exc, request, response):
             for key, value in exc.headers.items():
                 response.setHeader(key, value)
 
+        # Set the response body to the result of calling the view.
+        body = view()
+        response.setBody(body)
+
         # Explicitly set the content type header if it's not there yet so
-        # the response doesn't get served with the text/plain default
-        if not response.getHeader('Content-Type'):
+        # the response does not get served with the text/plain default.
+        # But only do this when there is a body.
+        # An empty body may indicate a 304 NotModified from Plone,
+        # and setting a content type header will change the stored header
+        # in for example Varnish.
+        if body and not response.getHeader('Content-Type'):
             response.setHeader('Content-Type', 'text/html')
 
-        # Set the response body to the result of calling the view.
-        response.setBody(view())
         return True
 
     return False

--- a/src/ZPublisher/WSGIPublisher.py
+++ b/src/ZPublisher/WSGIPublisher.py
@@ -155,10 +155,10 @@ def _exc_view_created_response(exc, request, response):
         # Explicitly set the content type header if it's not there yet so
         # the response does not get served with the text/plain default.
         # But only do this when there is a body.
-        # An empty body may indicate a 304 NotModified from Plone,
+        # An empty body may indicate a 304 NotModified response,
         # and setting a content type header will change the stored header
-        # in for example Varnish.
-        # See https://github.com/zopefoundation/Zope/pull/1088
+        # in caching servers such as Varnish.
+        # See https://github.com/zopefoundation/Zope/issues/1089
         if body and not response.getHeader('Content-Type'):
             response.setHeader('Content-Type', 'text/html')
 

--- a/src/ZPublisher/tests/test_WSGIPublisher.py
+++ b/src/ZPublisher/tests/test_WSGIPublisher.py
@@ -919,6 +919,26 @@ class ExcViewCreatedTests(ZopeTestCase):
         # After rendering the response content-type header is set
         self.assertIn('text/html', response.getHeader('Content-Type'))
 
+    def testWithEmptyErrorMessage(self):
+        from OFS.DTMLMethod import addDTMLMethod
+        from zExceptions import NotFound
+        self._registerStandardErrorView()
+        response = self.app.REQUEST.RESPONSE
+        addDTMLMethod(self.app, 'standard_error_message', file='')
+        self.app.standard_error_message.raw = ''
+
+        # The response content-type header is not set before rendering
+        # the standard error template
+        self.assertFalse(response.getHeader('Content-Type'))
+
+        try:
+            self.assertTrue(self._callFUT(NotFound))
+        finally:
+            self._unregisterStandardErrorView()
+
+        # After rendering the response still no content-type header is set
+        self.assertFalse(response.getHeader('Content-Type'))
+
 
 class WSGIPublisherTests(FunctionalTestCase):
 


### PR DESCRIPTION
Fixes issue #1089 for Zope 5.