### PR TITLE
Fix #1172

### DIFF
--- a/src/ZPublisher/HTTPRequest.py
+++ b/src/ZPublisher/HTTPRequest.py
@@ -1539,9 +1539,6 @@ class LimitedFileReader:
             raise StopIteration()
         return data
 
-    def __del__(self):
-        return self.fp.__del__()
-
     def __getattr__(self, attr):
         if attr not in self.DELEGATE:
             raise AttributeError(attr)


### PR DESCRIPTION
#1172 has defined  `ZPublisher.HTTPRequest.LimtedFileReader.__del__` as
```python
    def __del__(self):
        return self.fp.__del__()
```
This is wrong: `fp` might be referenced from somewhere else; then its `__del__` should not yet be called.

In fact, we do not need a  `__del__`  definition.
Therefore, this PR removes it.
