### PR TITLE
Allow ZPublisher to handle a query string together with a request body

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,13 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 5.8.2 (unreleased)
 ------------------
 
+- Allow ``ZPublisher`` to handle both a query string and a request body;
+  the request parameters from the query string are made available
+  in the request attribute ``form`` (a ``dict``),
+  the request body can be accessed via the request keys ``BODY``
+  (a ``bytes`` object) or ``BODYFILE`` (a file like object).
+  Fixes `#1122 <https://github.com/zopefoundation/Zope/issues/1122>`_.
+
 - Do not break on GET requests that pass a query string
   and a `Content-Type` header.
   For details see `#1117 <https://github.com/zopefoundation/Zope/pull/1117>`_.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,11 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
   (a ``bytes`` object) or ``BODYFILE`` (a file like object).
   Fixes `#1122 <https://github.com/zopefoundation/Zope/issues/1122>`_.
 
+- Support access to the request's ``BODY`` key for WSGI servers
+  which hand over an unseekable request body (such as e.g.
+  ``Gunicorn``).
+  Fixes `#1125 <https://github.com/zopefoundation/Zope/issues/1125>`_.
+
 - Do not break on GET requests that pass a query string
   and a `Content-Type` header.
   For details see `#1117 <https://github.com/zopefoundation/Zope/pull/1117>`_.

--- a/src/ZPublisher/HTTPRequest.py
+++ b/src/ZPublisher/HTTPRequest.py
@@ -165,7 +165,7 @@ class HTTPRequest(BaseRequest):
     _hacked_path = None
     args = ()
     _urls = ()
-    _fs = None
+    _file = None
 
     charset = default_encoding
     retry_max_count = 0
@@ -190,9 +190,8 @@ class HTTPRequest(BaseRequest):
         # Clear all references to the input stream, possibly
         # removing tempfiles.
         self.stdin = None
-        if self._fs is not None:
-            self._fs.file = None
-            del self._fs
+        self._file = None
+        self._fs = None
         self.form.clear()
         # we want to clear the lazy dict here because BaseRequests don't have
         # one.  Without this, there's the possibility of memory leaking
@@ -497,6 +496,7 @@ class HTTPRequest(BaseRequest):
         meth = None
 
         self._fs = fs = ZopeFieldStorage(fp, environ)
+        self._file = fs.file
 
         if 'HTTP_SOAPACTION' in environ:
             # Stash XML request for interpretation by a SOAP-aware view
@@ -1054,12 +1054,12 @@ class HTTPRequest(BaseRequest):
                     self._urls = self._urls + (key,)
                 return URL
 
-            if key == 'BODY' and self._fs.file is not None:
+            if key == 'BODY' and self._file is not None:
                 v = self.other[key] = self._fs.value
                 return v
 
-            if key == 'BODYFILE' and self._fs.file is not None:
-                v = self._fs.file
+            if key == 'BODYFILE' and self._file is not None:
+                v = self._file
                 self.other[key] = v
                 return v
 


### PR DESCRIPTION
Formerly, ZPublisher had the restriction to handle either request parameters (from a query string or a body with form data (i.e. a body with content type `application/x-www-form-urlencoded` or `multipart/form-data) or a request body not containing form data. A query string together with a body not containing form data raised a `NotImplementedError`.

This PR removes the restriction: request parameters from a query string can be combined with a request body not containing form data. Request parameters are made available in the request's `form` attribute (a `dict`), the request body can be accessed via the request key `BODY` (a `bytes` object) or `BODYFILE` (a file like object).

This PR fixes #1122.