### PR TITLE
Fix redirections to URLS with host given as IP-litteral

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,9 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 - Officially support Python 3.12.1.
   (`#1188 <https://github.com/zopefoundation/Zope/issues/1188>`_)
 
+- Fix redirections to URLs with host given as IP-literal with brackets.
+  Fixes `#1191 <https://github.com/zopefoundation/Zope/issues/1191>`_.
+
 
 5.9 (2023-11-24)
 ----------------

--- a/src/ZPublisher/HTTPResponse.py
+++ b/src/ZPublisher/HTTPResponse.py
@@ -235,24 +235,24 @@ class HTTPBaseResponse(BaseResponse):
         # To be entirely correct, we must make sure that all non-ASCII
         # characters are quoted correctly.
         parsed = list(urlparse(location))
-        rfc2396_unreserved = "-_.!~*'()"  # RFC 2396 section 2.3
+        rfc3986_unreserved = "-_.!~*'()"  # RFC 3986 section 2.3
         for idx, idx_safe in (
                 # authority
-                (1, ";:@?/&=+$,"),  # RFC 2396 section 3.2, 3.2.1, 3.2.3
+                (1, "[];:@?/&=+$,"),  # RFC 3986 section 3.2, 3.2.1, 3.2.3
                 # path
-                (2, "/;:@&=+$,"),  # RFC 2396 section 3.3
+                (2, "/;:@&=+$,"),  # RFC 3986 section 3.3
                 # params - actually part of path; empty in Python 3
-                (3, "/;:@&=+$,"),  # RFC 2396 section 3.3
+                (3, "/;:@&=+$,"),  # RFC 3986 section 3.3
                 # query
-                (4, ";/?:@&=+,$"),  # RFC 2396 section 3.4
+                (4, ";/?:@&=+,$"),  # RFC 3986 section 3.4
                 # fragment
-                (5, ";/?:@&=+$,"),  # RFC 2396 section 4
+                (5, ";/?:@&=+$,"),  # RFC 3986 section 4
         ):
             # Make a hacky guess whether the component is already
             # URL-encoded by checking for %. If it is, we don't touch it.
             if '%' not in parsed[idx]:
                 parsed[idx] = quote(parsed[idx],
-                                    safe=rfc2396_unreserved + idx_safe)
+                                    safe=rfc3986_unreserved + idx_safe)
         location = urlunparse(parsed)
 
         self.setStatus(status, lock=lock)

--- a/src/ZPublisher/tests/testHTTPResponse.py
+++ b/src/ZPublisher/tests/testHTTPResponse.py
@@ -802,13 +802,17 @@ class HTTPResponseTests(unittest.TestCase):
         self._redirectURLCheck(ENC_URL)
 
     def test_redirect_unreserved_chars(self):
-        # RFC 2396 section 2.3, characters that should not be encoded
+        # RFC 3986 section 2.3, characters that should not be encoded
         url = "http://example.com/-_.!~*'()"
         self._redirectURLCheck(url)
 
     def test_redirect_reserved_chars(self):
-        # RFC 2396 section 3.3, characters with reserved meaning in a path
+        # RFC 3986 section 3.3, characters with reserved meaning in a path
         url = 'http://example.com/+/$/;/,/=/?/&/@@index.html'
+        self._redirectURLCheck(url)
+
+    def test_redirect_ipv6(self):
+        url = "http://[fe80::1ff:fe23:4567:890a]:1234"
         self._redirectURLCheck(url)
 
     def test__encode_unicode_no_content_type_uses_default_encoding(self):


### PR DESCRIPTION
When redirecting to an URL with an IPv6 host with surrounding brackets,
we should not escape the surrounding brackets.

The patch updates referenced RFC from 2396 to 3986, which obsoletes it
and change the safe characters for the netloc part to allow [ and ].
The RFC specifies that [ and ] are only allowed when they are the first
and last characters, but we don't need to be more specific here, because
using [ or ] in other places of the host is rejected by urlparse above.

Fixes #1191