### PR TITLE
Tighten down the ZMI frame source logic to only allow site-local sources

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,8 +8,10 @@ The change log for the previous version, Zope 4, is at
 https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 
 
-5.9 (unreleased)
-----------------
+5.8.5 (unreleased)
+------------------
+
+- Tighten down the ZMI frame source logic to only allow site-local sources.
 
 - Update to newest compatible versions of dependencies.
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ def _read_file(filename):
 README = _read_file('README.rst')
 CHANGES = _read_file('CHANGES.rst')
 
-version = '5.9.dev0'
+version = '5.8.5.dev0'
 
 setup(
     name='Zope',

--- a/src/App/dtml/manage.dtml
+++ b/src/App/dtml/manage.dtml
@@ -19,7 +19,7 @@
 		name="manage_menu"
 		marginwidth="2" marginheight="2"
 		/>
-	<frame src="<dtml-var "REQUEST.get('came_from',None)!=None and REQUEST.get('came_from',None) or '%s/manage_workspace'%(REQUEST.URL1)" html_quote>"
+	<frame src="<dtml-var "getZMIMainFrameTarget(REQUEST)" html_quote>"
 		name="manage_main"
 		marginwidth="2" marginheight="2"
 		/>

--- a/src/OFS/Application.py
+++ b/src/OFS/Application.py
@@ -128,8 +128,8 @@ class Application(ApplicationDefaultPermissions, Folder.Folder, FindSupport):
         # Only allow a passed-in ``came_from`` URL if it is local (just a path)
         # or if the URL scheme and hostname are the same as our own
         if (not parsed_came_from.scheme and not parsed_came_from.netloc) or \
-           (parsed_parent_url.scheme == parsed_came_from.scheme and
-            parsed_parent_url.netloc == parsed_came_from.netloc):
+           (parsed_parent_url.scheme == parsed_came_from.scheme
+                and parsed_parent_url.netloc == parsed_came_from.netloc):
             return came_from
 
         return default

--- a/src/OFS/tests/testApplication.py
+++ b/src/OFS/tests/testApplication.py
@@ -1,5 +1,4 @@
 import unittest
-from urllib.parse import urlparse
 
 from Testing.ZopeTestCase import FunctionalTestCase
 
@@ -128,7 +127,6 @@ class ApplicationTests(unittest.TestCase):
 
         for URL1 in ('http://nohost', 'https://nohost/some/path'):
             request = {'URL1': URL1}
-            parsed_url1 = urlparse(URL1)
 
             # No came_from at all
             self.assertEqual(app.getZMIMainFrameTarget(request),
@@ -145,7 +143,7 @@ class ApplicationTests(unittest.TestCase):
             # Local (path only) came_from
             request['came_from'] = '/new/path'
             self.assertEqual(app.getZMIMainFrameTarget(request),
-                             f'/new/path')
+                             '/new/path')
 
             # came_from URL outside our own server
             request['came_from'] = 'https://www.zope.dev/index.html'


### PR DESCRIPTION
The ZMI frame logic uses a request variable `came_from` to determine the source location for the right-hand side frame when JavaScript is disabled. This can be passed in via query string, which means it's out of our control and must be sanity-checked. Only site-local pages should load into that frame.