### PR TITLE
Sanitize tainting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ https://zope.readthedocs.io/en/2.13/CHANGES.html
 4.8.8 (unreleased)
 ------------------
 
+- Sanitize tainting fixing
+  `#1095 <https://github.com/zopefoundation/Zope/issues/1095>`_
+
 
 4.8.7 (2023-01-10)
 ------------------

--- a/src/ZPublisher/HTTPRequest.py
+++ b/src/ZPublisher/HTTPRequest.py
@@ -31,7 +31,8 @@ from six import text_type
 from six.moves.urllib.parse import unquote
 from six.moves.urllib.parse import urlparse
 
-from AccessControl.tainted import should_be_tainted
+from AccessControl.tainted import \
+     should_be_tainted as base_should_be_tainted
 from AccessControl.tainted import taint_string
 from zope.component import queryUtility
 from zope.i18n.interfaces import IUserPreferredLanguages
@@ -443,22 +444,11 @@ class HTTPRequest(BaseRequest):
         # vars with the same name - they are more like default values
         # for names not otherwise specified in the form.
         cookies = {}
-        taintedcookies = {}
         k = get_env('HTTP_COOKIE', '')
         if k:
             parse_cookie(k, cookies)
-            for k, v in cookies.items():
-                istainted = 0
-                if should_be_tainted(k):
-                    k = taint_string(k)
-                    istainted = 1
-                if should_be_tainted(v):
-                    v = taint_string(v)
-                    istainted = 1
-                if istainted:
-                    taintedcookies[k] = v
         self.cookies = cookies
-        self.taintedcookies = taintedcookies
+        self.taintedcookies = taint(cookies)
 
     def processInputs(
             self,
@@ -494,7 +484,6 @@ class HTTPRequest(BaseRequest):
 
         form = self.form
         other = self.other
-        taintedform = self.taintedform
 
         # If 'QUERY_STRING' is not present in environ
         # FieldStorage will try to get it from sys.argv[1]
@@ -533,7 +522,6 @@ class HTTPRequest(BaseRequest):
             fslist = fs.list
             tuple_items = {}
             defaults = {}
-            tainteddefaults = {}
             converter = None
 
             for item in fslist:
@@ -555,7 +543,6 @@ class HTTPRequest(BaseRequest):
                 flags = 0
                 character_encoding = ''
                 # Variables for potentially unsafe values.
-                tainted = None
                 converter_type = None
 
                 # Loop through the different types and set
@@ -625,11 +612,6 @@ class HTTPRequest(BaseRequest):
                 if key in isCGI_NAMEs or key.startswith('HTTP_'):
                     continue
 
-                # If the key is tainted, mark it so as well.
-                tainted_key = key
-                if should_be_tainted(key):
-                    tainted_key = taint_string(key)
-
                 if flags:
 
                     # skip over empty fields
@@ -640,17 +622,6 @@ class HTTPRequest(BaseRequest):
                     if flags & REC:
                         key = key.split(".")
                         key, attr = ".".join(key[:-1]), key[-1]
-
-                        # Update the tainted_key if necessary
-                        tainted_key = key
-                        if should_be_tainted(key):
-                            tainted_key = taint_string(key)
-
-                        # Attributes cannot hold a <.
-                        if should_be_tainted(attr):
-                            raise ValueError(
-                                "%s is not a valid record attribute name" %
-                                escape(attr, True))
 
                     # defer conversion
                     if flags & CONVERTED:
@@ -670,23 +641,6 @@ class HTTPRequest(BaseRequest):
                             else:
                                 item = converter(item)
 
-                            # Flag potentially unsafe values
-                            if converter_type in ('string', 'required', 'text',
-                                                  'ustring', 'utext'):
-                                if not isFileUpload and \
-                                   should_be_tainted(item):
-                                    tainted = taint_string(item)
-                            elif converter_type in ('tokens', 'lines',
-                                                    'utokens', 'ulines'):
-                                is_tainted = 0
-                                tainted = item[:]
-                                for i in range(len(tainted)):
-                                    if should_be_tainted(tainted[i]):
-                                        is_tainted = 1
-                                        tainted[i] = taint_string(tainted[i])
-                                if not is_tainted:
-                                    tainted = None
-
                         except Exception:
                             if not item and \
                                not (flags & DEFAULT) and \
@@ -696,31 +650,15 @@ class HTTPRequest(BaseRequest):
                                     item = getattr(item, attr)
                                 if flags & RECORDS:
                                     item = getattr(item[-1], attr)
-                                if tainted_key in tainteddefaults:
-                                    tainted = tainteddefaults[tainted_key]
-                                    if flags & RECORD:
-                                        tainted = getattr(tainted, attr)
-                                    if flags & RECORDS:
-                                        tainted = getattr(tainted[-1], attr)
                             else:
                                 raise
 
-                    elif not isFileUpload and should_be_tainted(item):
-                        # Flag potentially unsafe values
-                        tainted = taint_string(item)
-
-                    # If the key is tainted, we need to store stuff in the
-                    # tainted dict as well, even if the value is safe.
-                    if should_be_tainted(tainted_key) and tainted is None:
-                        tainted = item
 
                     # Determine which dictionary to use
                     if flags & DEFAULT:
                         mapping_object = defaults
-                        tainted_mapping = tainteddefaults
                     else:
                         mapping_object = form
-                        tainted_mapping = taintedform
 
                     # Insert in dictionary
                     if key in mapping_object:
@@ -729,49 +667,6 @@ class HTTPRequest(BaseRequest):
                             # in the list. reclist is mutable.
                             reclist = mapping_object[key]
                             x = reclist[-1]
-
-                            if tainted:
-                                # Store a tainted copy as well
-                                if tainted_key not in tainted_mapping:
-                                    tainted_mapping[tainted_key] = deepcopy(
-                                        reclist)
-                                treclist = tainted_mapping[tainted_key]
-                                lastrecord = treclist[-1]
-
-                                if not hasattr(lastrecord, attr):
-                                    if flags & SEQUENCE:
-                                        tainted = [tainted]
-                                    setattr(lastrecord, attr, tainted)
-                                else:
-                                    if flags & SEQUENCE:
-                                        getattr(
-                                            lastrecord, attr).append(tainted)
-                                    else:
-                                        newrec = record()
-                                        setattr(newrec, attr, tainted)
-                                        treclist.append(newrec)
-
-                            elif tainted_key in tainted_mapping:
-                                # If we already put a tainted value into this
-                                # recordset, we need to make sure the whole
-                                # recordset is built.
-                                treclist = tainted_mapping[tainted_key]
-                                lastrecord = treclist[-1]
-                                copyitem = item
-
-                                if not hasattr(lastrecord, attr):
-                                    if flags & SEQUENCE:
-                                        copyitem = [copyitem]
-                                    setattr(lastrecord, attr, copyitem)
-                                else:
-                                    if flags & SEQUENCE:
-                                        getattr(
-                                            lastrecord, attr).append(copyitem)
-                                    else:
-                                        newrec = record()
-                                        setattr(newrec, attr, copyitem)
-                                        treclist.append(newrec)
-
                             if not hasattr(x, attr):
                                 # If the attribute does not
                                 # exist, set it
@@ -808,57 +703,9 @@ class HTTPRequest(BaseRequest):
                                 # it is not a sequence so
                                 # set the attribute
                                 setattr(b, attr, item)
-
-                            # Store a tainted copy as well if necessary
-                            if tainted:
-                                if tainted_key not in tainted_mapping:
-                                    tainted_mapping[tainted_key] = deepcopy(
-                                        mapping_object[key])
-                                b = tainted_mapping[tainted_key]
-                                if flags & SEQUENCE:
-                                    seq = getattr(b, attr, [])
-                                    seq.append(tainted)
-                                    setattr(b, attr, seq)
-                                else:
-                                    setattr(b, attr, tainted)
-
-                            elif tainted_key in tainted_mapping:
-                                # If we already put a tainted value into this
-                                # record, we need to make sure the whole record
-                                # is built.
-                                b = tainted_mapping[tainted_key]
-                                if flags & SEQUENCE:
-                                    seq = getattr(b, attr, [])
-                                    seq.append(item)
-                                    setattr(b, attr, seq)
-                                else:
-                                    setattr(b, attr, item)
-
                         else:
                             # it is not a record or list of records
                             found = mapping_object[key]
-
-                            if tainted:
-                                # Store a tainted version if necessary
-                                if tainted_key not in tainted_mapping:
-                                    copied = deepcopy(found)
-                                    if isinstance(copied, list):
-                                        tainted_mapping[tainted_key] = copied
-                                    else:
-                                        tainted_mapping[tainted_key] = [copied]
-                                tainted_mapping[tainted_key].append(tainted)
-
-                            elif tainted_key in tainted_mapping:
-                                # We may already have encountered a tainted
-                                # value for this key, and the tainted_mapping
-                                # needs to hold all the values.
-                                tfound = tainted_mapping[tainted_key]
-                                if isinstance(tfound, list):
-                                    tainted_mapping[tainted_key].append(item)
-                                else:
-                                    tainted_mapping[tainted_key] = [tfound,
-                                                                    item]
-
                             if isinstance(found, list):
                                 found.append(item)
                             else:
@@ -874,15 +721,6 @@ class HTTPRequest(BaseRequest):
                                 item = [item]
                             setattr(a, attr, item)
                             mapping_object[key] = [a]
-
-                            if tainted:
-                                # Store a tainted copy if necessary
-                                a = record()
-                                if flags & SEQUENCE:
-                                    tainted = [tainted]
-                                setattr(a, attr, tainted)
-                                tainted_mapping[tainted_key] = [a]
-
                         elif flags & RECORD:
                             # Create a new record, set its attribute
                             # and put it in the dictionary
@@ -890,63 +728,20 @@ class HTTPRequest(BaseRequest):
                                 item = [item]
                             r = mapping_object[key] = record()
                             setattr(r, attr, item)
-
-                            if tainted:
-                                # Store a tainted copy if necessary
-                                if flags & SEQUENCE:
-                                    tainted = [tainted]
-                                r = tainted_mapping[tainted_key] = record()
-                                setattr(r, attr, tainted)
                         else:
                             # it is not a record or list of records
                             if flags & SEQUENCE:
                                 item = [item]
                             mapping_object[key] = item
 
-                            if tainted:
-                                # Store a tainted copy if necessary
-                                if flags & SEQUENCE:
-                                    tainted = [tainted]
-                                tainted_mapping[tainted_key] = tainted
-
                 else:
                     # This branch is for case when no type was specified.
                     mapping_object = form
-
-                    if not isFileUpload and should_be_tainted(item):
-                        tainted = taint_string(item)
-                    elif should_be_tainted(key):
-                        tainted = item
 
                     # Insert in dictionary
                     if key in mapping_object:
                         # it is not a record or list of records
                         found = mapping_object[key]
-
-                        if tainted:
-                            # Store a tainted version if necessary
-                            if tainted_key not in taintedform:
-                                copied = deepcopy(found)
-                                if isinstance(copied, list):
-                                    taintedform[tainted_key] = copied
-                                else:
-                                    taintedform[tainted_key] = [copied]
-                            elif not isinstance(
-                                    taintedform[tainted_key], list):
-                                taintedform[tainted_key] = [
-                                    taintedform[tainted_key]]
-                            taintedform[tainted_key].append(tainted)
-
-                        elif tainted_key in taintedform:
-                            # We may already have encountered a tainted value
-                            # for this key, and the taintedform needs to hold
-                            # all the values.
-                            tfound = taintedform[tainted_key]
-                            if isinstance(tfound, list):
-                                taintedform[tainted_key].append(item)
-                            else:
-                                taintedform[tainted_key] = [tfound, item]
-
                         if isinstance(found, list):
                             found.append(item)
                         else:
@@ -954,54 +749,20 @@ class HTTPRequest(BaseRequest):
                             mapping_object[key] = found
                     else:
                         mapping_object[key] = item
-                        if tainted:
-                            taintedform[tainted_key] = tainted
 
             # insert defaults into form dictionary
             if defaults:
                 for key, value in defaults.items():
-                    tainted_key = key
-                    if should_be_tainted(key):
-                        tainted_key = taint_string(key)
-
                     if key not in form:
                         # if the form does not have the key,
                         # set the default
                         form[key] = value
-
-                        if tainted_key in tainteddefaults:
-                            taintedform[tainted_key] = \
-                                tainteddefaults[tainted_key]
                     else:
                         # The form has the key
-                        tdefault = tainteddefaults.get(tainted_key, value)
                         if isinstance(value, record):
                             # if the key is mapped to a record, get the
                             # record
                             r = form[key]
-
-                            # First deal with tainted defaults.
-                            if tainted_key in taintedform:
-                                tainted = taintedform[tainted_key]
-                                for k, v in tdefault.__dict__.items():
-                                    if not hasattr(tainted, k):
-                                        setattr(tainted, k, v)
-
-                            elif tainted_key in tainteddefaults:
-                                # Find out if any of the tainted default
-                                # attributes needs to be copied over.
-                                missesdefault = 0
-                                for k, v in tdefault.__dict__.items():
-                                    if not hasattr(r, k):
-                                        missesdefault = 1
-                                        break
-                                if missesdefault:
-                                    tainted = deepcopy(r)
-                                    for k, v in tdefault.__dict__.items():
-                                        if not hasattr(tainted, k):
-                                            setattr(tainted, k, v)
-                                    taintedform[tainted_key] = tainted
-
                             for k, v in value.__dict__.items():
                                 # loop through the attributes and value
                                 # in the default dictionary
@@ -1016,56 +777,6 @@ class HTTPRequest(BaseRequest):
                             val = form[key]
                             if not isinstance(val, list):
                                 val = [val]
-
-                            # First deal with tainted copies
-                            if tainted_key in taintedform:
-                                tainted = taintedform[tainted_key]
-                                if not isinstance(tainted, list):
-                                    tainted = [tainted]
-                                for defitem in tdefault:
-                                    if isinstance(defitem, record):
-                                        for k, v in defitem.__dict__.items():
-                                            for origitem in tainted:
-                                                if not hasattr(origitem, k):
-                                                    setattr(origitem, k, v)
-                                    else:
-                                        if defitem not in tainted:
-                                            tainted.append(defitem)
-                                taintedform[tainted_key] = tainted
-
-                            elif tainted_key in tainteddefaults:
-                                missesdefault = 0
-                                for defitem in tdefault:
-                                    if isinstance(defitem, record):
-                                        try:
-                                            for k, v in \
-                                                    defitem.__dict__.items():
-                                                for origitem in val:
-                                                    if not hasattr(
-                                                            origitem, k):
-                                                        missesdefault = 1
-                                                        raise NestedLoopExit
-                                        except NestedLoopExit:
-                                            break
-                                    else:
-                                        if defitem not in val:
-                                            missesdefault = 1
-                                            break
-                                if missesdefault:
-                                    tainted = deepcopy(val)
-                                    for defitem in tdefault:
-                                        if isinstance(defitem, record):
-                                            for k, v in (
-                                                    defitem.__dict__.items()):
-                                                for origitem in tainted:
-                                                    if not hasattr(
-                                                            origitem, k):
-                                                        setattr(origitem, k, v)
-                                        else:
-                                            if defitem not in tainted:
-                                                tainted.append(defitem)
-                                    taintedform[tainted_key] = tainted
-
                             for x in value:
                                 # for each x in the list
                                 if isinstance(x, record):
@@ -1112,9 +823,6 @@ class HTTPRequest(BaseRequest):
                     attr = new
                     if k in form:
                         # If the form has the split key get its value
-                        tainted_split_key = k
-                        if should_be_tainted(k):
-                            tainted_split_key = taint_string(k)
                         item = form[k]
                         if isinstance(item, record):
                             # if the value is mapped to a record, check if it
@@ -1132,24 +840,8 @@ class HTTPRequest(BaseRequest):
                                     # convert it to a tuple and set it
                                     value = tuple(getattr(x, attr))
                                     setattr(x, attr, value)
-
-                        # Do the same for the tainted counterpart
-                        if tainted_split_key in taintedform:
-                            tainted = taintedform[tainted_split_key]
-                            if isinstance(item, record):
-                                seq = tuple(getattr(tainted, attr))
-                                setattr(tainted, attr, seq)
-                            else:
-                                for trec in tainted:
-                                    if hasattr(trec, attr):
-                                        seq = getattr(trec, attr)
-                                        seq = tuple(seq)
-                                        setattr(trec, attr, seq)
                     else:
                         # the form does not have the split key
-                        tainted_key = key
-                        if should_be_tainted(key):
-                            tainted_key = taint_string(key)
                         if key in form:
                             # if it has the original key, get the item
                             # convert it to a tuple
@@ -1157,9 +849,7 @@ class HTTPRequest(BaseRequest):
                             item = tuple(form[key])
                             form[key] = item
 
-                        if tainted_key in taintedform:
-                            tainted = tuple(taintedform[tainted_key])
-                            taintedform[tainted_key] = tainted
+            self.taintedform = taint(self.form)
 
         if meth:
             if 'PATH_INFO' in environ:
@@ -1851,3 +1541,63 @@ def _decode(value, charset):
 def use_builtin_xmlrpc(request):
     checker = queryUtility(IXmlrpcChecker)
     return checker is None or checker(request)
+
+
+def taint(d):
+    """return as ``dict`` the items from *d* which require tainting.
+
+    *d* must be a ``dict`` with ``str`` keys and values recursively
+    build from elementary values, ``list``, ``tuple``, ``record`` and
+    ``dict``.
+    """
+    def should_taint(v):
+        """check whether *v* needs tainting."""
+        if isinstance(v, (list, tuple)):
+            return any(should_taint(x) for x in v)
+        if isinstance(v, (record, dict)):
+            for k in v:
+                if should_taint(k):
+                    return True
+                if should_taint(v[k]):
+                    return True
+        return should_be_tainted(v)
+
+    def _taint(v):
+        """return a copy of *v* with tainted replacements.
+
+        In the copy, each ``str`` which requires tainting
+        is replaced by the corresponding ``taint_string``.
+        """
+        __traceback_info__ = v
+        if isinstance(v, string_types) and should_be_tainted(v):
+            return taint_string(v)
+        if isinstance(v, (list, tuple)):
+            return v.__class__(_taint(x) for x in v)
+        if isinstance(v, record):
+            rn = record()
+            for k in v:
+                __traceback_info__ = v, k
+                if should_be_tainted(k):
+                    raise ValueError("Cannot taint `record` attribute names")
+                setattr(rn, k, _taint(v[k]))
+            return rn
+        if isinstance(v, dict):
+            return v.__class__((_taint(k), _taint(v[k])) for k in v)
+        return v
+    td = {}
+    for k in d:
+        v = d[k]
+        if should_taint(k) or should_taint(v):
+            td[_taint(k)] = _taint(v)
+    return td
+
+
+def should_be_tainted(v):
+    """Work around ``AccessControl`` weakness."""
+    if isinstance(v, FileUpload):
+        # `base_should_be_tainted` would read `v` as a side effect
+        return False
+    try:
+        return base_should_be_tainted(v)
+    except Exception:
+        return False

--- a/src/ZPublisher/HTTPRequest.py
+++ b/src/ZPublisher/HTTPRequest.py
@@ -20,7 +20,6 @@ import random
 import re
 import time
 from cgi import FieldStorage
-from copy import deepcopy
 from warnings import warn
 
 from six import PY2
@@ -31,8 +30,7 @@ from six import text_type
 from six.moves.urllib.parse import unquote
 from six.moves.urllib.parse import urlparse
 
-from AccessControl.tainted import \
-     should_be_tainted as base_should_be_tainted
+from AccessControl.tainted import should_be_tainted as base_should_be_tainted
 from AccessControl.tainted import taint_string
 from zope.component import queryUtility
 from zope.i18n.interfaces import IUserPreferredLanguages
@@ -526,7 +524,6 @@ class HTTPRequest(BaseRequest):
 
             for item in fslist:
 
-                isFileUpload = 0
                 key = item.name
                 if key is None:
                     continue
@@ -536,14 +533,11 @@ class HTTPRequest(BaseRequest):
                    hasattr(item, 'headers'):
                     if item.file and item.filename is not None:
                         item = FileUpload(item)
-                        isFileUpload = 1
                     else:
                         item = item.value
 
                 flags = 0
                 character_encoding = ''
-                # Variables for potentially unsafe values.
-                converter_type = None
 
                 # Loop through the different types and set
                 # the appropriate flags
@@ -568,7 +562,6 @@ class HTTPRequest(BaseRequest):
 
                         if c is not None:
                             converter = c
-                            converter_type = type_name
                             flags = flags | CONVERTED
                         elif type_name == 'list':
                             flags = flags | SEQUENCE
@@ -652,7 +645,6 @@ class HTTPRequest(BaseRequest):
                                     item = getattr(item[-1], attr)
                             else:
                                 raise
-
 
                     # Determine which dictionary to use
                     if flags & DEFAULT:

--- a/src/ZPublisher/HTTPRequest.py
+++ b/src/ZPublisher/HTTPRequest.py
@@ -1561,7 +1561,7 @@ def taint(d):
         is replaced by the corresponding ``taint_string``.
         """
         __traceback_info__ = v
-        if isinstance(v, string_types) and should_be_tainted(v):
+        if isinstance(v, (binary_type, text_type)) and should_be_tainted(v):
             return taint_string(v)
         if isinstance(v, (list, tuple)):
             return v.__class__(_taint(x) for x in v)

--- a/src/ZPublisher/tests/testHTTPRequest.py
+++ b/src/ZPublisher/tests/testHTTPRequest.py
@@ -1183,8 +1183,8 @@ class HTTPRequestTests(unittest.TestCase, HTTPRequestFactoryMixin):
         #  They happen implicitely in `request.resolve_url`
         #  They creates `zope.schema` events
         # Doing them here avoids those unrelated events
-        import OFS.PropertyManager
-        import OFS.SimpleItem
+        import OFS.PropertyManager  # noqa: F401
+        import OFS.SimpleItem  # noqa: F401
         #
         import zope.event
         events = []
@@ -1432,4 +1432,3 @@ Content-Type: text/html
 
 --12345--
 '''
-

--- a/src/ZPublisher/tests/testHTTPRequest.py
+++ b/src/ZPublisher/tests/testHTTPRequest.py
@@ -1179,6 +1179,13 @@ class HTTPRequestTests(unittest.TestCase, HTTPRequestFactoryMixin):
         self.assertTrue(IFoo.providedBy(clone))
 
     def test_resolve_url_doesnt_send_endrequestevent(self):
+        # The following imports are necessary:
+        #  They happen implicitely in `request.resolve_url`
+        #  They creates `zope.schema` events
+        # Doing them here avoids those unrelated events
+        import OFS.PropertyManager
+        import OFS.SimpleItem
+        #
         import zope.event
         events = []
         zope.event.subscribers.append(events.append)

--- a/src/ZPublisher/tests/testHTTPRequest.py
+++ b/src/ZPublisher/tests/testHTTPRequest.py
@@ -19,6 +19,7 @@ from io import BytesIO
 
 from six import PY2
 
+from AccessControl.tainted import TaintedString
 from AccessControl.tainted import should_be_tainted
 from zExceptions import NotFound
 from zope.component import getGlobalSiteManager
@@ -28,6 +29,7 @@ from zope.i18n.interfaces.locales import ILocale
 from zope.publisher.browser import BrowserLanguages
 from zope.publisher.interfaces.http import IHTTPRequest
 from zope.testing.cleanup import cleanUp
+from ZPublisher.HTTPRequest import FileUpload
 from ZPublisher.HTTPRequest import search_type
 from ZPublisher.interfaces import IXmlrpcChecker
 from ZPublisher.tests.testBaseRequest import TestRequestViewsBase
@@ -1314,6 +1316,19 @@ class HTTPRequestTests(unittest.TestCase, HTTPRequestFactoryMixin):
         req = self._makeOne(environ=env)
         self.assertEqual(req['SERVER_URL'], 'https://myhost')
 
+    def test_issue_1095(self):
+        body = TEST_ISSUE_1095_DATA
+        env = self._makePostEnviron(body)
+        req = self._makeOne(BytesIO(body), env)
+        req.processInputs()
+        r = req["r"]
+        self.assertEqual(len(r), 2)
+        self.assertIsInstance(r[0].x, FileUpload)
+        self.assertIsInstance(r[1].x, str)
+        r = req.taintedform["r"]
+        self.assertIsInstance(r[0].x, FileUpload)
+        self.assertIsInstance(r[1].x, TaintedString)
+
 
 class TestHTTPRequestZope3Views(TestRequestViewsBase):
 
@@ -1394,3 +1409,20 @@ Content-Disposition: form-data; name="largefile"; filename="largefile"
 Content-Type: application/octet-stream
 
 test ''' + (b'test' * 1000) + b'\n\n'
+
+TEST_ISSUE_1095_DATA = b'''
+--12345
+Content-Disposition: form-data; name="r.x:records"; filename="fn"
+Content-Type: application/octet-stream
+
+test
+
+--12345
+Content-Disposition: form-data; name="r.x:records"
+Content-Type: text/html
+
+<body>abc</body>
+
+--12345--
+'''
+


### PR DESCRIPTION
fixes #1095.

Primarily taken from #648.

The tainting logic has been incredibly complex and spread all over `ZPublisher.HTTPRequest.HTTPRequest.processInputs`. The PR takes it out of `processInputs` and centralizes it in the function `taint`. Doing so allows to work with the final results only not also with intermediate results.