### PR TITLE
Get rid of DeprecationWarnings during unit tests

### DIFF
--- a/src/OFS/tests/testChownRecursive.py
+++ b/src/OFS/tests/testChownRecursive.py
@@ -59,6 +59,5 @@ class TestRecursiveChangeOwnership(ZopeTestCase.ZopeTestCase):
 
 
 def test_suite():
-    return unittest.TestSuite((
-        unittest.makeSuite(TestRecursiveChangeOwnership),
-    ))
+    return unittest.defaultTestLoader.loadTestsFromTestCase(
+        TestRecursiveChangeOwnership)

--- a/src/OFS/tests/testTraverse.py
+++ b/src/OFS/tests/testTraverse.py
@@ -691,8 +691,9 @@ def test_view_doesnt_shadow_attribute():
 
 
 def test_suite():
-    suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(TestTraverse))
     from Testing.ZopeTestCase import FunctionalDocTestSuite
-    suite.addTest(FunctionalDocTestSuite())
-    return suite
+
+    return unittest.TestSuite((
+        unittest.defaultTestLoader.loadTestsFromTestCase(TestTraverse),
+        FunctionalDocTestSuite(),
+        ))

--- a/src/OFS/tests/testTraverse.py
+++ b/src/OFS/tests/testTraverse.py
@@ -696,4 +696,4 @@ def test_suite():
     return unittest.TestSuite((
         unittest.defaultTestLoader.loadTestsFromTestCase(TestTraverse),
         FunctionalDocTestSuite(),
-        ))
+    ))

--- a/src/OFS/tests/test_Uninstalled.py
+++ b/src/OFS/tests/test_Uninstalled.py
@@ -145,4 +145,4 @@ def test_suite():
         unittest.defaultTestLoader.loadTestsFromTestCase(TestsOfBroken),
         unittest.defaultTestLoader.loadTestsFromTestCase(
             TestsIntegratedBroken),
-        ))
+    ))

--- a/src/OFS/tests/test_Uninstalled.py
+++ b/src/OFS/tests/test_Uninstalled.py
@@ -141,7 +141,8 @@ class TestsIntegratedBroken(base.TestCase):
 
 
 def test_suite():
-    suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(TestsOfBroken))
-    suite.addTest(unittest.makeSuite(TestsIntegratedBroken))
-    return suite
+    return unittest.TestSuite((
+        unittest.defaultTestLoader.loadTestsFromTestCase(TestsOfBroken),
+        unittest.defaultTestLoader.loadTestsFromTestCase(
+            TestsIntegratedBroken),
+        ))

--- a/src/Products/Five/browser/tests/pages.txt
+++ b/src/Products/Five/browser/tests/pages.txt
@@ -171,12 +171,12 @@ try to access some protected stuff.  Let's not forgot to login again,
 of course:
 
   >>> from AccessControl import allow_module
-  >>> allow_module('smtpd')
+  >>> allow_module('pprint')
   >>> self.logout()
   >>> view = self.folder.unrestrictedTraverse('testoid/security.html')
   >>> print(view())
   <div>NoneType</div>
-  <div>smtpd</div>
+  <div>pprint</div>
   >>> self.login('manager')
 
 Test pages registered through the <five:pagesFromDirectory /> directive:

--- a/src/Products/Five/browser/tests/security.pt
+++ b/src/Products/Five/browser/tests/security.pt
@@ -1,5 +1,5 @@
 <div tal:define="comment string:Testing unrestricted code"
       tal:content="python:None.__class__.__name__" />
 <div tal:define="comment string:Testing unrestricted modules access;
-                 smtpd nocall:modules/smtpd"
-      tal:content="python:smtpd.__name__" />
+                 pprint nocall:modules/pprint"
+      tal:content="python:pprint.__name__" />

--- a/src/Products/Five/browser/tests/test_pages.py
+++ b/src/Products/Five/browser/tests/test_pages.py
@@ -159,9 +159,10 @@ def test_suite():
     from Testing.ZopeTestCase import FunctionalDocFileSuite
     from Testing.ZopeTestCase import ZopeDocFileSuite
     from Testing.ZopeTestCase import ZopeDocTestSuite
+
     return unittest.TestSuite((
         ZopeDocTestSuite(),
-        unittest.makeSuite(TestPublishTraverse),
+        unittest.defaultTestLoader.loadTestsFromTestCase(TestPublishTraverse),
         ZopeDocFileSuite('pages.txt', package='Products.Five.browser.tests'),
         FunctionalDocFileSuite('pages_ftest.txt',
                                package='Products.Five.browser.tests'),

--- a/src/Products/PageTemplates/tests/testZopePageTemplate.py
+++ b/src/Products/PageTemplates/tests/testZopePageTemplate.py
@@ -569,12 +569,15 @@ class DummyFileUpload:
 
 def test_suite():
     return unittest.TestSuite((
-        unittest.makeSuite(ZPTRegressions),
-        unittest.makeSuite(ZPTUtilsTests),
-        unittest.makeSuite(ZPTMacros),
-        unittest.makeSuite(ZopePageTemplateFileTests),
-        unittest.makeSuite(ZPTUnicodeEncodingConflictResolution),
-        unittest.makeSuite(ZPTBrowserTests),
-        unittest.makeSuite(PreferredCharsetUnicodeResolverTests),
-        unittest.makeSuite(SrcTests),
+        unittest.defaultTestLoader.loadTestsFromTestCase(ZPTRegressions),
+        unittest.defaultTestLoader.loadTestsFromTestCase(ZPTUtilsTests),
+        unittest.defaultTestLoader.loadTestsFromTestCase(ZPTMacros),
+        unittest.defaultTestLoader.loadTestsFromTestCase(
+            ZopePageTemplateFileTests),
+        unittest.defaultTestLoader.loadTestsFromTestCase(
+            ZPTUnicodeEncodingConflictResolution),
+        unittest.defaultTestLoader.loadTestsFromTestCase(ZPTBrowserTests),
+        unittest.defaultTestLoader.loadTestsFromTestCase(
+            PreferredCharsetUnicodeResolverTests),
+        unittest.defaultTestLoader.loadTestsFromTestCase(SrcTests),
     ))

--- a/src/Products/PageTemplates/tests/test_engine.py
+++ b/src/Products/PageTemplates/tests/test_engine.py
@@ -109,6 +109,4 @@ class TestPatches(Sandboxed, ZopeTestCase):
 
 
 def test_suite():
-    return unittest.TestSuite((
-        unittest.makeSuite(TestPatches),
-    ))
+    return unittest.defaultTestLoader.loadTestsFromTestCase(TestPatches)

--- a/src/Products/PageTemplates/tests/test_pagetemplate.py
+++ b/src/Products/PageTemplates/tests/test_pagetemplate.py
@@ -83,6 +83,5 @@ class TestPageTemplateFile(ZopeTestCase):
 
 
 def test_suite():
-    return unittest.TestSuite((
-        unittest.makeSuite(TestPageTemplateFile),
-    ))
+    return unittest.defaultTestLoader.loadTestsFromTestCase(
+        TestPageTemplateFile)

--- a/src/Products/PageTemplates/tests/test_persistenttemplate.py
+++ b/src/Products/PageTemplates/tests/test_persistenttemplate.py
@@ -240,6 +240,4 @@ class TestPersistent(ZopeTestCase):
 
 
 def test_suite():
-    return unittest.TestSuite((
-        unittest.makeSuite(TestPersistent),
-    ))
+    return unittest.defaultTestLoader.loadTestsFromTestCase(TestPersistent)

--- a/src/Products/PageTemplates/tests/test_viewpagetemplatefile.py
+++ b/src/Products/PageTemplates/tests/test_viewpagetemplatefile.py
@@ -87,6 +87,5 @@ class TestPageTemplateFile(ZopeTestCase):
 
 
 def test_suite():
-    return unittest.TestSuite((
-        unittest.makeSuite(TestPageTemplateFile),
-    ))
+    return unittest.defaultTestLoader.loadTestsFromTestCase(
+        TestPageTemplateFile)

--- a/src/Testing/ZopeTestCase/testBaseTestCase.py
+++ b/src/Testing/ZopeTestCase/testBaseTestCase.py
@@ -465,4 +465,4 @@ def test_suite():
         unittest.defaultTestLoader.loadTestsFromTestCase(TestRequestGarbage1),
         unittest.defaultTestLoader.loadTestsFromTestCase(TestRequestGarbage2),
         unittest.defaultTestLoader.loadTestsFromTestCase(TestRequestGarbage3),
-        ))
+    ))

--- a/src/Testing/ZopeTestCase/testBaseTestCase.py
+++ b/src/Testing/ZopeTestCase/testBaseTestCase.py
@@ -20,6 +20,7 @@ example test cases. See testSkeleton.py for a quick
 way of getting started.
 """
 import gc
+import unittest
 
 import transaction
 from AccessControl import getSecurityManager
@@ -451,17 +452,17 @@ class TestRequestGarbage3(sandbox.Sandboxed, base.TestCase):
 
 
 def test_suite():
-    from unittest import TestSuite
-    from unittest import makeSuite
-    suite = TestSuite()
-    suite.addTest(makeSuite(TestTestCase))
-    suite.addTest(makeSuite(TestSetUpRaises))
-    suite.addTest(makeSuite(TestTearDownRaises))
-    suite.addTest(makeSuite(TestConnectionRegistry))
-    suite.addTest(makeSuite(TestApplicationRegistry))
-    suite.addTest(makeSuite(TestListConverter))
-    suite.addTest(makeSuite(TestRequestVariables))
-    suite.addTest(makeSuite(TestRequestGarbage1))
-    suite.addTest(makeSuite(TestRequestGarbage2))
-    suite.addTest(makeSuite(TestRequestGarbage3))
-    return suite
+    return unittest.TestSuite((
+        unittest.defaultTestLoader.loadTestsFromTestCase(TestTestCase),
+        unittest.defaultTestLoader.loadTestsFromTestCase(TestSetUpRaises),
+        unittest.defaultTestLoader.loadTestsFromTestCase(TestTearDownRaises),
+        unittest.defaultTestLoader.loadTestsFromTestCase(
+            TestConnectionRegistry),
+        unittest.defaultTestLoader.loadTestsFromTestCase(
+            TestApplicationRegistry),
+        unittest.defaultTestLoader.loadTestsFromTestCase(TestListConverter),
+        unittest.defaultTestLoader.loadTestsFromTestCase(TestRequestVariables),
+        unittest.defaultTestLoader.loadTestsFromTestCase(TestRequestGarbage1),
+        unittest.defaultTestLoader.loadTestsFromTestCase(TestRequestGarbage2),
+        unittest.defaultTestLoader.loadTestsFromTestCase(TestRequestGarbage3),
+        ))

--- a/src/Testing/ZopeTestCase/testFunctional.py
+++ b/src/Testing/ZopeTestCase/testFunctional.py
@@ -160,8 +160,6 @@ class TestFunctional(ZopeTestCase.FunctionalTestCase):
 
 
 def test_suite():
-    from unittest import TestSuite
-    from unittest import makeSuite
-    suite = TestSuite()
-    suite.addTest(makeSuite(TestFunctional))
-    return suite
+    import unittest
+
+    return unittest.defaultTestLoader.loadTestsFromTestCase(TestFunctional)

--- a/src/Testing/ZopeTestCase/testInterfaces.py
+++ b/src/Testing/ZopeTestCase/testInterfaces.py
@@ -100,4 +100,4 @@ def test_suite():
         unittest.defaultTestLoader.loadTestsFromTestCase(
             TestFunctionalTestCase),
         unittest.defaultTestLoader.loadTestsFromTestCase(TestPortalTestCase),
-        ))
+    ))

--- a/src/Testing/ZopeTestCase/testInterfaces.py
+++ b/src/Testing/ZopeTestCase/testInterfaces.py
@@ -13,6 +13,8 @@
 """Interface tests
 """
 
+import unittest
+
 from Testing.ZopeTestCase import Functional
 from Testing.ZopeTestCase import FunctionalTestCase
 from Testing.ZopeTestCase import PortalTestCase
@@ -91,12 +93,11 @@ class TestPortalTestCase(PortalTestCase):
 
 
 def test_suite():
-    from unittest import TestSuite
-    from unittest import makeSuite
-    suite = TestSuite()
-    suite.addTest(makeSuite(TestAbstractClasses))
-    suite.addTest(makeSuite(TestBaseTestCase))
-    suite.addTest(makeSuite(TestZopeTestCase))
-    suite.addTest(makeSuite(TestFunctionalTestCase))
-    suite.addTest(makeSuite(TestPortalTestCase))
-    return suite
+    return unittest.TestSuite((
+        unittest.defaultTestLoader.loadTestsFromTestCase(TestAbstractClasses),
+        unittest.defaultTestLoader.loadTestsFromTestCase(TestBaseTestCase),
+        unittest.defaultTestLoader.loadTestsFromTestCase(TestZopeTestCase),
+        unittest.defaultTestLoader.loadTestsFromTestCase(
+            TestFunctionalTestCase),
+        unittest.defaultTestLoader.loadTestsFromTestCase(TestPortalTestCase),
+        ))

--- a/src/Testing/ZopeTestCase/testPlaceless.py
+++ b/src/Testing/ZopeTestCase/testPlaceless.py
@@ -13,6 +13,8 @@
 """Placeless setup tests
 """
 
+import unittest
+
 from Testing import ZopeTestCase
 from Testing.ZopeTestCase.placeless import setUp
 from Testing.ZopeTestCase.placeless import tearDown
@@ -117,8 +119,4 @@ class TestPlacelessSetUp(ZopeTestCase.ZopeTestCase):
 
 
 def test_suite():
-    from unittest import TestSuite
-    from unittest import makeSuite
-    suite = TestSuite()
-    suite.addTest(makeSuite(TestPlacelessSetUp))
-    return suite
+    return unittest.defaultTestLoader.loadTestsFromTestCase(TestPlacelessSetUp)

--- a/src/Testing/ZopeTestCase/testPortalTestCase.py
+++ b/src/Testing/ZopeTestCase/testPortalTestCase.py
@@ -20,6 +20,8 @@ example test cases. See testSkeleton.py for a quick
 way of getting started.
 """
 
+import unittest
+
 import transaction
 from AccessControl import getSecurityManager
 from Acquisition import aq_base
@@ -518,11 +520,10 @@ class TestSetUpRaises(HookTest):
 
 
 def test_suite():
-    from unittest import TestSuite
-    from unittest import makeSuite
-    suite = TestSuite()
-    suite.addTest(makeSuite(TestPortalTestCase))
-    suite.addTest(makeSuite(TestPlainUserFolder))
-    suite.addTest(makeSuite(TestWrappingUserFolder))
-    suite.addTest(makeSuite(TestSetUpRaises))
-    return suite
+    return unittest.TestSuite((
+        unittest.defaultTestLoader.loadTestsFromTestCase(TestPortalTestCase),
+        unittest.defaultTestLoader.loadTestsFromTestCase(TestPlainUserFolder),
+        unittest.defaultTestLoader.loadTestsFromTestCase(
+            TestWrappingUserFolder),
+        unittest.defaultTestLoader.loadTestsFromTestCase(TestSetUpRaises),
+        ))

--- a/src/Testing/ZopeTestCase/testPortalTestCase.py
+++ b/src/Testing/ZopeTestCase/testPortalTestCase.py
@@ -526,4 +526,4 @@ def test_suite():
         unittest.defaultTestLoader.loadTestsFromTestCase(
             TestWrappingUserFolder),
         unittest.defaultTestLoader.loadTestsFromTestCase(TestSetUpRaises),
-        ))
+    ))

--- a/src/Testing/ZopeTestCase/testSkeleton.py
+++ b/src/Testing/ZopeTestCase/testSkeleton.py
@@ -30,8 +30,6 @@ class TestSomeProduct(ZopeTestCase.ZopeTestCase):
 
 
 def test_suite():
-    from unittest import TestSuite
-    from unittest import makeSuite
-    suite = TestSuite()
-    suite.addTest(makeSuite(TestSomeProduct))
-    return suite
+    import unittest
+
+    return unittest.defaultTestLoader.loadTestsFromTestCase(TestSomeProduct)

--- a/src/Testing/ZopeTestCase/testZODBCompat.py
+++ b/src/Testing/ZopeTestCase/testZODBCompat.py
@@ -345,4 +345,4 @@ def test_suite():
         unittest.defaultTestLoader.loadTestsFromTestCase(
             TestAttributesOfDirtyObjects),
         unittest.defaultTestLoader.loadTestsFromTestCase(TestTransactionAbort),
-        ))
+    ))

--- a/src/Testing/ZopeTestCase/testZODBCompat.py
+++ b/src/Testing/ZopeTestCase/testZODBCompat.py
@@ -18,6 +18,7 @@ work if a savepoint is made before performing the respective operation.
 
 import os
 import tempfile
+import unittest
 
 from AccessControl.Permissions import add_documents_images_and_files
 from AccessControl.Permissions import delete_objects
@@ -336,12 +337,12 @@ class TestTransactionAbort(ZopeTestCase.ZopeTestCase):
 
 
 def test_suite():
-    from unittest import TestSuite
-    from unittest import makeSuite
-    suite = TestSuite()
-    suite.addTest(makeSuite(TestCopyPaste))
-    suite.addTest(makeSuite(TestImportExport))
-    suite.addTest(makeSuite(TestAttributesOfCleanObjects))
-    suite.addTest(makeSuite(TestAttributesOfDirtyObjects))
-    suite.addTest(makeSuite(TestTransactionAbort))
-    return suite
+    return unittest.TestSuite((
+        unittest.defaultTestLoader.loadTestsFromTestCase(TestCopyPaste),
+        unittest.defaultTestLoader.loadTestsFromTestCase(TestImportExport),
+        unittest.defaultTestLoader.loadTestsFromTestCase(
+            TestAttributesOfCleanObjects),
+        unittest.defaultTestLoader.loadTestsFromTestCase(
+            TestAttributesOfDirtyObjects),
+        unittest.defaultTestLoader.loadTestsFromTestCase(TestTransactionAbort),
+        ))

--- a/src/Testing/ZopeTestCase/testZopeTestCase.py
+++ b/src/Testing/ZopeTestCase/testZopeTestCase.py
@@ -398,4 +398,4 @@ def test_suite():
         unittest.defaultTestLoader.loadTestsFromTestCase(TestPlainUserFolder),
         unittest.defaultTestLoader.loadTestsFromTestCase(
             TestWrappingUserFolder),
-        ))
+    ))

--- a/src/Testing/ZopeTestCase/testZopeTestCase.py
+++ b/src/Testing/ZopeTestCase/testZopeTestCase.py
@@ -20,6 +20,8 @@ example test cases. See testSkeleton.py for a quick
 way of getting started.
 """
 
+import unittest
+
 import transaction
 from AccessControl import getSecurityManager
 from Acquisition import aq_base
@@ -391,10 +393,9 @@ class TestWrappingUserFolder(ZopeTestCase.ZopeTestCase):
 
 
 def test_suite():
-    from unittest import TestSuite
-    from unittest import makeSuite
-    suite = TestSuite()
-    suite.addTest(makeSuite(TestZopeTestCase))
-    suite.addTest(makeSuite(TestPlainUserFolder))
-    suite.addTest(makeSuite(TestWrappingUserFolder))
-    return suite
+    return unittest.TestSuite((
+        unittest.defaultTestLoader.loadTestsFromTestCase(TestZopeTestCase),
+        unittest.defaultTestLoader.loadTestsFromTestCase(TestPlainUserFolder),
+        unittest.defaultTestLoader.loadTestsFromTestCase(
+            TestWrappingUserFolder),
+        ))

--- a/src/Testing/ZopeTestCase/zopedoctest/testAuthHeaderTest.py
+++ b/src/Testing/ZopeTestCase/zopedoctest/testAuthHeaderTest.py
@@ -13,8 +13,7 @@
 """Test for auth_header
 """
 
-from unittest import TestSuite
-from unittest import makeSuite
+import unittest
 
 from Testing.ZopeTestCase import TestCase
 from Testing.ZopeTestCase import zopedoctest
@@ -49,6 +48,4 @@ class AuthHeaderTestCase(TestCase):
 
 
 def test_suite():
-    return TestSuite((
-        makeSuite(AuthHeaderTestCase),
-    ))
+    return unittest.defaultTestLoader.loadTestsFromTestCase(AuthHeaderTestCase)

--- a/src/Testing/ZopeTestCase/zopedoctest/testFunctionalDocTest.py
+++ b/src/Testing/ZopeTestCase/zopedoctest/testFunctionalDocTest.py
@@ -124,7 +124,8 @@ def setUp(self):
 
 def test_suite():
     return unittest.TestSuite((
-        unittest.makeSuite(HTTPHeaderOutputTests),
+        unittest.defaultTestLoader.loadTestsFromTestCase(
+            HTTPHeaderOutputTests),
         FunctionalDocTestSuite(setUp=setUp),
         FunctionalDocFileSuite('FunctionalDocTest.txt', setUp=setUp),
     ))

--- a/src/Testing/tests/test_testbrowser.py
+++ b/src/Testing/tests/test_testbrowser.py
@@ -14,6 +14,7 @@
 """Tests for the testbrowser module.
 """
 
+import unittest
 from urllib.error import HTTPError
 
 import transaction
@@ -192,8 +193,4 @@ class TestTestbrowser(FunctionalTestCase):
 
 
 def test_suite():
-    from unittest import TestSuite
-    from unittest import makeSuite
-    suite = TestSuite()
-    suite.addTest(makeSuite(TestTestbrowser))
-    return suite
+    return unittest.defaultTestLoader.loadTestsFromTestCase(TestTestbrowser)

--- a/src/Zope2/App/tests/test_startup.py
+++ b/src/Zope2/App/tests/test_startup.py
@@ -74,6 +74,4 @@ class StartupTests(ZopeTestCase):
 
 
 def test_suite():
-    suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(StartupTests))
-    return suite
+    return unittest.defaultTestLoader.loadTestsFromTestCase(StartupTests)


### PR DESCRIPTION
See #1091 - Fixes at least those parts that are triggered by Zope itself.
