### PR TITLE
Officially support Python 3.12.1.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 5.9.1 (unreleased)
 ------------------
 
+- Officially support Python 3.12.1.
+  (`#1188 <https://github.com/zopefoundation/Zope/issues/1188>`_)
+
 
 5.9 (2023-11-24)
 ----------------

--- a/versions.cfg
+++ b/versions.cfg
@@ -43,7 +43,7 @@ urllib3 = 2.1.0
 z3c.checkversions = 2.1
 zc.recipe.testrunner = 3.0
 zipp = 3.17.0
-zope.testrunner = 6.2
+zope.testrunner = 6.2.1
 
 [versions:python38]
 # Sphinx >= 7.2 requires Python 3.9+


### PR DESCRIPTION
Fixes #1188.

Steps after the PR is merged:

- [ ] update `gh-pages` branch, so the packages on master branch of versions get green again