### PR TITLE
Fix adding Page Templates without valid file input from the ZMI

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 5.8.3 (unreleased)
 ------------------
 
+- Fix adding Page Templates without valid file input from the ZMI
+  (`#1130 <https://github.com/zopefoundation/Zope/issues/1130>`_)
+
 - Update to newest compatible versions of dependencies.
 
 

--- a/src/Products/PageTemplates/ZopePageTemplate.py
+++ b/src/Products/PageTemplates/ZopePageTemplate.py
@@ -372,26 +372,22 @@ def manage_addPageTemplate(self, id, title='', text='', encoding='utf-8',
     "Add a Page Template with optional file content."
 
     filename = ''
+    filehandle = None
     content_type = 'text/html'
 
-    if REQUEST and 'file' in REQUEST:
-        file = REQUEST['file']
-        filename = file.filename
-        text = file.read()
-        headers = getattr(file, 'headers', None)
+    if REQUEST and hasattr(REQUEST.get('file', None), 'read'):
+        filehandle = REQUEST['file']
+    elif hasattr(text, 'read'):
+        filehandle = text
+
+    if filehandle is not None:
+        filename = getattr(filehandle, 'filename', '')
+        text = filehandle.read()
+        headers = getattr(filehandle, 'headers', None)
         if headers and 'content_type' in headers:
             content_type = headers['content_type']
         else:
             content_type = guess_type(filename, text)
-    else:
-        if hasattr(text, 'read'):
-            filename = getattr(text, 'filename', '')
-            headers = getattr(text, 'headers', None)
-            text = text.read()
-            if headers and 'content_type' in headers:
-                content_type = headers['content_type']
-            else:
-                content_type = guess_type(filename, text)
 
     # ensure that we pass text_type to the constructor to
     # avoid further hassles with pt_edit()

--- a/src/Products/PageTemplates/tests/testZopePageTemplate.py
+++ b/src/Products/PageTemplates/tests/testZopePageTemplate.py
@@ -422,6 +422,16 @@ class ZPTRegressions(unittest.TestCase):
         pt = self.app.pt1
         self.assertEqual(pt.document_src(), self.text)
 
+    def testAddWithRequestAndBadFile(self):
+        # Test with a file attribute on the Request that is not
+        # a valid file object.
+        request = self.app.REQUEST
+        request.form['file'] = ''
+        self._addPT('pt1', text=self.text, REQUEST=request)
+        # no object is returned when REQUEST is passed.
+        pt = self.app.pt1
+        self.assertEqual(pt.document_src(), self.text)
+
 
 class ZPTMacros(zope.component.testing.PlacelessSetup, unittest.TestCase):
 


### PR DESCRIPTION
Fixes #1130

Make sure adding a Page Template doesn't fail if the `file` input on the Request is not a valid file handle.