### PR TITLE
FileUpload: use default encoding as charset when nothing is passed.

### DIFF
--- a/src/ZPublisher/HTTPRequest.py
+++ b/src/ZPublisher/HTTPRequest.py
@@ -1477,18 +1477,26 @@ class FileUpload:
     In addition, they have a 'headers' attribute that is a dictionary
     containing the file-upload headers, and a 'filename' attribute
     containing the name of the uploaded file.
+
+    Note that file names in HTTP/1.1 use latin-1 as charset.  See
+    https://github.com/zopefoundation/Zope/pull/1094#issuecomment-1459654636
     '''
 
     # Allow access to attributes such as headers and filename so
     # that protected code can use DTML to work with FileUploads.
     __allow_access_to_unprotected_subobjects__ = 1
 
-    def __init__(self, aFieldStorage, charset):
+    def __init__(self, aFieldStorage, charset=default_encoding):
         self.file = aFieldStorage.file
         self.headers = aFieldStorage.headers
-        self.filename = aFieldStorage.filename\
-            .encode("latin-1").decode(charset)
-        self.name = aFieldStorage.name.encode("latin-1").decode(charset)
+        # Prevent needless encode-decode when both charsets are the same.
+        if charset != "latin-1":
+            self.filename = aFieldStorage.filename\
+                .encode("latin-1").decode(charset)
+            self.name = aFieldStorage.name.encode("latin-1").decode(charset)
+        else:
+            self.filename = aFieldStorage.filename
+            self.name = aFieldStorage.name
 
         # Add an assertion to the rfc822.Message object that implements
         # self.headers so that managed code can access them.

--- a/src/ZPublisher/HTTPRequest.py
+++ b/src/ZPublisher/HTTPRequest.py
@@ -1486,7 +1486,8 @@ class FileUpload:
     # that protected code can use DTML to work with FileUploads.
     __allow_access_to_unprotected_subobjects__ = 1
 
-    def __init__(self, aFieldStorage, charset=default_encoding):
+    def __init__(self, aFieldStorage, charset=None):
+        charset = charset or default_encoding
         self.file = aFieldStorage.file
         self.headers = aFieldStorage.headers
         # Prevent needless encode-decode when both charsets are the same.

--- a/src/ZPublisher/tests/testHTTPRequest.py
+++ b/src/ZPublisher/tests/testHTTPRequest.py
@@ -845,6 +845,7 @@ class HTTPRequestTests(unittest.TestCase, HTTPRequestFactoryMixin):
         f = req.form.get('largefile')
         self.assertTrue(f.name)
         self.assertEqual(4006, len(f.file.read()))
+        f.file.close()
 
     def test_processInputs_with_file_upload_gets_iterator(self):
         # checks fileupload object supports the iterator protocol


### PR DESCRIPTION
Without this change, some tests (and possibly live code) in Plone fail because they do not pass the new required `charset` parameter. See https://github.com/plone/buildout.coredev/pull/844
And see discussion that I just started here:
https://github.com/zopefoundation/Zope/pull/1094#issuecomment-1459047253

Also fixes an unclosed file in a test.