### PR TITLE
WSGIPublisher: set REMOTE_USER even in case of error

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 
 - Update to newest compatible versions of dependencies.
 
+- Added image dimensions to SVG file properties
+  `#1146 <https://github.com/zopefoundation/Zope/pull/1146>`_.
 
 5.8.4 (2023-09-06)
 ------------------
@@ -49,8 +51,6 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 - Update ``AccessControl`` to version 6.2 to mitigate a security problem.
   (CVE-2023-41050)
 
-- Added image dimensions to SVG file properties 
-  `#1146 <https://github.com/zopefoundation/Zope/pull/1146>`_.
 
 5.8.3 (2023-06-15)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,9 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 - Added image dimensions to SVG file properties
   `#1146 <https://github.com/zopefoundation/Zope/pull/1146>`_.
 
+- Fix username not in access log for error requests, see issue
+  `#1155 <https://github.com/zopefoundation/Zope/issues/1155>`_.
+
 5.8.4 (2023-09-06)
 ------------------
 

--- a/src/ZPublisher/WSGIPublisher.py
+++ b/src/ZPublisher/WSGIPublisher.py
@@ -387,12 +387,13 @@ def publish_module(environ, start_response,
             try:
                 with load_app(module_info) as new_mod_info:
                     with transaction_pubevents(request, response):
-                        response = _publish(request, new_mod_info)
-
-                        user = getSecurityManager().getUser()
-                        if user is not None and \
-                           user.getUserName() != 'Anonymous User':
-                            environ['REMOTE_USER'] = user.getUserName()
+                        try:
+                            response = _publish(request, new_mod_info)
+                        finally:
+                            user = getSecurityManager().getUser()
+                            if user is not None and \
+                               user.getUserName() != 'Anonymous User':
+                                environ['REMOTE_USER'] = user.getUserName()
                 break
             except TransientError:
                 if request.supports_retry():

--- a/src/ZPublisher/tests/test_WSGIPublisher.py
+++ b/src/ZPublisher/tests/test_WSGIPublisher.py
@@ -820,6 +820,15 @@ class TestPublishModule(ZopeTestCase):
         self._callFUT(environ, start_response, _publish)
         self.assertFalse('REMOTE_USER' in environ)
 
+    def test_set_REMOTE_USER_environ_error(self):
+        environ = self._makeEnviron()
+        start_response = DummyCallable()
+        _publish = DummyCallable()
+        _publish._raise = ValueError()
+        with self.assertRaises(ValueError):
+            self._callFUT(environ, start_response, _publish)
+        self.assertEqual(environ['REMOTE_USER'], user_name)
+
     def test_webdav_source_port(self):
         from ZPublisher import WSGIPublisher
         old_webdav_source_port = WSGIPublisher._WEBDAV_SOURCE_PORT


### PR DESCRIPTION
This fixes a problem that user name was empty in access log for error pages.

Fixes #1155