### PR TITLE
Disable `ZCatalog`  performance test

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,11 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 5.8.4 (unreleased)
 ------------------
 
+- Disable a ``ZCatalog`` (more precisly: ``Products.PluginIndexes``)
+  performance test which occasionally fails on GITHUB.
+  For details, see
+  `#1136 <https://github.com/zopefoundation/Zope/issues/1136>`_.
+
 - Update to newest compatible versions of dependencies.
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,9 @@ deps =
 commands_pre =
     {envbindir}/buildout -c {toxinidir}/buildout.cfg buildout:directory={envdir} buildout:develop={toxinidir} install alltests
 commands =
-    {envdir}/bin/alltests {posargs:-vc}
+    # the `layer` argument below suppresses a `ZCatalog` performance test
+    # which occasionally fails on GITHUB
+    {envdir}/bin/alltests --layer '!Products.PluginIndexes' {posargs:-vc}
 
 [testenv:pre-commit]
 basepython = python3


### PR DESCRIPTION
Fixes #1136.

This PR disables a `ZCatalog` (more precisely `Products.PluginIndexes`) performance test (`Products.ZCatalog.PluginIndexes.CompositeIndex.tests.testCompositeIndex.CompositeIndexPerformanceTest.testPerformance`) which depends highly on load conditions and therefore occasionally fails on GITHUB.

The test has been designed to get disabled when running unit tests only. It achieves this using an associated layer. The `ZCatalog` (and in particular the `Products.PluginIndexes`) tests do not use layers apart from this test. Therefore, this PR excludes the test by excluding tests with layers from `Products.PluginIndexes`.