### PR TITLE
SVG-File: avoid attr error on missing dimensions

### DIFF
--- a/src/OFS/Image.py
+++ b/src/OFS/Image.py
@@ -843,6 +843,8 @@ def getImageInfo(data):
         except Exception:
             return content_type, width, height
         for svg in xmldoc.getElementsByTagName('svg'):
+            w = width
+            h = height
             content_type = 'image/svg+xml'
             if 'height' in svg.attributes and 'width' in svg.attributes:
                 w = svg.attributes['width'].value
@@ -866,8 +868,8 @@ def getImageInfo(data):
                 viewBox = [int(float(x)) for x in viewBox.split(' ')]
                 w = viewBox[2] - viewBox[0]
                 h = viewBox[3] - viewBox[1]
-        width = int(w)
-        height = int(h)
+            width = int(w)
+            height = int(h)
 
     return content_type, width, height
 


### PR DESCRIPTION
In addition to https://github.com/zopefoundation/Zope/pull/1146:
SVG font files do not contain width/height dimension. This case of missing attrs is covered now and the preview show the browser rendered XML.

![svg_fonts](https://github.com/zopefoundation/Zope/assets/29705216/0bd45b85-e0f6-4ff9-b58f-f42005aa1658)
