### PR TITLE
Do not break with GET requests that have a query string and a Content-Type header 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,9 +10,9 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 5.8.2 (unreleased)
 ------------------
 
-- Support Plone REST API calls with a query string.
-  For details see `plone/plone.restapi#1611
-  <https://github.com/plone/plone.restapi/issues/1611>`_.
+- Do not break on GET requests that pass a query string
+  and a `Content-Type` header.
+  For details see `#1117 <https://github.com/zopefoundation/Zope/pull/1117>`_.
 
 - Implement code change suggestions from CodeQL scanning.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 5.8.2 (unreleased)
 ------------------
 
+- Support Plone REST API calls with a query string.
+  For details see `plone/plone.restapi#1611
+  <https://github.com/plone/plone.restapi/issues/1611>`_.
+
 - Implement code change suggestions from CodeQL scanning.
 
 - Added Japanese translations for some Sphinx docs

--- a/src/ZPublisher/HTTPRequest.py
+++ b/src/ZPublisher/HTTPRequest.py
@@ -1441,7 +1441,7 @@ class ZopeFieldStorage(ValueAccessor):
                 raise NotImplementedError("request parameters and body")
             if fpos is not None:
                 fp.seek(fpos)
-        elif fp and url_qs:
+        elif url_qs and fp is not None:
             raise NotImplementedError("request parameters and body")
         fl = []
         add_field = fl.append

--- a/src/ZPublisher/HTTPRequest.py
+++ b/src/ZPublisher/HTTPRequest.py
@@ -1441,7 +1441,7 @@ class ZopeFieldStorage(ValueAccessor):
                 raise NotImplementedError("request parameters and body")
             if fpos is not None:
                 fp.seek(fpos)
-        elif url_qs and content_type != "application/x-www-form-urlencoded":
+        elif fp and url_qs:
             raise NotImplementedError("request parameters and body")
         fl = []
         add_field = fl.append

--- a/src/ZPublisher/tests/testHTTPRequest.py
+++ b/src/ZPublisher/tests/testHTTPRequest.py
@@ -1332,6 +1332,36 @@ class HTTPRequestTests(unittest.TestCase, HTTPRequestFactoryMixin):
         req.processInputs()
         self.assertEqual(req.form["a"], val)
 
+    def test_get_with_body_and_query_string_ignores_body(self):
+        req_factory = self._getTargetClass()
+        req = req_factory(
+            BytesIO(b"foo"),
+            {
+                "SERVER_NAME": "localhost",
+                "SERVER_PORT": "8080",
+                "REQUEST_METHOD": "GET",
+                "QUERY_STRING": "bar"
+            },
+            None,
+        )
+        req.processInputs()
+        self.assertDictEqual(req.form, {"bar": ""})
+
+    def test_put_with_body_and_query_string_raises(self):
+        req_factory = self._getTargetClass()
+        req = req_factory(
+            BytesIO(b"foo"),
+            {
+                "SERVER_NAME": "localhost",
+                "SERVER_PORT": "8080",
+                "REQUEST_METHOD": "PUT",
+                "QUERY_STRING": "bar"
+            },
+            None,
+        )
+        with self.assertRaises(NotImplementedError()):
+            req.processInputs()
+
     def test_issue_1095(self):
         body = TEST_ISSUE_1095_DATA
         env = self._makePostEnviron(body)

--- a/src/ZPublisher/tests/testHTTPRequest.py
+++ b/src/ZPublisher/tests/testHTTPRequest.py
@@ -1359,7 +1359,7 @@ class HTTPRequestTests(unittest.TestCase, HTTPRequestFactoryMixin):
             },
             None,
         )
-        with self.assertRaises(NotImplementedError()):
+        with self.assertRaises(NotImplementedError):
             req.processInputs()
 
     def test_issue_1095(self):


### PR DESCRIPTION
We cannot make a GET request that contains both a Content-Type header and a query string.

Examples that work fine:
```shell
$ curl https://classic.demo.plone.org/@@ok?bar=1
OK
$ curl -H 'Content-Type: text/plain' https://classic.demo.plone.org/@@ok
OK
```

Example that should work fine, but it is not working fine:
```shell
$ curl -H 'Content-Type: text/plain' https://classic.demo.plone.org/@@ok?a=1
{"error_type": "NotImplementedError"}
```

Example that should actually trigger the error:
```shell
$ curl -H 'Content-Type: text/plain' -d @<(echo b=1) https://classic.demo.plone.org/@@ok?a=1
{"error_type": "NotImplementedError"}
```

Fixes plone/plone.restapi#1611

