### PR TITLE
fix handling of a request parameter of type `file` if no file has been selected

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 5.8.3 (unreleased)
 ------------------
 
+- Fix handling of a request parameter of type ``file`` if no value
+  has been specified;
+  fixes `#1130 <https://github.com/zopefoundation/Zope/issues/1130>`_.
+
 - Fix adding Page Templates without valid file input from the ZMI
   (`#1130 <https://github.com/zopefoundation/Zope/issues/1130>`_)
 

--- a/src/ZPublisher/HTTPRequest.py
+++ b/src/ZPublisher/HTTPRequest.py
@@ -1459,7 +1459,7 @@ class ZopeFieldStorage(ValueAccessor):
                 add_field(FormField(
                     name=name, value=val.encode("latin-1"), **opts))
         for part in parts:
-            if part.filename:
+            if part.filename is not None:
                 # a file
                 field = FormField(
                     name=part.name,

--- a/src/ZPublisher/tests/testHTTPRequest.py
+++ b/src/ZPublisher/tests/testHTTPRequest.py
@@ -947,6 +947,15 @@ class HTTPRequestTests(unittest.TestCase, HTTPRequestFactoryMixin):
         with self.assertRaises(KeyError):
             req["BODY"]
 
+    def test_processInputs_unspecified_file(self):
+        s = BytesIO(TEST_FILE_DATA_UNSPECIFIED)
+        environ = self._makePostEnviron(body=TEST_FILE_DATA_UNSPECIFIED)
+        req = self._makeOne(stdin=s, environ=environ)
+        req.processInputs()
+        f = req.form.get('smallfile')
+        self.assertEqual(f.filename, "")
+        self.assertEqual(list(f), [])
+
     def test__authUserPW_simple(self):
         user_id = 'user'
         password = 'password'
@@ -1560,6 +1569,14 @@ Content-Disposition: form-data; name="smallfile"; filename="smallfile"
 Content-Type: application/octet-stream
 
 test
+
+--12345--
+'''
+
+TEST_FILE_DATA_UNSPECIFIED = b'''
+--12345
+Content-Disposition: form-data; name="smallfile"; filename=""
+Content-Type: application/octet-stream
 
 --12345--
 '''


### PR DESCRIPTION
Fixes #1132.

`ZPublisher` used to map request parameters of type `file` to `FileUpload` objects; the application could check for a non-empty `filename` to determine whether a file has been selected for this parameter.
The switch from `cgi.fieldstorage` to `multipart` changed this behavior: a `file` request parameter was no longer mapped to a `FileUpload` object when no file has been selected.
This PR restores the former behavior.