### PR TITLE
Restore filename on code objects: `App.Extensions.getObject()`.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,9 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
   For details, see
   `#1136 <https://github.com/zopefoundation/Zope/issues/1136>`_.
 
+- Restore filename on code objects of objects returned from
+  ``App.Extensions.getObject()``. This got lost in 4.0a6.
+
 - Update to newest compatible versions of dependencies.
 
 

--- a/src/App/Extensions.py
+++ b/src/App/Extensions.py
@@ -180,8 +180,9 @@ def getObject(module, name, reload=0):
     except Exception:
         raise NotFound("The specified module, '%s', "
                        "couldn't be opened." % module)
+    execcode = compile(execsrc, path, 'exec')
     module_dict = {}
-    exec(execsrc, module_dict)
+    exec(execcode, module_dict)
 
     if old is not None:
         # XXX Accretive??

--- a/src/App/tests/fixtures/error.py
+++ b/src/App/tests/fixtures/error.py
@@ -1,0 +1,2 @@
+# This file intentionally contains a SyntaxError
+a =  # noqa

--- a/src/App/tests/fixtures/getObject.py
+++ b/src/App/tests/fixtures/getObject.py
@@ -1,0 +1,5 @@
+import sys
+
+
+def f1():
+    return sys._getframe(0).f_code.co_filename

--- a/src/App/tests/test_Extensions.py
+++ b/src/App/tests/test_Extensions.py
@@ -1,0 +1,37 @@
+import types
+import unittest
+from pathlib import Path
+
+import App.config
+from App.Extensions import getObject
+
+
+class GetObjectTests(unittest.TestCase):
+    """Testing ..Extensions.getObject()."""
+
+    def setUp(self):
+        cfg = App.config.getConfiguration()
+        assert not hasattr(cfg, 'extensions')
+        cfg.extensions = Path(__file__).parent / 'fixtures'
+
+    def tearDown(self):
+        cfg = App.config.getConfiguration()
+        del cfg.extensions
+
+    def test_Extensions__getObject__1(self):
+        """It returns an the requested function.
+
+        The code object of this function has the file name set.
+        """
+        obj = getObject('getObject', 'f1')
+        self.assertIsInstance(obj, types.FunctionType)
+        self.assertEqual(obj.__name__, 'f1')
+        path = obj()
+        self.assertTrue(path.endswith('/App/tests/fixtures/getObject.py'))
+
+    def test_Extensions__getObject__2(self):
+        """It raises a SyntaxError if necessary."""
+        try:
+            getObject('error', 'f1')
+        except SyntaxError as e:
+            self.assertEqual(str(e), 'invalid syntax (error.py, line 2)')

--- a/src/App/tests/test_Extensions.py
+++ b/src/App/tests/test_Extensions.py
@@ -27,7 +27,8 @@ class GetObjectTests(unittest.TestCase):
         self.assertIsInstance(obj, types.FunctionType)
         self.assertEqual(obj.__name__, 'f1')
         path = obj()
-        self.assertTrue(path.endswith('/App/tests/fixtures/getObject.py'))
+        self.assertTrue(
+            path.endswith(str(Path('App/tests/fixtures/getObject.py'))))
 
     def test_Extensions__getObject__2(self):
         """It raises a SyntaxError if necessary."""

--- a/src/App/tests/test_Extensions.py
+++ b/src/App/tests/test_Extensions.py
@@ -19,9 +19,9 @@ class GetObjectTests(unittest.TestCase):
         del cfg.extensions
 
     def test_Extensions__getObject__1(self):
-        """It returns an the requested function.
+        """Check that "getObject" returns the requested function and ...
 
-        The code object of this function has the file name set.
+        that its code object has the path set.
         """
         obj = getObject('getObject', 'f1')
         self.assertIsInstance(obj, types.FunctionType)


### PR DESCRIPTION
Since 4.0a6 the filename is missing there, resulting in problems while debugging (debugger is unable to show the code line) and coverage of Python modules loaded via Products.ExternalMethods.

The commit introducing this change was https://github.com/zopefoundation/Zope/commit/8d30ff802e60eae55711f200c3197916fa5f90e1

The previous code cannot be restored because in Python 3 `exec` no longer takes an open file as argument but just `str`, `bytes`, or `Code` objects.