### PR TITLE
support form data in PUT requests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 5.8.7 (unreleased)
 ------------------
 
+- Support form data in ``PUT`` requests (following the ``multipart`` example).
+  Fixes `#1182 <https://github.com/zopefoundation/Zope/issues/1182>`_.
+
 - Separate ZODB connection information into new ZODB Connections view.
 
 - Move the cache detail links to the individual database pages.

--- a/src/ZPublisher/HTTPRequest.py
+++ b/src/ZPublisher/HTTPRequest.py
@@ -1450,7 +1450,12 @@ class ZopeFieldStorage(ValueAccessor):
         if method in ("POST", "PUT") \
            and content_type in (
            "multipart/form-data", "application/x-www-form-urlencoded",
-           "application/x-url-encoded"):
+           "application/x-url-encoded",
+           # ``Testing`` assumes "application/x-www-form-urlencoded"
+           # as default content type
+           # We have mapped a missing content type to ``""``.
+           "",
+           ):
             try:
                 fpos = fp.tell()
             except Exception:
@@ -1462,7 +1467,7 @@ class ZopeFieldStorage(ValueAccessor):
                     disk_limit=FORM_DISK_LIMIT,
                     memfile_limit=FORM_MEMFILE_LIMIT,
                     charset="latin-1").parts()
-            elif content_type == "application/x-www-form-urlencoded":
+            else:
                 post_qs = fp.read(FORM_MEMORY_LIMIT).decode("latin-1")
                 if fp.read(1):
                     raise BadRequest("form data processing "

--- a/src/ZPublisher/HTTPRequest.py
+++ b/src/ZPublisher/HTTPRequest.py
@@ -1432,19 +1432,25 @@ class ZopeFieldStorage(ValueAccessor):
         url_qs = environ.get("QUERY_STRING", "")
         post_qs = ""
         hl = []
-        content_type = environ.get("CONTENT_TYPE",
-                                   "application/x-www-form-urlencoded")
-        hl.append(("content-type", content_type))
+        content_type = environ.get("CONTENT_TYPE")
+        if content_type is not None:
+            hl.append(("content-type", content_type))
+        else:
+            content_type = ""
         content_type, options = parse_options_header(content_type)
         content_type = content_type.lower()
         content_disposition = environ.get("CONTENT_DISPOSITION")
         if content_disposition is not None:
             hl.append(("content-disposition", content_disposition))
+        # Note: ``headers`` does not reflect the complete headers.
+        #  Likely, it should get removed altogether and accesses be replaced
+        #  by a lookup of the corresponding CGI environment keys.
         self.headers = Headers(hl)
         parts = ()
-        if method == "POST" \
-           and content_type in \
-           ("multipart/form-data", "application/x-www-form-urlencoded"):
+        if method in ("POST", "PUT") \
+           and content_type in (
+           "multipart/form-data", "application/x-www-form-urlencoded",
+           "application/x-url-encoded"):
             try:
                 fpos = fp.tell()
             except Exception:

--- a/src/ZPublisher/tests/testHTTPRequest.py
+++ b/src/ZPublisher/tests/testHTTPRequest.py
@@ -1468,6 +1468,7 @@ class HTTPRequestTests(unittest.TestCase, HTTPRequestFactoryMixin):
                 "SERVER_NAME": "localhost",
                 "SERVER_PORT": "8080",
                 "REQUEST_METHOD": "PUT",
+                "CONTENT_TYPE": "application",
             },
             None,
         )
@@ -1524,7 +1525,7 @@ class HTTPRequestTests(unittest.TestCase, HTTPRequestFactoryMixin):
                 "SERVER_PORT": "8080",
                 "REQUEST_METHOD": "PUT",
                 "CONTENT_TYPE": "application/x-www-form-urlencoded",
-                "CONTENT_LENGTH" : len(body),
+                "CONTENT_LENGTH": len(body),
             },
             None,
         )

--- a/src/ZPublisher/tests/testHTTPRequest.py
+++ b/src/ZPublisher/tests/testHTTPRequest.py
@@ -1514,6 +1514,23 @@ class HTTPRequestTests(unittest.TestCase, HTTPRequestFactoryMixin):
         self.assertEqual(req["x"], "äöü")
         self.assertEqual(req["y"], "äöü")
 
+    def test_put_with_form(self):
+        req_factory = self._getTargetClass()
+        body = b"foo=foo"
+        req = req_factory(
+            BytesIO(body),
+            {
+                "SERVER_NAME": "localhost",
+                "SERVER_PORT": "8080",
+                "REQUEST_METHOD": "PUT",
+                "CONTENT_TYPE": "application/x-www-form-urlencoded",
+                "CONTENT_LENGTH" : len(body),
+            },
+            None,
+        )
+        req.processInputs()
+        self.assertEqual(req.form["foo"], "foo")
+
 
 class TestHTTPRequestZope3Views(TestRequestViewsBase):
 


### PR DESCRIPTION
Fixes #1182.

Unlike `multipart`, Zope did not support form data in `PUT` requests. This likely has been a bug: whether a request contains form data is not determined by the request method but by the content type.

This PR brings Zope in line with `multipart`: form data is processed for `POST` and `PUT` requests  controlled by the content type. Like `multipart`, form data is not processed for other request methods (even if the content type indicates form data) because `multipart` would reject those request methods.
