### PR TITLE
Base logic for CVE-2023-42458 on the media type proper

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,9 +13,10 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 
 - Update to newest compatible versions of dependencies.
 
-- Base the inline/attachment logic developped for CVE-2023-42458
-  on the media type proper (ignoring parameters and leading/trailing
-  whitespace).
+- Base the inline/attachment logic developed for CVE-2023-42458
+  on the media type proper (ignore parameters and
+  whitespace and normalize to lowercase)
+  (`#1167 <https://github.com/zopefoundation/Zope/pull/1167>`_).
 
 
 5.8.5 (2023-09-21)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,10 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 
 - Update to newest compatible versions of dependencies.
 
+- Base the inline/attachment logic developped for CVE-2023-42458
+  on the media type proper (ignoring parameters and leading/trailing
+  whitespace).
+
 
 5.8.5 (2023-09-21)
 ------------------

--- a/src/OFS/Image.py
+++ b/src/OFS/Image.py
@@ -474,7 +474,7 @@ class File(
     def _should_force_download(self):
         # If this returns True, the caller should set a
         # Content-Disposition header with filename.
-        mimetype = self.content_type
+        mimetype = extract_media_type(self.content_type)
         if not mimetype:
             return False
         if self.use_denylist:
@@ -1170,3 +1170,11 @@ class Pdata(Persistent, Implicit):
             _next = self.next
 
         return b''.join(r)
+
+
+def extract_media_type(content_type):
+    """extract the proper media type from *content_type*.
+
+    Ignore parameters and leading/trailing whitespace.
+    """
+    return content_type and content_type.split(";", 1)[0].strip()

--- a/src/OFS/Image.py
+++ b/src/OFS/Image.py
@@ -1175,6 +1175,13 @@ class Pdata(Persistent, Implicit):
 def extract_media_type(content_type):
     """extract the proper media type from *content_type*.
 
-    Ignore parameters and leading/trailing whitespace.
+    Ignore parameters and whitespace and normalize to lower case.
     """
-    return content_type and content_type.split(";", 1)[0].strip()
+    if not content_type:
+        return content_type
+    # ignore parameters
+    content_type = content_type.split(";", 1)[0]
+    # ignore whitespace
+    content_type = "".join(content_type.split())
+    # normalize to lowercase
+    return content_type.lower()

--- a/src/OFS/tests/testFileAndImage.py
+++ b/src/OFS/tests/testFileAndImage.py
@@ -458,6 +458,8 @@ class SVGTests(ImageTests):
         extract = OFS.Image.extract_media_type
         self.assertIsNone(extract(None))
         self.assertEqual(extract("text/plain"), "text/plain")
+        self.assertEqual(extract("TEXT/PLAIN"), "text/plain")
+        self.assertEqual(extract("text / plain"), "text/plain")
         self.assertEqual(extract(" text/plain ; charset=utf-8"), "text/plain")
 
 

--- a/src/OFS/tests/testFileAndImage.py
+++ b/src/OFS/tests/testFileAndImage.py
@@ -433,6 +433,18 @@ class SVGTests(ImageTests):
             "attachment; filename*=UTF-8''file.svg",
         )
 
+    def testViewImageOrFile_with_denylist_and_ct_param(self):
+        request = self.app.REQUEST
+        response = request.RESPONSE
+        self.file.use_denylist = True
+        self.file.content_type += ";charset=utf-8"
+        result = self.file.index_html(request, response)
+        self.assertEqual(result, self.data)
+        self.assertEqual(
+            response.getHeader("Content-Disposition"),
+            "attachment; filename*=UTF-8''file.svg",
+        )
+
     def testViewImageOrFile_with_empty_denylist(self):
         request = self.app.REQUEST
         response = request.RESPONSE
@@ -441,6 +453,12 @@ class SVGTests(ImageTests):
         result = self.file.index_html(request, response)
         self.assertEqual(result, self.data)
         self.assertIsNone(response.getHeader("Content-Disposition"))
+
+    def test_extract_media_type(self):
+        extract = OFS.Image.extract_media_type
+        self.assertIsNone(extract(None))
+        self.assertEqual(extract("text/plain"), "text/plain")
+        self.assertEqual(extract(" text/plain ; charset=utf-8"), "text/plain")
 
 
 class FileEditTests(Testing.ZopeTestCase.FunctionalTestCase):


### PR DESCRIPTION
ignore parameters and whitespace and normalize to lowercase.

Motivated by the report from Almir Zunic on "mailto:security@plone.org" " [p/z-sec] XSS - found in Management interface" I reexamined the logic developed for CVE-2023-42458 and found it incomplete. It compares the whole `content_type` against a list of types. But, at least if set manually, `content_type` can contain parameters and/or additional whitespace and may use uppercase letters which could not be directly compared with a types list.

When the logic is based on an allow list (the default), files with an unexpected `content_type` are delivered as attachment (which is safe). However, if the logic is based on a deny list, potentially dangerous files could be presented inline.

This PR bases the  CVE-2023-42458 logic on the media type proper: it ignores parameters and whitespace and normalizes to lowercase.