### PR TITLE
Zope 4: Restore filename on code objects: `App.Extensions.getObject()`.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,8 +4,6 @@ name: tests
 
 on:
   push:
-    branches: [ 4.x ]
-  pull_request:
   schedule:
     - cron: '0 12 * * 0'  # run once a week on Sunday
   # Allow to run this workflow manually from the Actions tab

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,6 +33,7 @@ jobs:
           - { os: ["windows", "windows-latest"], config: ["3.8",   "lint"] }
           - { os: ["windows", "windows-latest"], config: ["3.8",   "docs"] }
           - { os: ["windows", "windows-latest"], config: ["3.8",   "coverage"] }
+          - { os: ["windows", "windows-latest"], config: ["2.7",   "py27"] }
           - { os: ["windows", "windows-latest"], config: ["2.7",   "py27-zserver"] }
 
     runs-on: ${{ matrix.os[1] }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,6 @@ jobs:
           - { os: ["windows", "windows-latest"], config: ["2.7",   "py27-zserver"] }
 
     runs-on: ${{ matrix.os[1] }}
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: ${{ matrix.os[0] }}-${{ matrix.config[1] }}
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: MatteoH2O1999/setup-python@v1
       with:
         python-version: ${{ matrix.config[0] }}
     - name: Pip cache

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,9 @@ https://zope.readthedocs.io/en/2.13/CHANGES.html
 - Sanitize tainting fixing
   `#1095 <https://github.com/zopefoundation/Zope/issues/1095>`_
 
+- Restore filename on code objects of objects returned from
+  ``App.Extensions.getObject()``. This got lost in 4.0a6.
+
 
 4.8.7 (2023-01-10)
 ------------------

--- a/src/App/Extensions.py
+++ b/src/App/Extensions.py
@@ -182,8 +182,9 @@ def getObject(module, name, reload=0):
     except Exception:
         raise NotFound("The specified module, '%s', "
                        "couldn't be opened." % module)
+    execcode = compile(execsrc, path, 'exec')
     module_dict = {}
-    exec_(execsrc, module_dict)
+    exec_(execcode, module_dict)
 
     if old is not None:
         # XXX Accretive??

--- a/src/App/tests/fixtures/error.py
+++ b/src/App/tests/fixtures/error.py
@@ -1,0 +1,2 @@
+# This file intentionally contains a SyntaxError
+a =  # noqa

--- a/src/App/tests/fixtures/getObject.py
+++ b/src/App/tests/fixtures/getObject.py
@@ -1,0 +1,5 @@
+import sys
+
+
+def f1():
+    return sys._getframe(0).f_code.co_filename

--- a/src/App/tests/test_Extensions.py
+++ b/src/App/tests/test_Extensions.py
@@ -1,0 +1,40 @@
+import os.path
+import types
+import unittest
+
+import App.config
+from App.Extensions import getObject
+
+
+class GetObjectTests(unittest.TestCase):
+    """Testing ..Extensions.getObject()."""
+
+    def setUp(self):
+        cfg = App.config.getConfiguration()
+        assert not hasattr(cfg, 'extensions')
+        cfg.extensions = os.path.join(os.path.dirname(__file__), 'fixtures')
+
+    def tearDown(self):
+        cfg = App.config.getConfiguration()
+        del cfg.extensions
+
+    def test_Extensions__getObject__1(self):
+        """It returns an the requested function.
+
+        The code object of this function has the file name set.
+        """
+        obj = getObject('getObject', 'f1')
+        self.assertIsInstance(obj, types.FunctionType)
+        self.assertEqual(obj.__name__, 'f1')
+        path = obj()
+        self.assertTrue(
+            path.endswith(
+                os.path.sep.join(
+                    ['App', 'tests', 'fixtures', 'getObject.py'])))
+
+    def test_Extensions__getObject__2(self):
+        """It raises a SyntaxError if necessary."""
+        try:
+            getObject('error', 'f1')
+        except SyntaxError as e:
+            self.assertEqual(str(e), 'invalid syntax (error.py, line 2)')

--- a/src/App/tests/test_Extensions.py
+++ b/src/App/tests/test_Extensions.py
@@ -19,9 +19,9 @@ class GetObjectTests(unittest.TestCase):
         del cfg.extensions
 
     def test_Extensions__getObject__1(self):
-        """It returns an the requested function.
+        """Check that "getObject" returns the requested function and ...
 
-        The code object of this function has the file name set.
+        that its code object has the path set.
         """
         obj = getObject('getObject', 'f1')
         self.assertIsInstance(obj, types.FunctionType)


### PR DESCRIPTION
Port of https://github.com/zopefoundation/Zope/pull/1138 to Zope 4.

I need this change for a customer on Zope 4 to fix coverage of code used by ExternalMethods.