### PR TITLE
Separate lint and package checks

### DIFF
--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/zope-product
 [meta]
 template = "zope-product"
-commit-id = "571024f0"
+commit-id = "13b9049c"
 
 [python]
 with-pypy = false
@@ -10,7 +10,7 @@ with-docs = true
 with-sphinx-doctests = false
 with-windows = true
 with-macos = true
-with-future-python = true
+with-future-python = false
 
 [coverage]
 fail-under = 80

--- a/src/ZPublisher/HTTPRequest.py
+++ b/src/ZPublisher/HTTPRequest.py
@@ -1505,7 +1505,7 @@ class LimitedFileReader:
     """File wrapper emulating EOF."""
 
     # attributes to be delegated to the file
-    DELEGATE = set(["close", "closed", "fileno", "mode", "name"])
+    DELEGATE = {"close", "closed", "fileno", "mode", "name"}
 
     def __init__(self, fp, limit):
         """emulate EOF after *limit* bytes have been read.

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@
 [tox]
 minversion = 3.18
 envlist =
+    release-check
     lint
     py37
     py38
@@ -52,6 +53,23 @@ commands =
     autopep8 --verbose --in-place --recursive --aggressive --aggressive {toxinidir}/src setup.py
     docformatter --in-place --recursive {toxinidir}/src setup.py
 
+[testenv:release-check]
+description = ensure that the distribution is ready to release
+basepython = python3
+skip_install = true
+deps =
+    twine
+    build
+    check-manifest
+    check-python-versions >= 0.20.0
+    wheel
+commands_pre =
+commands =
+    check-manifest
+    check-python-versions
+    python -m build --sdist --no-isolation
+    twine check dist/*
+
 [testenv:lint]
 basepython = python3
 commands_pre =
@@ -61,11 +79,7 @@ allowlist_externals =
 commands =
     isort --check-only --diff {toxinidir}/src {toxinidir}/setup.py
     flake8 {toxinidir}/src {toxinidir}/setup.py
-    check-manifest
-    check-python-versions
 deps =
-    check-manifest
-    check-python-versions
     flake8
     isort
     # Useful flake8 plugins that are Python and Plone specific:


### PR DESCRIPTION
This PR applies https://github.com/zopefoundation/meta/pull/216 as well as https://github.com/zopefoundation/meta/commit/13b9049c6e3fbfbfa04bae5f18ff7396140e1933 to Zope and separates real linting steps, which should run every time, from package consistency checks, which are only important when making a release. That way the lint check will turn green again and contributors can merge their own PRs.