### PR TITLE
Support `charset` parameter for content type `application/x-www-form-encoded`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,15 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 
 - Update to newest compatible versions of dependencies.
 
+- Support the (non standard) ``charset`` parameter for
+  content type ``application/x-www-form-urlencoded``.
+  This is required (e.g. for ``Plone``) because
+  ``jquery`` constructs content types of the form
+  ```application/x-www-form-urlencoded; charset=utf-8``.
+  For details see
+  `plone/buildout.coredev#844
+  <https://github.com/plone/buildout.coredev/pull/844>`_.
+
 
 5.8 (2023-01-10)
 ----------------

--- a/src/ZPublisher/HTTPRequest.py
+++ b/src/ZPublisher/HTTPRequest.py
@@ -1413,7 +1413,8 @@ class ZopeFieldStorage(ValueAccessor):
         content_type = environ.get("CONTENT_TYPE",
                                    "application/x-www-form-urlencoded")
         hl.append(("content-type", content_type))
-        content_type, options = parse_options_header(content_type.lower())
+        content_type, options = parse_options_header(content_type)
+        content_type = content_type.lower()
         content_disposition = environ.get("CONTENT_DISPOSITION")
         if content_disposition is not None:
             hl.append(("content-disposition", content_disposition))

--- a/src/ZPublisher/HTTPRequest.py
+++ b/src/ZPublisher/HTTPRequest.py
@@ -547,23 +547,24 @@ class HTTPRequest(BaseRequest):
                 # problems when surrogates reach the application because
                 # they cannot be encoded with a standard error handler.
                 # We might want to prevent this.
-                character_encoding = ''  # currently used encoding
                 key = item.name
                 if key is None:
                     continue
-                key = item.name.encode("latin-1").decode(self.charset)
+                character_encoding = ""
+                key = item.name.encode("latin-1").decode(
+                    item.name_charset or self.charset)
 
                 if hasattr(item, 'file') and \
                    hasattr(item, 'filename') and \
                    hasattr(item, 'headers'):
                     item = FileUpload(item, self.charset)
                 else:
-                    character_encoding = self.charset
+                    character_encoding = item.value_charset or self.charset
                     item = item.value.decode(
                         character_encoding, "surrogateescape")
                 # from here on, `item` contains the field value
                 # either as `FileUpload` or `str` with
-                # `character_encoding` as encoding.
+                # `character_encoding` as encoding,
                 # `key` the field name (`str`)
 
                 flags = 0
@@ -1382,6 +1383,9 @@ class FormField(SimpleNamespace, ValueAccessor):
       the field name
     value
       the field value (`bytes`)
+    name_charset, value_charset
+      the charset for the name and value, respectively, or ``None``
+      if no charset has been specified.
 
     File fields additionally have the attributes:
     file
@@ -1396,17 +1400,20 @@ class FormField(SimpleNamespace, ValueAccessor):
     are used to represent textual data.
     """
 
+    name_charset = value_charset = None
+
 
 class ZopeFieldStorage(ValueAccessor):
     def __init__(self, fp, environ):
         self.file = fp
         method = environ.get("REQUEST_METHOD", "GET").upper()
-        qs = environ.get("QUERY_STRING", "")
+        url_qs = environ.get("QUERY_STRING", "")
+        post_qs = ""
         hl = []
         content_type = environ.get("CONTENT_TYPE",
                                    "application/x-www-form-urlencoded")
-        content_type = content_type
         hl.append(("content-type", content_type))
+        content_type, options = parse_options_header(content_type.lower())
         content_disposition = environ.get("CONTENT_DISPOSITION")
         if content_disposition is not None:
             hl.append(("content-disposition", content_disposition))
@@ -1417,8 +1424,7 @@ class ZopeFieldStorage(ValueAccessor):
                 fpos = fp.tell()
             except Exception:
                 fpos = None
-            if content_type.startswith("multipart/form-data"):
-                ct, options = parse_options_header(content_type)
+            if content_type == "multipart/form-data":
                 parts = MultipartParser(
                     fp, options["boundary"],
                     mem_limit=FORM_MEMORY_LIMIT,
@@ -1426,31 +1432,28 @@ class ZopeFieldStorage(ValueAccessor):
                     memfile_limit=FORM_MEMFILE_LIMIT,
                     charset="latin-1").parts()
             elif content_type == "application/x-www-form-urlencoded":
-                if qs:
-                    qs += "&"
-                qs += fp.read(FORM_MEMORY_LIMIT).decode("latin-1")
+                post_qs = fp.read(FORM_MEMORY_LIMIT).decode("latin-1")
                 if fp.read(1):
                     raise BadRequest("form data processing "
                                      "requires too much memory")
-            else:
-                # `processInputs` currently expects either
-                # form values or a response body, not both.
-                # reset `qs` to fulfill this expectation.
-                qs = ""
+            elif url_qs:
+                raise NotImplementedError("request parameters and body")
             if fpos is not None:
                 fp.seek(fpos)
-        elif method not in ("GET", "HEAD"):
-            # `processInputs` currently expects either
-            # form values or a response body, not both.
-            # reset `qs` to fulfill this expectation.
-            qs = ""
+        elif url_qs and content_type != "application/x-www-form-urlencoded":
+            raise NotImplementedError("request parameters and body")
         fl = []
         add_field = fl.append
-        for name, val in parse_qsl(
-           qs,  # noqa: E121
-           keep_blank_values=True, encoding="latin-1"):
-            add_field(FormField(
-                name=name, value=val.encode("latin-1")))
+        post_opts = {}
+        if options.get("charset"):
+            post_opts["name_charset"] = post_opts["value_charset"] = \
+                options["charset"]
+        for qs, opts in ((url_qs, {}), (post_qs, post_opts)):
+            for name, val in parse_qsl(
+               qs,  # noqa: E121
+               keep_blank_values=True, encoding="latin-1"):
+                add_field(FormField(
+                    name=name, value=val.encode("latin-1"), **opts))
         for part in parts:
             if part.filename:
                 # a file
@@ -1460,10 +1463,19 @@ class ZopeFieldStorage(ValueAccessor):
                     filename=part.filename,
                     headers=part.headers)
             else:
-                field = FormField(name=part.name, value=part.raw)
+                field = FormField(
+                    name=part.name, value=part.raw,
+                    value_charset=_mp_charset(part))
             add_field(field)
         if fl:
             self.list = fl
+
+
+def _mp_charset(part):
+    """the charset of *part*."""
+    content_type = part.headers.get("Content-Type", "")
+    _, options = parse_options_header(content_type)
+    return options.get("charset")
 
 
 # Original version: zope.publisher.browser.FileUpload


### PR DESCRIPTION
This PR fixes a problem reported in
https://github.com/plone/buildout.coredev/pull/844#issuecomment-1461044889

Apparently, `jquery` uses not standard conform content types of the form
`application/x-www-form-urlencoded; charset=utf-8`. With the switch from `cgi.FieldStorage` to `multipart`, `Zope` no longer recognized not standard `application/x-www-form-urlencoded` content type headers. As a result, some Plone tests broke.

This PR supports the `charset` parameter for `application/x-www-form-urlencoded`.