### PR TITLE
Credit Miguel Segovia Gil for reporting a problem.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 ------------------
 
 - Tighten down the ZMI frame source logic to only allow site-local sources.
+  Problem reported by Miguel Segovia Gil.
 
 - Update to newest compatible versions of dependencies.
 


### PR DESCRIPTION
I did this just now on the [backport to the 4.x branch](https://github.com/zopefoundation/Zope/pull/1160/files) as well.
Miguel reported the problem earlier this year to the security list.  We decided to fix it without security advisory, but crediting him would still be good.