### PR TITLE
Make `mapply`  `__signature__` aware

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,7 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 
 - Make ``mapply`` ``__signature__`` aware.
   This allows to publish methods decorated via a decorator
-  which sets ``__signature__` on the wrapper to specify
+  which sets ``__signature__`` on the wrapper to specify
   the signature to use.
   For details, see
   `#1134 <https://github.com/zopefoundation/Zope/issues/1134>`_.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,15 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 
 - Update to newest compatible versions of dependencies.
 
+- Make ``mapply`` ``__signature__`` aware.
+  This allows to publish methods decorated via a decorator
+  which sets ``__signature__` on the wrapper to specify
+  the signature to use.
+  For details, see
+  `#1134 <https://github.com/zopefoundation/Zope/issues/1134>`_.
+  Note: ``mapply`` still does not support keyword only, var positional
+  and var keyword parameters.
+
 
 5.8.3 (2023-06-15)
 ------------------

--- a/src/ZPublisher/mapply.py
+++ b/src/ZPublisher/mapply.py
@@ -58,7 +58,7 @@ def mapply(object, positional=(), keyword={},
             # We use ``getfullargspec`` because it packages
             # the signature information in the way we need it here.
             # Should the function get deprecated, we could do the
-            # packaging outselves
+            # packaging ourselves
             argspec = getfullargspec(f)
             defaults = argspec.defaults
             names = argspec.args[count:]

--- a/src/ZPublisher/mapply.py
+++ b/src/ZPublisher/mapply.py
@@ -12,6 +12,8 @@
 ##############################################################################
 """Provide an apply-like facility that works with any mapping object
 """
+from inspect import getfullargspec
+
 import zope.publisher.publish
 
 
@@ -50,9 +52,20 @@ def mapply(object, positional=(), keyword={},
             if maybe:
                 return object
             raise
-        code = f.__code__
-        defaults = f.__defaults__
-        names = code.co_varnames[count:code.co_argcount]
+        if hasattr(f, "__signature__"):
+            # The function has specified the signature to use
+            # (likely via a decorator)
+            # We use ``getfullargspec`` because it packages
+            # the signature information in the way we need it here.
+            # Should the function get deprecated, we could do the
+            # packaging outselves
+            argspec = getfullargspec(f)
+            defaults = argspec.defaults
+            names = argspec.args[count:]
+        else:
+            code = f.__code__
+            defaults = f.__defaults__
+            names = code.co_varnames[count:code.co_argcount]
 
     nargs = len(names)
     if positional:

--- a/src/ZPublisher/tests/test_mapply.py
+++ b/src/ZPublisher/tests/test_mapply.py
@@ -90,3 +90,17 @@ class MapplyTests(unittest.TestCase):
 
         ob = NoCallButAcquisition().__of__(Root())
         self.assertRaises(TypeError, mapply, ob, (), {})
+
+    def testFunctionWithSignature(self):
+        from inspect import Parameter
+        from inspect import Signature
+
+        def f(*args, **kw):
+            return args, kw
+
+        f.__signature__ = Signature(
+            (Parameter("a", Parameter.POSITIONAL_OR_KEYWORD),
+             Parameter("b", Parameter.POSITIONAL_OR_KEYWORD, default="b")))
+
+        self.assertEqual(mapply(f, ("a",), {}), (("a", "b"), {}))
+        self.assertEqual(mapply(f, (), {"a": "A", "b": "B"}), (("A", "B"), {}))


### PR DESCRIPTION
Fixes #1134.

This PR makes `mapply` `__signature__` aware.

`__signature__` has been introduced by Python 3 to allow (usually decorators) to specify the signature of a function. It makes it easy to implement signature preserving decorators.

With this PR `mapply` looks for `__signature__`  and (if present) uses it to determine the parameter names and their default. Otherwise, `mapply` determines this information as before.