### PR TITLE
Preliminary support for Python 3.13a3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,7 @@ jobs:
         - ["3.10",  "py310"]
         - ["3.11",  "py311"]
         - ["3.12",  "py312"]
+        - ["3.13.0-alpha - 3.13.0",  "py313"]
         - ["3.9",   "docs"]
         - ["3.9",   "coverage"]
         exclude:
@@ -45,18 +46,19 @@ jobs:
           # which causes build and package selection issues.
           - { os: ["macos", "macos-11"], config: ["3.11",  "py311"] }
           - { os: ["macos", "macos-11"], config: ["3.12",  "py312"] }
+          - { os: ["macos", "macos-11"], config: ["3.13.0-alpha - 3.13.0",  "py313"] }
 
     runs-on: ${{ matrix.os[1] }}
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: ${{ matrix.os[0] }}-${{ matrix.config[1] }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.config[0] }}
     - name: Pip cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ matrix.config[0] }}-${{ hashFiles('setup.*', 'tox.ini') }}

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/zope-product
 [meta]
 template = "zope-product"
-commit-id = "cb0568c7"
+commit-id = "74a0f0f2"
 
 [python]
 with-pypy = false
@@ -10,7 +10,7 @@ with-docs = true
 with-sphinx-doctests = false
 with-windows = true
 with-macos = true
-with-future-python = false
+with-future-python = true
 
 [coverage]
 fail-under = 80

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -17,6 +17,12 @@ parts =
 sources-dir = develop
 root-directory = ${buildout:directory}
 auto-checkout =
+    AccessControl
+    Persistence
+    zodbpickle
+    zope.interface
+    zope.proxy
+    zope.security
 
 [testenv]
 PYTHONHASHSEED = random

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,5 +1,5 @@
 AccessControl==6.3
-Acquisition==5.1
+Acquisition==5.2
 AuthEncoding==5.0
 BTrees==5.1
 Chameleon==4.2.0
@@ -22,7 +22,7 @@ beautifulsoup4==4.12.2
 cffi==1.15.1; python_version == '3.7'
 cffi==1.16.0; python_version > '3.7'
 multipart==0.2.4
-persistent==5.1
+persistent==5.2
 pycparser==2.21
 python-gettext==5.0
 pytz==2023.3.post1

--- a/constraints.txt
+++ b/constraints.txt
@@ -11,7 +11,13 @@ Paste==3.7.1
 PasteDeploy==2.1.1; python_version == '3.7'
 PasteDeploy==3.1.0; python_version > '3.7'
 Persistence==4.1
-RestrictedPython==7.0
+RestrictedPython==7.1; python_version == '3.10'
+RestrictedPython==7.1; python_version == '3.11'
+RestrictedPython==7.1; python_version == '3.12'
+RestrictedPython==7.1; python_version == '3.7'
+RestrictedPython==7.1; python_version == '3.8'
+RestrictedPython==7.1; python_version == '3.9'
+RestrictedPython==7.2a1.dev0; python_version > '3.12'
 WSGIProxy2==0.5.1
 WebOb==1.8.7
 WebTest==3.0.0

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -12,7 +12,13 @@ Paste==3.7.1
 PasteDeploy==2.1.1; python_version == '3.7'
 PasteDeploy==3.1.0; python_version > '3.7'
 Persistence==4.1
-RestrictedPython==7.0
+RestrictedPython==7.1; python_version == '3.10'
+RestrictedPython==7.1; python_version == '3.11'
+RestrictedPython==7.1; python_version == '3.12'
+RestrictedPython==7.1; python_version == '3.7'
+RestrictedPython==7.1; python_version == '3.8'
+RestrictedPython==7.1; python_version == '3.9'
+RestrictedPython==7.2a1.dev0; python_version > '3.12'
 WSGIProxy2==0.5.1
 WebOb==1.8.7
 WebTest==3.0.0

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -1,6 +1,6 @@
 -e git+https://github.com/zopefoundation/Zope.git@master#egg=Zope
 AccessControl==6.3
-Acquisition==5.1
+Acquisition==5.2
 AuthEncoding==5.0
 BTrees==5.1
 Chameleon==4.2.0
@@ -23,7 +23,7 @@ beautifulsoup4==4.12.2
 cffi==1.15.1; python_version == '3.7'
 cffi==1.16.0; python_version > '3.7'
 multipart==0.2.4
-persistent==5.1
+persistent==5.2
 pycparser==2.21
 python-gettext==5.0
 pytz==2023.3.post1

--- a/sources.cfg
+++ b/sources.cfg
@@ -32,6 +32,7 @@ Products.SiteErrorLog = git ${remotes:github}/Products.SiteErrorLog pushurl=${re
 Record = git ${remotes:github}/Record pushurl=${remotes:github_push}/Record
 
 # ZTK
+persistent = git ${remotes:github}/persistent
 zodbpickle = git ${remotes:github}/zodbpickle
 zope.annotation = git ${remotes:github}/zope.annotation
 zope.browser = git ${remotes:github}/zope.browser

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ envlist =
     py310
     py311
     py312
+    py313
     docs
     coverage
     pre-commit
@@ -52,7 +53,6 @@ deps =
 commands =
     autopep8 --verbose --in-place --recursive --aggressive --aggressive {toxinidir}/src setup.py
     docformatter --in-place --recursive {toxinidir}/src setup.py
-
 [testenv:release-check]
 description = ensure that the distribution is ready to release
 basepython = python3
@@ -66,7 +66,7 @@ deps =
 commands_pre =
 commands =
     check-manifest
-    check-python-versions
+    check-python-versions --only setup.py,tox.ini,.github/workflows/tests.yml
     python -m build --sdist --no-isolation
     twine check dist/*
 

--- a/versions-prod.cfg
+++ b/versions-prod.cfg
@@ -16,7 +16,7 @@ MultiMapping = 5.0
 Paste = 3.7.1
 PasteDeploy = 3.1.0
 Persistence = 4.1
-RestrictedPython = 7.0
+RestrictedPython = 7.2a1.dev0
 WebTest = 3.0.0
 WSGIProxy2 = 0.5.1
 WebOb = 1.8.7
@@ -89,3 +89,25 @@ PasteDeploy = 2.1.1
 soupsieve = 2.4.1
 # cffi 1.16.0 requires Python 3.8
 cffi = 1.15.1
+# Use newest final release
+RestrictedPython = 7.1
+
+[versions:python38]
+# Use newest final release
+RestrictedPython = 7.1
+
+[versions:python39]
+# Use newest final release
+RestrictedPython = 7.1
+
+[versions:python310]
+# Use newest final release
+RestrictedPython = 7.1
+
+[versions:python311]
+# Use newest final release
+RestrictedPython = 7.1
+
+[versions:python312]
+# Use newest final release
+RestrictedPython = 7.1

--- a/versions-prod.cfg
+++ b/versions-prod.cfg
@@ -5,7 +5,7 @@
 Zope =
 Zope2 = 4.0
 AccessControl = 6.3
-Acquisition = 5.1
+Acquisition = 5.2
 AuthEncoding = 5.0
 BTrees = 5.1
 Chameleon = 4.2.0
@@ -25,7 +25,7 @@ ZODB = 5.8.1
 beautifulsoup4 = 4.12.2
 cffi = 1.16.0
 multipart = 0.2.4
-persistent = 5.1
+persistent = 5.2
 pycparser = 2.21
 python-gettext = 5.0
 pytz = 2023.3.post1


### PR DESCRIPTION
Open issues:

- [x] Pin `RestrictedPython` to a version which can be installed on Python 3.13, probably `7.0a2.dev0` or a newly to be created dev release.
- [x] Needs https://github.com/zopefoundation/zodbpickle/pull/83 to be merged and released.
- [x] Need a release of zope.container after https://github.com/zopefoundation/zope.container/pull/53 is merged.