### PR TITLE
Separate ZODB connection information into new ZODB Connections view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 5.8.7 (unreleased)
 ------------------
 
+- Separate ZODB connection information into new ZODB Connections view
+
 - Update the Ace editor in the ZMI.
 
 - Restrict access to static ZMI resources.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,11 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 5.8.7 (unreleased)
 ------------------
 
-- Separate ZODB connection information into new ZODB Connections view
+- Separate ZODB connection information into new ZODB Connections view.
+
+- Move the cache detail links to the individual database pages.
+
+- Fix the auto refresh functionality on the Reference Count page
 
 - Update the Ace editor in the ZMI.
 

--- a/src/App/ApplicationManager.py
+++ b/src/App/ApplicationManager.py
@@ -238,8 +238,7 @@ class DebugManager(Tabs, Traversable, Implicit):
 InitializeClass(DebugManager)
 
 
-class ApplicationManager(CacheManager,
-                         Persistent,
+class ApplicationManager(Persistent,
                          Tabs,
                          Traversable,
                          Implicit):
@@ -316,7 +315,7 @@ class ApplicationManager(CacheManager,
         return getConfiguration().clienthome
 
 
-class AltDatabaseManager(Traversable, UndoSupport):
+class AltDatabaseManager(CacheManager, Traversable, UndoSupport):
     """ Database management DBTab-style
     """
     id = 'DatabaseManagement'

--- a/src/App/ApplicationManager.py
+++ b/src/App/ApplicationManager.py
@@ -338,6 +338,9 @@ class AltDatabaseManager(Traversable, UndoSupport):
     def cache_length(self):
         return self._getDB().cacheSize()
 
+    def cache_active_and_inactive_count(self):
+        return sum([x['size'] for x in self._getDB().cacheDetailSize()])
+
     def cache_length_bytes(self):
         return self._getDB().getCacheSizeBytes()
 

--- a/src/App/ApplicationManager.py
+++ b/src/App/ApplicationManager.py
@@ -28,6 +28,7 @@ from App.Management import Tabs
 from App.special_dtml import DTMLFile
 from App.Undo import UndoSupport
 from App.version_txt import version_txt
+from App.ZODBConnectionDebugger import ZODBConnectionDebugger
 from DateTime.DateTime import DateTime
 from OFS.Traversable import Traversable
 from Persistence import Persistent
@@ -63,7 +64,9 @@ class DatabaseChooser(Tabs, Traversable, Implicit):
         {'label': 'Databases', 'action': 'manage_main'},
         {'label': 'Configuration', 'action': '../Configuration/manage_main'},
         {'label': 'DAV Locks', 'action': '../DavLocks/manage_main'},
-        {'label': 'Debug Information', 'action': '../DebugInfo/manage_main'},
+        {'label': 'Reference Counts', 'action': '../DebugInfo/manage_main'},
+        {'label': 'ZODB Connections',
+         'action': '../ZODBConnections/manage_main'},
     )
     MANAGE_TABS_NO_BANNER = True
 
@@ -108,7 +111,9 @@ class ConfigurationViewer(Tabs, Traversable, Implicit):
         {'label': 'Databases', 'action': '../Database/manage_main'},
         {'label': 'Configuration', 'action': 'manage_main'},
         {'label': 'DAV Locks', 'action': '../DavLocks/manage_main'},
-        {'label': 'Debug Information', 'action': '../DebugInfo/manage_main'},
+        {'label': 'Reference Counts', 'action': '../DebugInfo/manage_main'},
+        {'label': 'ZODB Connections',
+         'action': '../ZODBConnections/manage_main'},
     )
     MANAGE_TABS_NO_BANNER = True
 
@@ -150,7 +155,7 @@ class DebugManager(Tabs, Traversable, Implicit):
     manage = manage_main = manage_workspace = DTMLFile('dtml/debug', globals())
     manage_main._setName('manage_main')
     id = 'DebugInfo'
-    name = title = 'Debug Information'
+    name = title = 'Reference Counts'
     meta_type = name
     zmi_icon = 'fas fa-bug'
 
@@ -159,7 +164,9 @@ class DebugManager(Tabs, Traversable, Implicit):
         {'label': 'Databases', 'action': '../Database/manage_main'},
         {'label': 'Configuration', 'action': '../Configuration/manage_main'},
         {'label': 'DAV Locks', 'action': '../DavLocks/manage_main'},
-        {'label': 'Debug Information', 'action': 'manage_main'},
+        {'label': 'Reference Counts', 'action': 'manage_main'},
+        {'label': 'ZODB Connections',
+         'action': '../ZODBConnections/manage_main'},
     )
 
     def refcount(self, n=None, t=(type(Implicit), type(object))):
@@ -224,10 +231,6 @@ class DebugManager(Tabs, Traversable, Implicit):
                  'rc': n[1][0],
                  } for n in rd]
 
-    def dbconnections(self):
-        import Zope2  # for data
-        return Zope2.DB.connectionDebugInfo()
-
     def manage_getSysPath(self):
         return list(sys.path)
 
@@ -255,6 +258,7 @@ class ApplicationManager(CacheManager,
     Configuration = ConfigurationViewer()
     DavLocks = DavLockManager()
     DebugInfo = DebugManager()
+    ZODBConnections = ZODBConnectionDebugger()
 
     manage = manage_main = DTMLFile('dtml/cpContents', globals())
     manage_main._setName('manage_main')
@@ -263,7 +267,8 @@ class ApplicationManager(CacheManager,
         {'label': 'Databases', 'action': 'Database/manage_main'},
         {'label': 'Configuration', 'action': 'Configuration/manage_main'},
         {'label': 'DAV Locks', 'action': 'DavLocks/manage_main'},
-        {'label': 'Debug Information', 'action': 'DebugInfo/manage_main'},
+        {'label': 'Reference Counts', 'action': 'DebugInfo/manage_main'},
+        {'label': 'ZODB Connections', 'action': 'ZODBConnections/manage_main'},
     )
     MANAGE_TABS_NO_BANNER = True
 

--- a/src/App/DavLockManager.py
+++ b/src/App/DavLockManager.py
@@ -39,7 +39,9 @@ class DavLockManager(Item, Implicit):
         {'label': 'Databases', 'action': '../Database/manage_main'},
         {'label': 'Configuration', 'action': '../Configuration/manage_main'},
         {'label': 'DAV Locks', 'action': 'manage_main'},
-        {'label': 'Debug Information', 'action': '../DebugInfo/manage_main'},
+        {'label': 'Reference Counts', 'action': '../DebugInfo/manage_main'},
+        {'label': 'ZODB Connections',
+         'action': '../ZODBConnections/manage_main'},
     )
 
     @security.protected(webdav_manage_locks)

--- a/src/App/ZODBConnectionDebugger.py
+++ b/src/App/ZODBConnectionDebugger.py
@@ -64,6 +64,7 @@ class ZODBConnectionDebugger(Item, Implicit):
                     request_info_formatted = pprint.pformat(request_info)
 
             if opened is not None:
+                # output UTC time with the standard Z time zone indicator
                 open_since = "{}".format(
                     time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(opened)))
                 open_for = "{:.2f}s".format(now - opened)
@@ -71,7 +72,6 @@ class ZODBConnectionDebugger(Item, Implicit):
                 open_since = '(closed)'
                 open_for = ''
 
-            # output UTC time with the standard Z time zone indicator
             result.append({
                 'open_since': open_since,
                 'open_for': open_for,

--- a/src/App/ZODBConnectionDebugger.py
+++ b/src/App/ZODBConnectionDebugger.py
@@ -1,0 +1,90 @@
+##############################################################################
+#
+# Copyright (c) 2023 Zope Foundation and Contributors.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE
+#
+##############################################################################
+
+import pprint
+import time
+from operator import itemgetter
+
+from AccessControl.class_init import InitializeClass
+from AccessControl.SecurityInfo import ClassSecurityInfo
+from Acquisition import Implicit
+from App.special_dtml import DTMLFile
+from OFS.SimpleItem import Item
+
+
+class ZODBConnectionDebugger(Item, Implicit):
+    id = 'ZODBConnectionDebugger'
+    name = title = 'ZODB Connections'
+    meta_type = 'ZODB Connection Debugger'
+    zmi_icon = 'fas fa-bug'
+
+    security = ClassSecurityInfo()
+
+    manage_zodb_conns = manage_main = manage = manage_workspace = DTMLFile(
+        'dtml/zodbConnections', globals())
+    manage_zodb_conns._setName('manage_zodb_conns')
+    manage_options = (
+        {'label': 'Control Panel', 'action': '../manage_main'},
+        {'label': 'Databases', 'action': '../Database/manage_main'},
+        {'label': 'Configuration', 'action': '../Configuration/manage_main'},
+        {'label': 'DAV Locks', 'action': '../DavLocks/manage_main'},
+        {'label': 'Reference Counts', 'action': '../DebugInfo/manage_main'},
+        {'label': 'ZODB Connections', 'action': 'manage_main'},
+    )
+
+    def dbconnections(self):
+        import Zope2  # for data
+
+        result = []
+        now = time.time()
+
+        def get_info(connection):
+            # `result`, `time` and `before` are lexically inherited.
+            request_info = {}
+            request_info_formatted = ''
+            debug_info_formatted = ''
+            opened = connection.opened
+            debug_info = connection.getDebugInfo() or {}
+
+            if debug_info:
+                debug_info_formatted = pprint.pformat(debug_info)
+                if len(debug_info) == 2:
+                    request_info = debug_info[0]
+                    request_info.update(debug_info[1])
+                    request_info_formatted = pprint.pformat(request_info)
+
+            if opened is not None:
+                open_since = "{}".format(
+                    time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(opened)))
+                open_for = "{:.2f}s".format(now - opened)
+            else:
+                open_since = '(closed)'
+                open_for = ''
+
+            # output UTC time with the standard Z time zone indicator
+            result.append({
+                'open_since': open_since,
+                'open_for': open_for,
+                'info': debug_info,
+                'info_formatted': debug_info_formatted,
+                'request_info': request_info,
+                'request_formatted': request_info_formatted,
+                'before': connection.before,
+                'cache_size': len(connection._cache),
+            })
+
+        Zope2.DB._connectionMap(get_info)
+        return sorted(result, key=itemgetter('open_since'))
+
+
+InitializeClass(ZODBConnectionDebugger)

--- a/src/App/dtml/dbMain.dtml
+++ b/src/App/dtml/dbMain.dtml
@@ -91,10 +91,21 @@
       <tr>
           <th>Total</th>
           <th>&dtml-cache_length;</th>
-          <th>&nbsp;</th>
+          <th>&dtml-cache_active_and_inactive_count;</th>
       </tr>
     </tbody>
   </table>
+
+  <p class="form-help">
+    <a href="cache_detail" class="mr-3" target="blank">
+      <i class="fas fa-microchip" title="Cache detail"></i>
+      Cache detail
+    </a>
+    <a href="cache_extreme_detail" target="blank">
+      <i class="fas fa-microchip" title="Cache extreme detail"></i>
+      Cache extreme detail
+    </a>
+  </p>
 
   <div class="zmi-controls mb-5">
     <form action="&dtml-URL1;/manage_minimize" method="post">

--- a/src/App/dtml/debug.dtml
+++ b/src/App/dtml/debug.dtml
@@ -49,33 +49,26 @@
     </dtml-if>
   </dtml-let>
   
-  <p class="form-help">
-    <a href="../Database/cache_detail" class="mr-3" target="blank">
-      <i class="fas fa-microchip" title="Cache detail"></i> 
-      Cache detail
-    </a>
-    <a href="../Database/cache_extreme_detail" target="blank">
-      <i class="fas fa-microchip" title="Cache extreme detail"></i> 
-      Cache extreme detail
-    </a>
-  </p>
-
   <div class="zmi-controls row border-top border-bottom p-3 bg-light">
     <form action="&dtml-URL;" method="GET" class="form-group form-inline p-0 m-0">
       <button class="btn btn-primary mr-3" 
         onclick="window.location.href='&dtml-URL;?update_snapshot=1';"
       >Update Snapshot</button>
       <dtml-if debug_auto_reload>
-        <button class="btn btn-primary mr-3"
-          onclick="window.location.href='&dtml-URL;';"
-        >Stop auto refresh</button>
+          <button class="btn btn-primary mr-3"
+            onclick="window.location.href='&dtml-URL;';"
+          >Stop auto refresh</button>
+        </form>
       <dtml-else>
-        <button class="btn btn-primary mr-3"
-          onclick="window.location.href='&dtml-URL;';"
-        >Refresh</button>
-        <label for="debug_auto_reload" class="mx-3">Auto refresh interval (seconds):</label>
-        <input class="form-control mr-3" type="text" id="debug_auto_reload" name="debug_auto_reload" size="3" value="10" />
-        <input class="btn btn-primary" type="submit" value="Start auto refresh" />
+          <button class="btn btn-primary mr-3"
+            onclick="window.location.href='&dtml-URL;';"
+          >Refresh</button>
+        </form>
+        <form action="&dtml-URL;" method="GET" class="form-group form-inline p-0 m-0">
+          <label for="debug_auto_reload" class="mx-3">Auto refresh interval (seconds):</label>
+          <input class="form-control mr-3" type="text" id="debug_auto_reload" name="debug_auto_reload" size="3" value="10" />
+          <input class="btn btn-primary" type="submit" value="Start auto refresh" />
+        </form>
       </dtml-if>
     </form>
   </div>

--- a/src/App/dtml/debug.dtml
+++ b/src/App/dtml/debug.dtml
@@ -3,7 +3,7 @@
 <meta HTTP-EQUIV="Refresh"
   CONTENT="&dtml-debug_auto_reload;;URL=&dtml-URL;?debug_auto_reload=&dtml-debug_auto_reload;">
 </dtml-if>
-<dtml-with "_(management_view='Debug Information')">
+<dtml-with "_(management_view='Reference Counts')">
   <dtml-var manage_tabs>
 </dtml-with>
 
@@ -14,7 +14,7 @@
 <main class="container-fluid">
 
   <p class="form-help mt-4">
-    Reference count and database connection information
+    Python reference count information
   </p>
 
   <h3>Top 100 reference counts</h3>
@@ -80,20 +80,6 @@
     </form>
   </div>
   
-  <h3>ZODB database connections</h3>
-  <table class="table table-sm table-bordered mb-5">
-    <tr>
-      <th>Opened</th>
-      <th>Info</th>
-    </tr>
-    <dtml-in dbconnections mapping>
-      <tr>
-        <td class="text-nowrap">&dtml-opened;</td>
-        <td><samp>&dtml-info;</samp></td>
-      </tr>
-    </dtml-in>
-  </table>
-
 </main>
 
 <dtml-var manage_page_footer>

--- a/src/App/dtml/zodbConnections.dtml
+++ b/src/App/dtml/zodbConnections.dtml
@@ -13,29 +13,29 @@
   </p>
  
   <h3>ZODB database connections</h3>
-  <table class="table-sm table-bordered mb-5">
+  <table class="table table-sm table-striped mt-3 mb-5">
     <tr>
-      <th>Opened at</th>
-      <th>Duration</th>
-      <th>Info</th>
+      <th class="text-muted pr-3">Opened at</th>
+      <th class="text-muted pr-3">Duration</th>
+      <th class="text-muted w-100">Info</th>
     </tr>
     <dtml-in dbconnections mapping>
       <tr>
-        <td class="text-nowrap" valign="top">&dtml-open_since;</td>
-        <td class="text-nowrap" valign="top"><dtml-var "open_for or '-'"></td>
-        <td>
+        <td class="text-nowrap pr-3" valign="top">&dtml-open_since;</td>
+        <td class="text-nowrap pr-3" valign="top"><dtml-var "open_for or '-'"></td>
+        <td class="text-nowrap text-primary">
           <dtml-if open_for>
             <details>
               <dtml-if request_info>
                 <summary>
-                  <b><dtml-var "request_info['REQUEST_METHOD']"> <dtml-var "request_info['REQUEST_URI']"></b>
+                  <b><dtml-var "request_info.get('REQUEST_METHOD')"> <dtml-var "request_info.get('REQUEST_URI')"></b>
                 </summary>
-                <pre><dtml-var request_formatted html_quote></pre>
+                <pre style="font-size:smaller"><dtml-var request_formatted html_quote></pre>
               <dtml-else>
                 <summary>
                   No request information available
                 </summary>
-                <pre><dtml-var info_formatted html_quote></pre>
+                <pre style="font-size:smaller"><dtml-var info_formatted html_quote></pre>
               </dtml-if>
             </details>
           <dtml-else>

--- a/src/App/dtml/zodbConnections.dtml
+++ b/src/App/dtml/zodbConnections.dtml
@@ -28,7 +28,7 @@
             <details>
               <dtml-if request_info>
                 <summary>
-                  <b><dtml-var "request_info.get('REQUEST_METHOD')"> <dtml-var "request_info.get('REQUEST_URI')"></b>
+                  <b><dtml-var "request_info.get('REQUEST_METHOD')"> <dtml-var "request_info.get('REQUEST_URI') or request_info.get('PATH_INFO')"></b>
                 </summary>
                 <pre style="font-size:smaller"><dtml-var request_formatted html_quote></pre>
               <dtml-else>

--- a/src/App/dtml/zodbConnections.dtml
+++ b/src/App/dtml/zodbConnections.dtml
@@ -1,0 +1,55 @@
+<dtml-var manage_page_header>
+<dtml-if debug_auto_reload>
+<meta HTTP-EQUIV="Refresh"
+  CONTENT="&dtml-debug_auto_reload;;URL=&dtml-URL;?debug_auto_reload=&dtml-debug_auto_reload;">
+</dtml-if>
+<dtml-with "_(management_view='ZODB Connections')">
+  <dtml-var manage_tabs>
+</dtml-with>
+
+<main class="container-fluid">
+
+  <p class="form-help mt-4">
+    This page shows ZODB database connections and their current state. The
+    Duration column tells you how long an open database connection has been
+    held by the request shown in the Info column next to it. You can use this
+    view to diagnose long-running requests.
+  </p>
+ 
+  <h3>ZODB database connections</h3>
+  <table class="table-sm table-bordered mb-5">
+    <tr>
+      <th>Opened at</th>
+      <th>Duration</th>
+      <th>Info</th>
+    </tr>
+    <dtml-in dbconnections mapping>
+      <tr>
+        <td class="text-nowrap" valign="top">&dtml-open_since;</td>
+        <td class="text-nowrap" valign="top"><dtml-var "open_for or '-'"></td>
+        <td>
+          <dtml-if open_for>
+            <details>
+              <dtml-if request_info>
+                <summary>
+                  <b><dtml-var "request_info['REQUEST_METHOD']"> <dtml-var "request_info['REQUEST_URI']"></b>
+                </summary>
+                <pre><dtml-var request_formatted html_quote></pre>
+              <dtml-else>
+                <summary>
+                  No request information available
+                </summary>
+                <pre><dtml-var info_formatted html_quote></pre>
+              </dtml-if>
+            </details>
+          <dtml-else>
+            -
+          </dtml-if>
+        </td>
+      </tr>
+    </dtml-in>
+  </table>
+
+</main>
+
+<dtml-var manage_page_footer>

--- a/src/App/dtml/zodbConnections.dtml
+++ b/src/App/dtml/zodbConnections.dtml
@@ -13,7 +13,7 @@
   </p>
  
   <h3>ZODB database connections</h3>
-  <table class="table table-sm table-striped mt-3 mb-5">
+  <table class="table table-striped mt-3 mb-5">
     <tr>
       <th class="text-muted pr-3">Opened at</th>
       <th class="text-muted pr-3">Duration</th>

--- a/src/App/dtml/zodbConnections.dtml
+++ b/src/App/dtml/zodbConnections.dtml
@@ -1,8 +1,4 @@
 <dtml-var manage_page_header>
-<dtml-if debug_auto_reload>
-<meta HTTP-EQUIV="Refresh"
-  CONTENT="&dtml-debug_auto_reload;;URL=&dtml-URL;?debug_auto_reload=&dtml-debug_auto_reload;">
-</dtml-if>
 <dtml-with "_(management_view='ZODB Connections')">
   <dtml-var manage_tabs>
 </dtml-with>

--- a/src/zmi/styles/resources/zmi_base.css
+++ b/src/zmi/styles/resources/zmi_base.css
@@ -969,6 +969,18 @@ header.navbar select.form-control-sm,
 	box-sizing: border-box;
 }
 
+.zmi-connection_info {
+    display: none;
+}
+
+#request_uri {
+    margin-bottom: 0;
+}
+
+#conn_info {
+    margin-top: 1rem;
+}
+
 /* EXAMPLE: IMPLANT YOUR LOGO */
 /*
 	.zmi-manage_menu {


### PR DESCRIPTION
This PR creates a new Control Panel tab "ZODB Connections" that contains the ZODB connection information shown at the bottom of the former "Debug" page. Debug is renamed to "Reference Counts". The goal is to make this information easier to access and read.

When Zope is running and you visit the "Debug" page several times the page can get very long and getting to the ZODB connection information is inconvenient and cumbersome.

The new "ZODB Connections" page also aims to show more useful information at a glance. It hides the full request information at first and reveals it when you click on the request URI that is shown. The request data is also formatted and sorted now.