### PR TITLE
Preliminary step to deprecate docstring based publication control

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,11 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 - Fix redirections to URLs with host given as IP-literal with brackets.
   Fixes `#1191 <https://github.com/zopefoundation/Zope/issues/1191>`_.
 
+- Introduce the decorator ``ZPublisher.zpublish` to explicitly
+  control publication by ``ZPublisher``.
+  For details see
+  `#1197 <https://github.com/zopefoundation/Zope/pull/1197>`_.
+
 
 5.9 (2023-11-24)
 ----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,7 +18,7 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 - Fix redirections to URLs with host given as IP-literal with brackets.
   Fixes `#1191 <https://github.com/zopefoundation/Zope/issues/1191>`_.
 
-- Introduce the decorator ``ZPublisher.zpublish` to explicitly
+- Introduce the decorator ``ZPublisher.zpublish`` to explicitly
   control publication by ``ZPublisher``.
   For details see
   `#1197 <https://github.com/zopefoundation/Zope/pull/1197>`_.

--- a/docs/zdgbook/ObjectPublishing.rst
+++ b/docs/zdgbook/ObjectPublishing.rst
@@ -141,6 +141,11 @@ the future.
 If you decorate a method or class with ``zpublsh(False)``,
 you explicitly mark it or its instances, respectively, as not
 zpublishable.
+If you decorate a method with ``zpublish(methods=...)``
+where the `...` is either a single request method name
+or a sequence of request method names,
+you specify that the object is zpublishable only for the mentioned request
+methods.
 
 Another requirement is that a publishable object must not have a name
 that begins with an underscore. These two restrictions are designed to

--- a/docs/zdgbook/ObjectPublishing.rst
+++ b/docs/zdgbook/ObjectPublishing.rst
@@ -130,8 +130,17 @@ Publishable Object Requirements
 -------------------------------
 
 Zope has few restrictions on publishable objects. The basic rule is
-that the object must have a doc string. This requirement goes for
+that the object must have been marked as zpublishable. This requirement goes for
 methods, too.
+An object or method is marked as zpublishable by decorating
+its class (or a base class) or underlying function, respectively,
+with the ``Zpublisher.zpublish`` decorator.
+For backward compatibility, the existence of a docstring, too,
+marks an object or method as zpublishable; but this will be removed in
+the future.
+If you decorate a method or class with ``zpublsh(False)``,
+you explicitly mark it or its instances, respectively, as not
+zpublishable.
 
 Another requirement is that a publishable object must not have a name
 that begins with an underscore. These two restrictions are designed to
@@ -270,9 +279,13 @@ allow you to navigate between methods.
 
 Consider this example::
 
+  from ZPublisher import zpublish
+
+  @zpublish
   class Example:
       """example class"""
 
+      @zpublish
       def one(self):
           """render page one"""
           return """<html>
@@ -282,6 +295,7 @@ Consider this example::
                     </body>
                     </html>"""
 
+      @zpublish
       def two(self):
           """render page two"""
           return """<html>
@@ -298,9 +312,11 @@ the URL, relative links returned by ``index_html`` won't work right.
 
 For example::
 
+	    @zpublish
             class Example:
                 """example class""""
 
+		 @zpublish
                  def index_html(self):
                      """render default view"""
                     return """<html>
@@ -375,7 +391,9 @@ acquisition, you can use traversal to walk over acquired objects.
 Consider the the following object hierarchy::
 
         from Acquisition import Implicit
+	from ZPublisher import zpublish
 
+	@zpublish
         class Node(Implicit):
             ...
 
@@ -401,20 +419,27 @@ method that your acquire from outside your container.
 For example::
 
         from Acquisition import Implicit
+	from ZPublisher import zpublish
 
+	@zpublish
         class Basket(Implicit):
             ...
+	    @zpublish
             def number_of_items(self):
                 """Returns the number of contained items."""
                 ...
 
+	@zpublish
         class Vegetable(Implicit):
             ...
+	    @zpublish
             def texture(self):
                 """Returns the texture of the vegetable."""
 
+	@zpublish
         class Fruit(Implicit):
             ...
+	    @zpublish
             def color(self):
                 """Returns the color of the fruit."""
 
@@ -582,6 +607,7 @@ called from the web.
 
 Consider this function::
 
+      @zpublish
       def greet(name):
           """Greet someone by name."""
           return "Hello, %s!" % name
@@ -663,6 +689,7 @@ Argument Conversion
 The publisher supports argument conversion. For example consider this
 function::
 
+	@zpublish
         def one_third(number):
             """returns the number divided by three"""
             return number / 3.0

--- a/src/App/ApplicationManager.py
+++ b/src/App/ApplicationManager.py
@@ -19,7 +19,6 @@ from _thread import get_ident
 from urllib import parse
 
 from AccessControl.class_init import InitializeClass
-from AccessControl.requestmethod import requestmethod
 from Acquisition import Implicit
 from App.CacheManager import CacheManager
 from App.config import getConfiguration
@@ -33,6 +32,7 @@ from DateTime.DateTime import DateTime
 from OFS.Traversable import Traversable
 from Persistence import Persistent
 from Products.PageTemplates.PageTemplateFile import PageTemplateFile
+from ZPublisher import zpublish
 
 
 class FakeConnection:
@@ -365,7 +365,7 @@ class AltDatabaseManager(CacheManager, Traversable, UndoSupport):
             return '%.1fM' % (s / 1048576.0)
         return '%.1fK' % (s / 1024.0)
 
-    @requestmethod('POST')
+    @zpublish(methods='POST')
     def manage_minimize(self, value=1, REQUEST=None):
         "Perform a full sweep through the cache"
         # XXX Add a deprecation warning about value?
@@ -376,7 +376,7 @@ class AltDatabaseManager(CacheManager, Traversable, UndoSupport):
             url = f'{REQUEST["URL1"]}/manage_main?manage_tabs_message={msg}'
             REQUEST.RESPONSE.redirect(url)
 
-    @requestmethod('POST')
+    @zpublish(methods='POST')
     def manage_pack(self, days=0, REQUEST=None):
         """Pack the database"""
         if not isinstance(days, (int, float)):

--- a/src/App/DavLockManager.py
+++ b/src/App/DavLockManager.py
@@ -19,6 +19,7 @@ from Acquisition import aq_base
 from App.special_dtml import DTMLFile
 from OFS.Lockable import wl_isLocked
 from OFS.SimpleItem import Item
+from ZPublisher import zpublish
 
 
 class DavLockManager(Item, Implicit):
@@ -73,6 +74,7 @@ class DavLockManager(Item, Implicit):
             ob.wl_clearLocks()
 
     @security.protected(webdav_manage_locks)
+    @zpublish
     def manage_unlockObjects(self, paths=[], REQUEST=None):
         " Management screen action to unlock objects. "
         if paths:

--- a/src/App/FactoryDispatcher.py
+++ b/src/App/FactoryDispatcher.py
@@ -25,6 +25,7 @@ from Acquisition import Implicit
 from Acquisition import aq_base
 from ExtensionClass import Base
 from OFS.metaconfigure import get_registered_packages
+from ZPublisher import zpublish
 
 
 def _product_packages():
@@ -45,6 +46,7 @@ def _product_packages():
     return _packages
 
 
+@zpublish
 class Product(Base):
     """Model a non-persistent product wrapper.
     """
@@ -68,6 +70,7 @@ class Product(Base):
 InitializeClass(Product)
 
 
+@zpublish
 class ProductDispatcher(Implicit):
     " "
     # Allow access to factory dispatchers
@@ -95,6 +98,7 @@ class ProductDispatcher(Implicit):
         return dispatcher.__of__(self)
 
 
+@zpublish
 class FactoryDispatcher(Implicit):
     """Provide a namespace for product "methods"
     """

--- a/src/App/FactoryDispatcher.py
+++ b/src/App/FactoryDispatcher.py
@@ -161,6 +161,7 @@ class FactoryDispatcher(Implicit):
     _owner = UnownableOwner
 
     # Provide a replacement for manage_main that does a redirection:
+    @zpublish
     def manage_main(trueself, self, REQUEST, update_menu=0):
         """Implement a contents view by redirecting to the true view
         """

--- a/src/App/Management.py
+++ b/src/App/Management.py
@@ -29,8 +29,10 @@ from App.interfaces import INavigation
 from App.special_dtml import DTMLFile
 from ExtensionClass import Base
 from zope.interface import implementer
+from ZPublisher import zpublish
 
 
+@zpublish
 class Tabs(Base):
     """Mix-in provides management folder tab support."""
 
@@ -68,6 +70,7 @@ class Tabs(Base):
 
     manage_workspace__roles__ = ('Authenticated',)
 
+    @zpublish
     def manage_workspace(self, REQUEST):
         """Dispatch to first interface in manage_options
         """
@@ -181,6 +184,7 @@ class Navigation(Base):
     security.declarePublic('zope_copyright')  # NOQA: D001
     zope_copyright = DTMLFile('dtml/copyright', globals())
 
+    @zpublish
     @security.public
     def manage_zmi_logout(self, REQUEST, RESPONSE):
         """Logout current user"""

--- a/src/App/ProductContext.py
+++ b/src/App/ProductContext.py
@@ -23,6 +23,8 @@ from App.FactoryDispatcher import FactoryDispatcher
 from OFS.ObjectManager import ObjectManager
 from zope.interface import implementedBy
 from ZPublisher import zpublish
+from ZPublisher import zpublish_marked
+from ZPublisher import zpublish_wrap
 
 
 if not hasattr(Products, 'meta_types'):
@@ -100,7 +102,7 @@ class ProductContext:
         productObject = self.__prod
         pid = productObject.id
 
-        if instance_class is not None:
+        if instance_class is not None and not zpublish_marked(instance_class):
             zpublish(instance_class)
 
         if permissions:
@@ -140,7 +142,7 @@ class ProductContext:
                 name = method.__name__
                 aliased = 0
             if name not in OM.__dict__:
-                method = zpublish(True, method)
+                method = zpublish_wrap(method)
                 setattr(OM, name, method)
                 setattr(OM, name + '__roles__', pr)
                 if aliased:
@@ -201,7 +203,7 @@ class ProductContext:
             else:
                 name = os.path.split(method.__name__)[-1]
             if name not in productObject.__dict__:
-                m[name] = zpublish(True, method)
+                m[name] = zpublish_wrap(method)
                 m[name + '__roles__'] = pr
 
     def getApplication(self):

--- a/src/App/ProductContext.py
+++ b/src/App/ProductContext.py
@@ -194,7 +194,7 @@ class ProductContext:
             'container_filter': container_filter
         },)
 
-        m[name] = initial
+        m[name] = zpublish_wrap(initial)
         m[name + '__roles__'] = pr
 
         for method in constructors[1:]:

--- a/src/App/ProductContext.py
+++ b/src/App/ProductContext.py
@@ -22,6 +22,7 @@ from AccessControl.PermissionRole import PermissionRole
 from App.FactoryDispatcher import FactoryDispatcher
 from OFS.ObjectManager import ObjectManager
 from zope.interface import implementedBy
+from ZPublisher import zpublish
 
 
 if not hasattr(Products, 'meta_types'):
@@ -99,6 +100,9 @@ class ProductContext:
         productObject = self.__prod
         pid = productObject.id
 
+        if instance_class is not None:
+            zpublish(instance_class)
+
         if permissions:
             if isinstance(permissions, str):  # You goofed it!
                 raise TypeError(
@@ -130,19 +134,21 @@ class ProductContext:
         for method in legacy:
             if isinstance(method, tuple):
                 name, method = method
+                mname = method.__name__
                 aliased = 1
             else:
                 name = method.__name__
                 aliased = 0
             if name not in OM.__dict__:
+                method = zpublish(True, method)
                 setattr(OM, name, method)
                 setattr(OM, name + '__roles__', pr)
                 if aliased:
                     # Set the unaliased method name and its roles
                     # to avoid security holes.  XXX: All "legacy"
                     # methods need to be eliminated.
-                    setattr(OM, method.__name__, method)
-                    setattr(OM, method.__name__ + '__roles__', pr)
+                    setattr(OM, mname, method)
+                    setattr(OM, mname + '__roles__', pr)
 
         if isinstance(initial, tuple):
             name, initial = initial
@@ -195,7 +201,7 @@ class ProductContext:
             else:
                 name = os.path.split(method.__name__)[-1]
             if name not in productObject.__dict__:
-                m[name] = method
+                m[name] = zpublish(True, method)
                 m[name + '__roles__'] = pr
 
     def getApplication(self):

--- a/src/App/Undo.py
+++ b/src/App/Undo.py
@@ -23,6 +23,7 @@ from Acquisition import Implicit
 from App.Management import Tabs
 from App.special_dtml import DTMLFile
 from DateTime.DateTime import DateTime
+from ZPublisher import zpublish
 
 
 class UndoSupport(Tabs, Implicit):
@@ -98,6 +99,7 @@ class UndoSupport(Tabs, Implicit):
         return r
 
     @security.protected(undo_changes)
+    @zpublish
     def manage_undo_transactions(self, transaction_info=(), REQUEST=None):
         """
         """

--- a/src/App/special_dtml.py
+++ b/src/App/special_dtml.py
@@ -33,6 +33,7 @@ from DocumentTemplate._DocumentTemplate import render_blocks
 from DocumentTemplate.DT_String import DTReturn
 from DocumentTemplate.DT_String import _marker
 from Shared.DC.Scripts.Bindings import Bindings
+from ZPublisher import zpublish
 
 
 LOG = getLogger('special_dtml')
@@ -46,10 +47,12 @@ class Code:
     pass
 
 
+@zpublish
 class HTML(DocumentTemplate.HTML, Persistence.Persistent):
     "Persistent HTML Document Templates"
 
 
+@zpublish
 class ClassicHTMLFile(DocumentTemplate.HTMLFile, MethodObject.Method):
     "Persistent HTML Document Templates read from files"
 

--- a/src/OFS/Application.py
+++ b/src/OFS/Application.py
@@ -39,6 +39,7 @@ from webdav.NullResource import NullResource
 from zExceptions import Forbidden
 from zExceptions import Redirect as RedirectException
 from zope.interface import implementer
+from ZPublisher import zpublish
 
 from . import Folder
 from . import misc_
@@ -107,6 +108,7 @@ class Application(ApplicationDefaultPermissions, Folder.Folder, FindSupport):
 
     ZopeRedirect = Redirect
 
+    @zpublish
     @security.protected(view_management_screens)
     def getZMIMainFrameTarget(self, REQUEST):
         """Utility method to get the right hand side ZMI frame source URL
@@ -200,11 +202,13 @@ class Application(ApplicationDefaultPermissions, Folder.Folder, FindSupport):
 
             return version
 
+    @zpublish
     def DELETE(self, REQUEST, RESPONSE):
         """Delete a resource object."""
         self.dav__init(REQUEST, RESPONSE)
         raise Forbidden('This resource cannot be deleted.')
 
+    @zpublish
     def MOVE(self, REQUEST, RESPONSE):
         """Move a resource to a new location."""
         self.dav__init(REQUEST, RESPONSE)

--- a/src/OFS/CopySupport.py
+++ b/src/OFS/CopySupport.py
@@ -51,6 +51,7 @@ from zope.event import notify
 from zope.interface import implementer
 from zope.lifecycleevent import ObjectCopiedEvent
 from zope.lifecycleevent import ObjectMovedEvent
+from ZPublisher import zpublish
 
 
 class CopyError(Exception):
@@ -91,6 +92,7 @@ class CopyContainer(Base):
         return [self._getOb(i) for i in REQUEST['ids']]
 
     @security.protected(delete_objects)
+    @zpublish
     def manage_cutObjects(self, ids=None, REQUEST=None):
         """Put a reference to the objects named in ids in the clip board"""
         if ids is None and REQUEST is not None:
@@ -121,6 +123,7 @@ class CopyContainer(Base):
         return cp
 
     @security.protected(view_management_screens)
+    @zpublish
     def manage_copyObjects(self, ids=None, REQUEST=None, RESPONSE=None):
         """Put a reference to the objects named in ids in the clip board"""
         if ids is None and REQUEST is not None:
@@ -298,6 +301,7 @@ class CopyContainer(Base):
         return op, result
 
     @security.protected(view_management_screens)
+    @zpublish
     def manage_pasteObjects(self, cb_copy_data=None, REQUEST=None):
         """Paste previously copied objects into the current object.
 
@@ -334,6 +338,7 @@ class CopyContainer(Base):
     manage_renameForm = DTMLFile('dtml/renameForm', globals())
 
     @security.protected(view_management_screens)
+    @zpublish
     def manage_renameObjects(self, ids=[], new_ids=[], REQUEST=None):
         """Rename several sub-objects"""
         if len(ids) != len(new_ids):
@@ -345,6 +350,7 @@ class CopyContainer(Base):
             return self.manage_main(self, REQUEST)
 
     @security.protected(view_management_screens)
+    @zpublish
     def manage_renameObject(self, id, new_id, REQUEST=None):
         """Rename a particular sub-object.
         """
@@ -400,6 +406,7 @@ class CopyContainer(Base):
             return self.manage_main(self, REQUEST)
 
     @security.public
+    @zpublish
     def manage_clone(self, ob, id, REQUEST=None):
         """Clone an object, creating a new object with the given id.
         """

--- a/src/OFS/DTMLMethod.py
+++ b/src/OFS/DTMLMethod.py
@@ -20,7 +20,6 @@ from AccessControl.class_init import InitializeClass
 from AccessControl.Permissions import change_proxy_roles  # NOQA
 from AccessControl.Permissions import view as View
 from AccessControl.Permissions import view_management_screens
-from AccessControl.requestmethod import requestmethod
 from AccessControl.SecurityInfo import ClassSecurityInfo
 from AccessControl.tainted import TaintedString
 from Acquisition import Implicit
@@ -340,9 +339,8 @@ class DTMLMethod(
             'do not have proxy roles.\n<!--%s, %s-->' % (
                 self.__name__, user, roles))
 
-    @zpublish
+    @zpublish(methods="POST")
     @security.protected(change_proxy_roles)
-    @requestmethod('POST')
     def manage_proxy(self, roles=(), REQUEST=None):
         """Change Proxy Roles"""
         user = getSecurityManager().getUser()

--- a/src/OFS/DTMLMethod.py
+++ b/src/OFS/DTMLMethod.py
@@ -39,6 +39,7 @@ from zExceptions import Forbidden
 from zExceptions import ResourceLockedError
 from zExceptions.TracebackSupplement import PathTracebackSupplement
 from zope.contenttype import guess_content_type
+from ZPublisher import zpublish
 from ZPublisher.HTTPRequest import default_encoding
 from ZPublisher.Iterators import IStreamIterator
 
@@ -51,6 +52,7 @@ class Code:
     pass
 
 
+@zpublish
 class DTMLMethod(
     PathReprProvider,
     RestrictedDTML,
@@ -265,6 +267,7 @@ class DTMLMethod(
     security.declareProtected(change_proxy_roles, 'manage_proxyForm')  # NOQA: D001,E501
     manage_proxyForm = DTMLFile('dtml/documentProxy', globals())
 
+    @zpublish
     @security.protected(change_dtml_methods)
     def manage_edit(self, data, title, SUBMIT='Change', REQUEST=None):
         """ Replace contents with 'data', title with 'title'.
@@ -293,6 +296,7 @@ class DTMLMethod(
             message = "Saved changes."
             return self.manage_main(self, REQUEST, manage_tabs_message=message)
 
+    @zpublish
     @security.protected(change_dtml_methods)
     def manage_upload(self, file='', REQUEST=None):
         """ Replace the contents of the document with the text in 'file'.
@@ -336,6 +340,7 @@ class DTMLMethod(
             'do not have proxy roles.\n<!--%s, %s-->' % (
                 self.__name__, user, roles))
 
+    @zpublish
     @security.protected(change_proxy_roles)
     @requestmethod('POST')
     def manage_proxy(self, roles=(), REQUEST=None):
@@ -363,6 +368,7 @@ class DTMLMethod(
             RESPONSE.setHeader('Content-Type', 'text/plain')
         return self.read()
 
+    @zpublish
     @security.protected(change_dtml_methods)
     def PUT(self, REQUEST, RESPONSE):
         """ Handle HTTP PUT requests.

--- a/src/OFS/FindSupport.py
+++ b/src/OFS/FindSupport.py
@@ -28,6 +28,7 @@ from DocumentTemplate.security import RestrictedDTML
 from ExtensionClass import Base
 from OFS.interfaces import IFindSupport
 from zope.interface import implementer
+from ZPublisher import zpublish
 from ZPublisher.HTTPRequest import default_encoding
 
 
@@ -52,6 +53,7 @@ class FindSupport(Base):
         },
     )
 
+    @zpublish
     @security.protected(view_management_screens)
     def ZopeFind(self, obj, obj_ids=None, obj_metatypes=None,
                  obj_searchterm=None, obj_expr=None,
@@ -69,6 +71,7 @@ class FindSupport(Base):
             pre=pre, apply_func=None, apply_path=''
         )
 
+    @zpublish
     @security.protected(view_management_screens)
     def ZopeFindAndApply(self, obj, obj_ids=None, obj_metatypes=None,
                          obj_searchterm=None, obj_expr=None,

--- a/src/OFS/Folder.py
+++ b/src/OFS/Folder.py
@@ -27,6 +27,7 @@ from OFS.SimpleItem import Item
 from OFS.SimpleItem import PathReprProvider
 from webdav.Collection import Collection
 from zope.interface import implementer
+from ZPublisher import zpublish
 
 
 manage_addFolderForm = DTMLFile('dtml/folderAdd', globals())
@@ -50,6 +51,7 @@ def manage_addFolder(
         return self.manage_main(self, REQUEST)
 
 
+@zpublish
 @implementer(IFolder)
 class Folder(
     PathReprProvider,

--- a/src/OFS/History.py
+++ b/src/OFS/History.py
@@ -94,6 +94,7 @@ class Historian(Implicit):
 
         return rev.__of__(self.aq_parent)
 
+    @zpublish
     def manage_workspace(self, REQUEST):
         """ We aren't real, so we delegate to that that spawned us! """
         raise Redirect('/%s/manage_change_history_page' % REQUEST['URL2'])

--- a/src/OFS/History.py
+++ b/src/OFS/History.py
@@ -26,6 +26,7 @@ from App.special_dtml import DTMLFile
 from DateTime.DateTime import DateTime
 from ExtensionClass import Base
 from zExceptions import Redirect
+from ZPublisher import zpublish
 
 
 view_history = 'View History'
@@ -122,6 +123,7 @@ class Historical(Base):
         HistoryBatchSize=20,
         first_transaction=0, last_transaction=20)
 
+    @zpublish
     @security.protected(view_history)
     def manage_change_history(self):
         first = 0
@@ -146,6 +148,7 @@ class Historical(Base):
     def manage_beforeHistoryCopy(self):
         pass
 
+    @zpublish
     def manage_historyCopy(self, keys=[], RESPONSE=None, URL1=None):
         """ Copy a selected revision to the present """
         if not keys:
@@ -176,6 +179,7 @@ class Historical(Base):
     _manage_historyComparePage = DTMLFile(
         'dtml/historyCompare', globals(), management_view='History')
 
+    @zpublish
     @security.protected(view_history)
     def manage_historyCompare(self, rev1, rev2, REQUEST,
                               historyComparisonResults=''):
@@ -186,6 +190,7 @@ class Historical(Base):
             dt1=dt1, dt2=dt2,
             historyComparisonResults=historyComparisonResults)
 
+    @zpublish
     @security.protected(view_history)
     def manage_historicalComparison(self, REQUEST, keys=[]):
         """ Compare two selected revisions """

--- a/src/OFS/Image.py
+++ b/src/OFS/Image.py
@@ -48,6 +48,7 @@ from zope.interface import implementer
 from zope.lifecycleevent import ObjectCreatedEvent
 from zope.lifecycleevent import ObjectModifiedEvent
 from ZPublisher import HTTPRangeSupport
+from ZPublisher import zpublish
 from ZPublisher.HTTPRequest import FileUpload
 
 
@@ -157,6 +158,7 @@ def manage_addFile(
         REQUEST.RESPONSE.redirect(self.absolute_url() + '/manage_main')
 
 
+@zpublish
 @implementer(IWriteLock, HTTPRangeSupport.HTTPRangeInterface)
 class File(
     PathReprProvider,
@@ -484,6 +486,7 @@ class File(
         # We only explicitly allow a few mimetypes, and deny the rest.
         return mimetype not in self.allowed_inline_mimetypes
 
+    @zpublish
     @security.protected(View)
     def index_html(self, REQUEST, RESPONSE):
         """
@@ -560,6 +563,7 @@ class File(
 
         return b''
 
+    @zpublish
     @security.protected(View)
     def view_image_or_file(self, URL1):
         """The default view of the contents of the File or Image."""
@@ -592,6 +596,7 @@ class File(
         """Get the canonical encoding for ZMI."""
         return ZPublisher.HTTPRequest.default_encoding
 
+    @zpublish
     @security.protected(change_images_and_files)
     def manage_edit(
         self,
@@ -627,6 +632,7 @@ class File(
             return self.manage_main(
                 self, REQUEST, manage_tabs_message=message)
 
+    @zpublish
     @security.protected(change_images_and_files)
     def manage_upload(self, file='', REQUEST=None):
         """
@@ -735,6 +741,7 @@ class File(
 
         return (_next, size)
 
+    @zpublish
     @security.protected(change_images_and_files)
     def PUT(self, REQUEST, RESPONSE):
         """Handle HTTP PUT requests"""
@@ -791,6 +798,7 @@ class File(
         data = bytes(self.data)
         return len(data)
 
+    @zpublish
     @security.protected(webdav_access)
     def manage_DAVget(self):
         """Return body for WebDAV."""

--- a/src/OFS/ObjectManager.py
+++ b/src/OFS/ObjectManager.py
@@ -61,6 +61,7 @@ from zope.interface import implementer
 from zope.interface.interfaces import ComponentLookupError
 from zope.lifecycleevent import ObjectAddedEvent
 from zope.lifecycleevent import ObjectRemovedEvent
+from ZPublisher import zpublish
 from ZPublisher.HTTPResponse import make_content_disposition
 
 
@@ -524,6 +525,7 @@ class ObjectManager(
 
     manage_addProduct = ProductDispatcher()
 
+    @zpublish
     @security.protected(delete_objects)
     def manage_delObjects(self, ids=[], REQUEST=None):
         """Delete a subordinate object
@@ -585,6 +587,7 @@ class ObjectManager(
                     r.append(o)
         return r
 
+    @zpublish
     @security.protected(import_export_objects)
     def manage_exportObject(
         self,
@@ -632,6 +635,7 @@ class ObjectManager(
     security.declareProtected(import_export_objects, 'manage_importExportForm')  # NOQA: D001,E501
     manage_importExportForm = DTMLFile('dtml/importExport', globals())
 
+    @zpublish
     @security.protected(import_export_objects)
     def manage_importObject(self, file, REQUEST=None, set_owner=1,
                             suppress_events=False):

--- a/src/OFS/OrderSupport.py
+++ b/src/OFS/OrderSupport.py
@@ -22,6 +22,7 @@ from OFS.interfaces import IOrderedContainer as IOrderedContainer
 from zope.container.contained import notifyContainerModified
 from zope.interface import implementer
 from zope.sequencesort.ssort import sort
+from ZPublisher import zpublish
 
 
 @implementer(IOrderedContainer)
@@ -48,6 +49,7 @@ class OrderSupport:
     )
 
     @security.protected(manage_properties)
+    @zpublish
     def manage_move_objects_up(self, REQUEST, ids=None, delta=1):
         """ Move specified sub-objects up by delta in container.
         """
@@ -67,6 +69,7 @@ class OrderSupport:
         )
 
     @security.protected(manage_properties)
+    @zpublish
     def manage_move_objects_down(self, REQUEST, ids=None, delta=1):
         """ Move specified sub-objects down by delta in container.
         """
@@ -86,6 +89,7 @@ class OrderSupport:
         )
 
     @security.protected(manage_properties)
+    @zpublish
     def manage_move_objects_to_top(self, REQUEST, ids=None):
         """ Move specified sub-objects to top of container.
         """
@@ -102,6 +106,7 @@ class OrderSupport:
                                 manage_tabs_message=message)
 
     @security.protected(manage_properties)
+    @zpublish
     def manage_move_objects_to_bottom(self, REQUEST, ids=None):
         """ Move specified sub-objects to bottom of container.
         """
@@ -118,6 +123,7 @@ class OrderSupport:
                                 manage_tabs_message=message)
 
     @security.protected(manage_properties)
+    @zpublish
     def manage_set_default_sorting(self, REQUEST, key, reverse):
         """ Set default sorting key and direction."""
         self.setDefaultSorting(key, reverse)
@@ -237,6 +243,7 @@ class OrderSupport:
         self._default_sort_key = key
         self._default_sort_reverse = reverse and 1 or 0
 
+    @zpublish
     def manage_renameObject(self, id, new_id, REQUEST=None):
         """ Rename a particular sub-object without changing its position.
         """

--- a/src/OFS/PropertyManager.py
+++ b/src/OFS/PropertyManager.py
@@ -27,6 +27,7 @@ from OFS.PropertySheets import DefaultPropertySheets
 from OFS.PropertySheets import vps
 from zExceptions import BadRequest
 from zope.interface import implementer
+from ZPublisher import zpublish
 from ZPublisher.Converters import type_converters
 
 
@@ -275,6 +276,7 @@ class PropertyManager(Base):
             dict[p['id']] = p
         return dict
 
+    @zpublish
     @security.protected(manage_properties)
     def manage_addProperty(self, id, value, type, REQUEST=None):
         """Add a new property via the web.
@@ -287,6 +289,7 @@ class PropertyManager(Base):
         if REQUEST is not None:
             return self.manage_propertiesForm(self, REQUEST)
 
+    @zpublish
     @security.protected(manage_properties)
     def manage_editProperties(self, REQUEST):
         """Edit object properties via the web.
@@ -312,6 +315,7 @@ class PropertyManager(Base):
                 manage_tabs_message=message,
             )
 
+    @zpublish
     @security.protected(manage_properties)
     def manage_changeProperties(self, REQUEST=None, **kw):
         """Change existing object properties.
@@ -344,6 +348,7 @@ class PropertyManager(Base):
                 manage_tabs_message=message
             )
 
+    @zpublish
     @security.protected(manage_properties)
     def manage_changePropertyTypes(self, old_ids, props, REQUEST=None):
         """Replace one set of properties with another.
@@ -363,6 +368,7 @@ class PropertyManager(Base):
         if REQUEST is not None:
             return self.manage_propertiesForm(self, REQUEST)
 
+    @zpublish
     @security.protected(manage_properties)
     def manage_delProperties(self, ids=None, REQUEST=None):
         """Delete one or more properties specified by 'ids'."""

--- a/src/OFS/PropertySheets.py
+++ b/src/OFS/PropertySheets.py
@@ -30,6 +30,7 @@ from OFS.Traversable import Traversable
 from Persistence import Persistent
 from webdav.PropertySheet import DAVPropertySheetMixin
 from zExceptions import BadRequest
+from ZPublisher import zpublish
 from ZPublisher.Converters import type_converters
 
 
@@ -50,6 +51,7 @@ class View(Tabs, Base):
     to be used as a view on an object.
     """
 
+    @zpublish
     def manage_workspace(self, URL1, RESPONSE):
         '''Implement a "management" interface
         '''
@@ -322,11 +324,13 @@ class PropertySheet(Traversable, Persistent, Implicit, DAVPropertySheetMixin):
 
     manage = DTMLFile('dtml/properties', globals())
 
+    @zpublish
     @security.protected(manage_properties)
     def manage_propertiesForm(self, URL1, RESPONSE):
         " "
         RESPONSE.redirect(URL1 + '/manage')
 
+    @zpublish
     @security.protected(manage_properties)
     def manage_addProperty(self, id, value, type, REQUEST=None):
         """Add a new property via the web. Sets a new property with
@@ -337,6 +341,7 @@ class PropertySheet(Traversable, Persistent, Implicit, DAVPropertySheetMixin):
         if REQUEST is not None:
             return self.manage(self, REQUEST)
 
+    @zpublish
     @security.protected(manage_properties)
     def manage_editProperties(self, REQUEST):
         """Edit object properties via the web."""
@@ -348,6 +353,7 @@ class PropertySheet(Traversable, Persistent, Implicit, DAVPropertySheetMixin):
         message = 'Your changes have been saved.'
         return self.manage(self, REQUEST, manage_tabs_message=message)
 
+    @zpublish
     @security.protected(manage_properties)
     def manage_changeProperties(self, REQUEST=None, **kw):
         """Change existing object properties.
@@ -372,6 +378,7 @@ class PropertySheet(Traversable, Persistent, Implicit, DAVPropertySheetMixin):
         message = 'Your changes have been saved.'
         return self.manage(self, REQUEST, manage_tabs_message=message)
 
+    @zpublish
     @security.protected(manage_properties)
     def manage_delProperties(self, ids=None, REQUEST=None):
         """Delete one or more properties specified by 'ids'."""
@@ -466,6 +473,7 @@ class PropertySheets(Traversable, Implicit, Tabs):
                 return propset.__of__(self)
         return default
 
+    @zpublish
     @security.protected(manage_properties)
     def manage_addPropertySheet(self, id, ns, REQUEST=None):
         """ """
@@ -502,6 +510,7 @@ class PropertySheets(Traversable, Implicit, Tabs):
             return 0
         return 1
 
+    @zpublish
     def manage_delPropertySheets(self, ids=(), REQUEST=None):
         '''delete all sheets identified by *ids*.'''
         for id in ids:

--- a/src/OFS/SimpleItem.py
+++ b/src/OFS/SimpleItem.py
@@ -200,7 +200,6 @@ class Item(
 
     _manage_editedDialog = DTMLFile('dtml/editedDialog', globals())
 
-    @zpublish
     def manage_editedDialog(self, REQUEST, **args):
         return self._manage_editedDialog(self, REQUEST, **args)
 

--- a/src/OFS/SimpleItem.py
+++ b/src/OFS/SimpleItem.py
@@ -53,6 +53,7 @@ from webdav.Resource import Resource
 from zExceptions import Redirect
 from zExceptions.ExceptionFormatter import format_exception
 from zope.interface import implementer
+from ZPublisher import zpublish
 from ZPublisher.HTTPRequest import default_encoding
 
 
@@ -199,6 +200,7 @@ class Item(
 
     _manage_editedDialog = DTMLFile('dtml/editedDialog', globals())
 
+    @zpublish
     def manage_editedDialog(self, REQUEST, **args):
         return self._manage_editedDialog(self, REQUEST, **args)
 
@@ -303,6 +305,7 @@ class Item(
                 del self._v_eek
             tb = None
 
+    @zpublish
     def manage(self, URL1):
         """
         """
@@ -377,6 +380,7 @@ def pretty_tb(t, v, tb, as_html=1):
     return tb
 
 
+@zpublish
 @implementer(ISimpleItem)
 class SimpleItem(
     Item,

--- a/src/OFS/owner.py
+++ b/src/OFS/owner.py
@@ -21,13 +21,13 @@ from AccessControl.owner import UnownableOwner
 from AccessControl.owner import ownableFilter
 from AccessControl.Permissions import take_ownership
 from AccessControl.Permissions import view_management_screens
-from AccessControl.requestmethod import requestmethod
 from AccessControl.SecurityInfo import ClassSecurityInfo
 from AccessControl.SecurityManagement import getSecurityManager
 from AccessControl.unauthorized import Unauthorized
 from Acquisition import aq_get
 from Acquisition import aq_parent
 from App.special_dtml import DTMLFile
+from ZPublisher import zpublish
 
 
 class Owned(BaseOwned):
@@ -47,7 +47,7 @@ class Owned(BaseOwned):
     manage_owner = DTMLFile('dtml/owner', globals())
 
     @security.protected(take_ownership)
-    @requestmethod('POST')
+    @zpublish(methods='POST')
     def manage_takeOwnership(self, REQUEST, RESPONSE, recursive=0):
         """Take ownership (responsibility) for an object.
 
@@ -68,7 +68,7 @@ class Owned(BaseOwned):
             RESPONSE.redirect(REQUEST['HTTP_REFERER'])
 
     @security.protected(take_ownership)
-    @requestmethod('POST')
+    @zpublish(methods='POST')
     def manage_changeOwnershipType(
         self,
         explicit=1,

--- a/src/OFS/role.py
+++ b/src/OFS/role.py
@@ -25,6 +25,7 @@ from AccessControl.rolemanager import _string_hash
 from AccessControl.rolemanager import reqattr
 from App.special_dtml import DTMLFile
 from zExceptions import BadRequest
+from ZPublisher import zpublish
 
 
 class RoleManager(BaseRoleManager):
@@ -47,7 +48,7 @@ class RoleManager(BaseRoleManager):
     )
 
     @security.protected(change_permissions)
-    @requestmethod('POST')
+    @zpublish(methods='POST')
     def manage_role(self, role_to_manage, permissions=[], REQUEST=None):
         """Change the permissions given to the given role.
         """
@@ -64,7 +65,7 @@ class RoleManager(BaseRoleManager):
     )
 
     @security.protected(change_permissions)
-    @requestmethod('POST')
+    @zpublish(methods='POST')
     def manage_acquiredPermissions(self, permissions=[], REQUEST=None):
         """Change the permissions that acquire.
         """
@@ -81,7 +82,7 @@ class RoleManager(BaseRoleManager):
     )
 
     @security.protected(change_permissions)
-    @requestmethod('POST')
+    @zpublish(methods='POST')
     def manage_permission(
         self,
         permission_to_manage,
@@ -107,12 +108,13 @@ class RoleManager(BaseRoleManager):
     )
 
     @security.protected(change_permissions)
+    @zpublish
     def manage_access(self, REQUEST, **kw):
         """Return an interface for making permissions settings."""
         return self._normal_manage_access(**kw)
 
     @security.protected(change_permissions)
-    @requestmethod('POST')
+    @zpublish(methods='POST')
     def manage_changePermissions(self, REQUEST):
         """Change all permissions settings, called by management screen."""
         valid_roles = self.valid_roles()
@@ -158,7 +160,7 @@ class RoleManager(BaseRoleManager):
     )
 
     @security.protected(change_permissions)
-    @requestmethod('POST')
+    @zpublish(methods='POST')
     def manage_addLocalRoles(self, userid, roles, REQUEST=None):
         """Set local roles for a user."""
         BaseRoleManager.manage_addLocalRoles(self, userid, roles)
@@ -167,7 +169,7 @@ class RoleManager(BaseRoleManager):
             return self.manage_listLocalRoles(self, REQUEST, stat=stat)
 
     @security.protected(change_permissions)
-    @requestmethod('POST')
+    @zpublish(methods='POST')
     def manage_setLocalRoles(self, userid, roles=[], REQUEST=None):
         """Set local roles for a user."""
         if roles:
@@ -179,7 +181,7 @@ class RoleManager(BaseRoleManager):
             return self.manage_listLocalRoles(self, REQUEST, stat=stat)
 
     @security.protected(change_permissions)
-    @requestmethod('POST')
+    @zpublish(methods='POST')
     def manage_delLocalRoles(self, userids, REQUEST=None):
         """Remove all local roles for a user."""
         BaseRoleManager.manage_delLocalRoles(self, userids)
@@ -188,6 +190,7 @@ class RoleManager(BaseRoleManager):
             return self.manage_listLocalRoles(self, REQUEST, stat=stat)
 
     @security.protected(change_permissions)
+    @zpublish
     def manage_defined_roles(self, submit=None, REQUEST=None):
         """Called by management screen."""
         if submit == 'Add Role':

--- a/src/OFS/userfolder.py
+++ b/src/OFS/userfolder.py
@@ -32,6 +32,7 @@ from App.special_dtml import DTMLFile
 from OFS.role import RoleManager
 from OFS.SimpleItem import Item
 from zExceptions import BadRequest
+from ZPublisher import zpublish
 
 
 class BasicUserFolder(
@@ -54,7 +55,7 @@ class BasicUserFolder(
     ) + RoleManager.manage_options + Item.manage_options)
 
     @security.protected(ManageUsers)
-    @requestmethod('POST')
+    @zpublish(methods='POST')
     def userFolderAddUser(self, name, password, roles, domains,
                           REQUEST=None, **kw):
         """API method for creating a new user object. Note that not all
@@ -65,7 +66,7 @@ class BasicUserFolder(
         raise NotImplementedError
 
     @security.protected(ManageUsers)
-    @requestmethod('POST')
+    @zpublish(methods='POST')
     def userFolderEditUser(
         self,
         name,
@@ -83,7 +84,7 @@ class BasicUserFolder(
         raise NotImplementedError
 
     @security.protected(ManageUsers)
-    @requestmethod('POST')
+    @zpublish(methods='POST')
     def userFolderDelUsers(self, names, REQUEST=None):
         """API method for deleting one or more user objects. Note that not
            all user folder implementations support deletion of user objects."""
@@ -101,6 +102,7 @@ class BasicUserFolder(
 
     _userFolderProperties = DTMLFile('dtml/userFolderProps', globals())
 
+    @zpublish
     def manage_userFolderProperties(
         self,
         REQUEST=None,
@@ -115,7 +117,7 @@ class BasicUserFolder(
             management_view='Properties',
         )
 
-    @requestmethod('POST')
+    @zpublish(methods='POST')
     def manage_setUserFolderProperties(
         self,
         encrypt_passwords=0,
@@ -214,6 +216,7 @@ class BasicUserFolder(
             return self._mainUser(self, REQUEST)
 
     @security.protected(ManageUsers)
+    @zpublish
     def manage_users(self, submit=None, REQUEST=None, RESPONSE=None):
         """This method handles operations on users for the web based forms
            of the ZMI. Application code (code that is outside of the forms

--- a/src/Products/Five/browser/__init__.py
+++ b/src/Products/Five/browser/__init__.py
@@ -15,8 +15,10 @@
 """
 
 from zope.publisher import browser
+from ZPublisher import zpublish
 
 
+@zpublish
 class BrowserView(browser.BrowserView):
 
     # Use an explicit __init__ to work around problems with magically inserted

--- a/src/Products/Five/browser/tests/pages.py
+++ b/src/Products/Five/browser/tests/pages.py
@@ -20,20 +20,25 @@ from AccessControl.SecurityInfo import ClassSecurityInfo
 from OFS.SimpleItem import SimpleItem
 from Products.Five import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from ZPublisher import zpublish
 
 
+@zpublish
 class SimpleView(BrowserView):
 
     """More docstring. Please Zope"""
 
+    @zpublish
     def eagle(self):
         """Docstring"""
         return "The eagle has landed"
 
+    @zpublish
     def eagle2(self):
         """Docstring"""
         return "The eagle has landed:\n%s" % self.context.absolute_url()
 
+    @zpublish
     def mouse(self):
         """Docstring"""
         return "The mouse has been eaten by the eagle"
@@ -105,16 +110,19 @@ class ProtectedView:
 
     security = ClassSecurityInfo()
 
+    @zpublish
     @security.public
     def public_method(self):
         """Docstring"""
         return 'PUBLIC'
 
+    @zpublish
     @security.protected('View')
     def protected_method(self):
         """Docstring"""
         return 'PROTECTED'
 
+    @zpublish
     @security.private
     def private_method(self):
         """Docstring"""
@@ -133,6 +141,7 @@ class IHamburger(zope.interface.Interface):
 class CheeseburgerView(BrowserView):
     """View those `meat` method gets allowed via `IHamburger`."""
 
+    @zpublish
     def meat(self):
         """Make meat publically available via a docstring."""
         return 'yummi'

--- a/src/Products/Five/tests/testing/fancycontent.py
+++ b/src/Products/Five/tests/testing/fancycontent.py
@@ -20,12 +20,14 @@ from Acquisition import Explicit
 from OFS.SimpleItem import SimpleItem
 from zope.interface import Interface
 from zope.interface import implementer
+from ZPublisher import zpublish
 
 
 class IFancyContent(Interface):
     pass
 
 
+@zpublish
 class FancyAttribute(Explicit):
     """Doc test fanatics"""
 
@@ -34,6 +36,7 @@ class FancyAttribute(Explicit):
 
     security = ClassSecurityInfo()
 
+    @zpublish
     @security.public
     def index_html(self, REQUEST):
         """Doc test fanatics"""

--- a/src/Products/Five/tests/testing/simplecontent.py
+++ b/src/Products/Five/tests/testing/simplecontent.py
@@ -19,6 +19,7 @@ from AccessControl.SecurityInfo import ClassSecurityInfo
 from OFS.SimpleItem import SimpleItem
 from zope.interface import Interface
 from zope.interface import implementer
+from ZPublisher import zpublish
 
 
 class ISimpleContent(Interface):
@@ -77,6 +78,7 @@ class IndexSimpleContent(SimpleItem):
 
     meta_type = 'Five IndexSimpleContent'
 
+    @zpublish
     def index_html(self, *args, **kw):
         """ """
         return "Default index_html called"

--- a/src/Products/PageTemplates/ZopePageTemplate.py
+++ b/src/Products/PageTemplates/ZopePageTemplate.py
@@ -39,6 +39,7 @@ from Products.PageTemplates.utils import convertToUnicode
 from Shared.DC.Scripts.Script import Script
 from Shared.DC.Scripts.Signature import FuncCode
 from zExceptions import ResourceLockedError
+from ZPublisher import zpublish
 
 
 preferred_encodings = ['utf-8', 'iso-8859-15']
@@ -66,6 +67,7 @@ class Src(Explicit):
 InitializeClass(Src)
 
 
+@zpublish
 class ZopePageTemplate(Script, PageTemplate, Historical, Cacheable,
                        Traversable, PropertyManager):
     "Zope wrapper for Page Template using TAL, TALES, and METAL"
@@ -145,6 +147,7 @@ class ZopePageTemplate(Script, PageTemplate, Historical, Cacheable,
 
     source_dot_xml = Src()
 
+    @zpublish
     @security.protected(change_page_templates)
     def pt_editAction(self, REQUEST, title, text, content_type, expand=0):
         """Change the title and document."""
@@ -178,6 +181,7 @@ class ZopePageTemplate(Script, PageTemplate, Historical, Cacheable,
         PropertyManager._setPropValue(self, id, value)
         self.ZCacheable_invalidate()
 
+    @zpublish
     @security.protected(change_page_templates)
     def pt_upload(self, REQUEST, file='', encoding='utf-8'):
         """Replace the document with the text in file."""
@@ -344,6 +348,7 @@ class ZopePageTemplate(Script, PageTemplate, Historical, Cacheable,
         assert isinstance(result, str)
         return result
 
+    @zpublish
     @security.protected(change_page_templates)
     def PUT(self, REQUEST, RESPONSE):
         """ Handle HTTP PUT requests """

--- a/src/Products/SiteAccess/VirtualHostMonster.py
+++ b/src/Products/SiteAccess/VirtualHostMonster.py
@@ -11,6 +11,7 @@ from OFS.SimpleItem import Item
 from Persistence import Persistent
 from zExceptions import BadRequest
 from zope.publisher.http import splitport
+from ZPublisher import zpublish
 from ZPublisher.BaseRequest import quote
 from ZPublisher.BeforeTraverse import NameCaller
 from ZPublisher.BeforeTraverse import queryBeforeTraverse
@@ -18,6 +19,7 @@ from ZPublisher.BeforeTraverse import registerBeforeTraverse
 from ZPublisher.BeforeTraverse import unregisterBeforeTraverse
 
 
+@zpublish
 class VirtualHostMonster(Persistent, Item, Implicit):
     """Provide a simple drop-in solution for virtual hosting.
     """
@@ -46,6 +48,7 @@ class VirtualHostMonster(Persistent, Item, Implicit):
     security.declareProtected('Add Site Roots', 'manage_edit')  # NOQA: D001
     manage_edit = DTMLFile('www/manage_edit', globals())
 
+    @zpublish
     @security.protected('Add Site Roots')
     def set_map(self, map_text, RESPONSE=None):
         "Set domain to path mappings."

--- a/src/Shared/DC/Scripts/Bindings.py
+++ b/src/Shared/DC/Scripts/Bindings.py
@@ -24,6 +24,7 @@ from Acquisition import aq_base
 from Acquisition import aq_inner
 from Acquisition import aq_parent
 from zope.component import queryMultiAdapter as qma
+from ZPublisher import zpublish
 
 
 defaultBindings = {'name_context': 'context',
@@ -207,6 +208,7 @@ class UnauthorizedBinding:
     __str__ = __call__ = index_html = __you_lose
 
 
+@zpublish
 class Bindings:
 
     security = ClassSecurityInfo()

--- a/src/Shared/DC/Scripts/BindingsUI.py
+++ b/src/Shared/DC/Scripts/BindingsUI.py
@@ -16,6 +16,7 @@ from AccessControl.Permissions import view_management_screens
 from AccessControl.SecurityInfo import ClassSecurityInfo
 from App.special_dtml import DTMLFile
 from Shared.DC.Scripts.Bindings import Bindings
+from ZPublisher import zpublish
 
 
 class BindingsUI(Bindings):
@@ -30,6 +31,7 @@ class BindingsUI(Bindings):
                               'ZBindingsHTML_editForm')
     ZBindingsHTML_editForm = DTMLFile('dtml/scriptBindings', globals())
 
+    @zpublish
     @security.protected('Change bindings')
     def ZBindingsHTML_editAction(self, REQUEST):
         '''Changes binding names.

--- a/src/Testing/tests/test_testbrowser.py
+++ b/src/Testing/tests/test_testbrowser.py
@@ -25,10 +25,12 @@ from Testing.ZopeTestCase import FunctionalTestCase
 from Testing.ZopeTestCase import user_name
 from Testing.ZopeTestCase import user_password
 from zExceptions import NotFound
+from ZPublisher import zpublish
 from ZPublisher.httpexceptions import HTTPExceptionHandler
 from ZPublisher.WSGIPublisher import publish_module
 
 
+@zpublish
 class CookieStub(Item):
     """This is a cookie stub."""
 
@@ -37,6 +39,7 @@ class CookieStub(Item):
         return 'Stub'
 
 
+@zpublish
 class ExceptionStub(Item):
     """This is a stub, raising an exception."""
 
@@ -44,6 +47,7 @@ class ExceptionStub(Item):
         raise ValueError('dummy')
 
 
+@zpublish
 class RedirectStub(Item):
     """This is a stub, causing a redirect."""
 

--- a/src/ZPublisher/BaseRequest.py
+++ b/src/ZPublisher/BaseRequest.py
@@ -14,9 +14,9 @@
 """
 
 import types
+import warnings
 from os import environ
 from urllib.parse import quote as urllib_quote
-from warnings import warn
 
 from AccessControl.ZopeSecurityPolicy import getRoles
 from Acquisition import aq_base
@@ -729,7 +729,7 @@ class BaseRequest:
                 "to `ZPublisher.zpublish` decorator or have a docstring to be "
                 "published.")
         if deprecate_docstrings:
-            warn(DocstringWarning(obj, url))
+            warnings.warn(DocstringWarning(obj, url))
 
 
 def exec_callables(callables):
@@ -869,3 +869,19 @@ class DocstringWarning(DeprecationWarning):
         return (f"{self.tag()} uses deprecated docstring "
                 "publication control. Use the `ZPublisher.zpublish` decorator "
                 "instead")
+
+
+if deprecate_docstrings:
+    # look whether there is already a ``DocstringWarning`` filter
+    for f in warnings.filters:
+        if f[2] is DocstringWarning:
+            break
+    else:
+        # provide a ``DocstringWarning`` filter
+        # if ``deprecate_docstrings`` specifies a sensefull action
+        # use it, otherwise ``"default"``.
+        warn_action = deprecate_docstrings \
+            if deprecate_docstrings \
+            in ("default", "error", "ignore", "always") \
+            else "default"
+        warnings.filterwarnings(warn_action, category=DocstringWarning)

--- a/src/ZPublisher/BaseRequest.py
+++ b/src/ZPublisher/BaseRequest.py
@@ -37,7 +37,7 @@ from zope.publisher.interfaces import NotFound as ztkNotFound
 from zope.publisher.interfaces.browser import IBrowserPublisher
 from zope.traversing.namespace import namespaceLookup
 from zope.traversing.namespace import nsParse
-from ZPublisher import _ZPUBLISH_ATTR
+from ZPublisher import zpublish_mark
 from ZPublisher.Converters import type_converters
 from ZPublisher.interfaces import UseTraversalDefault
 from ZPublisher.xmlrpc import is_xmlrpc_response
@@ -683,9 +683,20 @@ class BaseRequest:
         """
         url, default = self["URL"], None
         if for_call:
-            url += ".__call__"
+            # We are called to check the publication
+            # of the ``__call__`` method.
+            # Usually, its publication indication comes from its
+            # ``__self__`` and this has already been checked.
+            # It can however carry a stricter publication indication
+            # which we want to check here.
+            # We achieve this by changing *default* from
+            # ``None`` to ``True``. In this way, we get the publication
+            # indication of ``__call__`` if it carries one
+            # or ``True`` otherwise which in this case
+            # indicates "already checked".
+            url += "[__call__]"
             default = True
-        publishable = getattr(obj, _ZPUBLISH_ATTR, default)
+        publishable = zpublish_mark(obj, default)
         # ``publishable`` is either ``None``, ``True``, ``False`` or
         # a tuple of allowed request methods.
         if publishable is True:  # explicitely marked as publishable

--- a/src/ZPublisher/__init__.py
+++ b/src/ZPublisher/__init__.py
@@ -1,6 +1,6 @@
 ##############################################################################
 #
-# Copyright (c) 2002 Zope Foundation and Contributors.
+# Copyright (c) 2002-2024 Zope Foundation and Contributors.
 #
 # This software is subject to the provisions of the Zope Public License,
 # Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
@@ -10,6 +10,9 @@
 # FOR A PARTICULAR PURPOSE
 #
 ##############################################################################
+
+from functools import wraps
+from inspect import signature
 
 
 class Retry(Exception):
@@ -29,3 +32,54 @@ class Retry(Exception):
             raise v.with_traceback(tb)
         finally:
             tb = None
+
+
+_ZPUBLISH_ATTR = "__zpublishable__"
+
+
+def zpublish(publish=True, callable=None):
+    """decorator signaling design for/not for publication.
+
+    Usage:
+
+      @zpublish
+      def f(...): ...
+
+      @zpublish(True)
+      def f(...): ...
+
+        ``f`` is designed to be published by ``ZPublisher``.
+
+      @zpublish(False)
+      def f(...): ...
+        ``ZPublisher`` should not publish ``f``
+
+      @zpublish...
+      class C: ...
+        instances of ``C`` can/can not be published by ``ZPublisher``.
+
+      zpublish(publish=..., callable=obj)
+        returns a wrapper for callable *obj* with the same signature;
+        *publish* determines its publishability.
+
+    ``Zpublish(f)`` is equivalent to ``zpublish(True)(f)`` if
+    ``f`` is not a boolean.
+    """
+    if callable is not None:
+        assert isinstance(publish, bool), "publish must be a boolean"
+
+        @zpublish(publish)
+        @wraps(callable)
+        def wrapper(*args, **kw):
+            return callable(*args, **kw)
+        wrapper.__signature__ = signature(callable, follow_wrapped=False)
+        return wrapper
+
+    if not isinstance(publish, bool):
+        return zpublish(True)(publish)
+
+    def wrap(f):
+        setattr(f, _ZPUBLISH_ATTR, publish)
+        return f
+
+    return wrap

--- a/src/ZPublisher/__init__.py
+++ b/src/ZPublisher/__init__.py
@@ -91,7 +91,7 @@ def zpublish(publish=True, *, methods=None):
 
 
 def zpublish_mark(obj):
-    """the ``zpublis`` indication at *obj*."""
+    """the ``zpublish`` indication at *obj*."""
     return getattr(obj, _ZPUBLISH_ATTR, None)
 
 

--- a/src/ZPublisher/__init__.py
+++ b/src/ZPublisher/__init__.py
@@ -90,21 +90,30 @@ def zpublish(publish=True, *, methods=None):
     return wrap
 
 
-def zpublish_mark(obj):
-    """the ``zpublish`` indication at *obj*."""
-    return getattr(obj, _ZPUBLISH_ATTR, None)
+def zpublish_mark(obj, default=None):
+    """the publication indication effective at *obj* or *default*.
+
+    For an instance, the indication usually comes from its class
+    or a base class; a function/method typically carries the
+    indication itself.
+
+    The publication indication is either ``True`` (publication allowed),
+    ``False`` (publication disallowed) or a tuple
+    of request method names for which publication is allowed.
+    """
+    return getattr(obj, _ZPUBLISH_ATTR, default)
 
 
 def zpublish_marked(obj):
-    """true if *obj* carries a publication indication."""
+    """true if a publication indication is effective at *obj*."""
     return zpublish_mark(obj) is not None
 
 
 def zpublish_wrap(callable):
     """wrap *callable* to provide a publication indication.
 
-    Return *callable* unchanged if it already carries a
-    publication indication;
+    Return *callable* unchanged if a publication indication
+    is already effective at *callable*;
     otherwise, return a signature preserving wrapper
     allowing publication.
     """

--- a/src/ZPublisher/tests/docstring.py
+++ b/src/ZPublisher/tests/docstring.py
@@ -1,0 +1,13 @@
+"""Resources for ``testBaseRequest.TestDocstringWarning``.
+
+The tests there depend on line numbers in this module.
+"""
+
+
+def f():
+    "f"
+
+
+class C:
+    "C"
+    g = f

--- a/src/ZPublisher/tests/testBaseRequest.py
+++ b/src/ZPublisher/tests/testBaseRequest.py
@@ -6,6 +6,9 @@ from zope.interface import implementer
 from zope.publisher.interfaces import IPublishTraverse
 from zope.publisher.interfaces import NotFound as ztkNotFound
 from ZPublisher import zpublish
+from ZPublisher.BaseRequest import DocstringWarning
+
+from . import docstring
 
 
 @implementer(IPublishTraverse)
@@ -885,3 +888,37 @@ class TestBaseRequestViews(TestRequestViewsBase):
         root, folder = self._makeRootAndFolder()
         r = self._makeOne(root)
         self.assertIsInstance(str(r), str)
+
+
+class TestDocstringWarning(unittest.TestCase):
+    def test_method(self):
+        c = docstring.C()
+        ds = DocstringWarning(c.g, "URL")
+        self.assertEqual(ds.tag(),
+                         "'ZPublisher.tests.docstring.C' method "
+                         "'f'[ZPublisher.tests.docstring:7]")
+
+    def test_function(self):
+        f = docstring.f
+        ds = DocstringWarning(f, "URL")
+        self.assertEqual(ds.tag(),
+                         "function 'ZPublisher.tests.docstring.f' at line 7")
+
+    def test_instance_with_own_docstring(self):
+        c = docstring.C()
+        c.__doc__ = "c"
+        ds = DocstringWarning(c, "URL")
+        self.assertEqual(ds.tag(), "object at 'URL'")
+
+    def test_instance_with_inherited_docstring(self):
+        c = docstring.C()
+        ds = DocstringWarning(c, "URL")
+        self.assertEqual(ds.tag(), "'ZPublisher.tests.docstring.C' at line 11")
+
+    def test__str__(self):
+        ds = DocstringWarning("special", "URL")
+        self.assertEqual(
+            str(ds),
+            "'builtins.str' uses deprecated docstring "
+            "publication control. Use the `ZPublisher.zpublish` decorator "
+            "instead")

--- a/src/ZPublisher/tests/testBeforeTraverse.py
+++ b/src/ZPublisher/tests/testBeforeTraverse.py
@@ -1,6 +1,7 @@
 import doctest
 
 from Acquisition import Implicit
+from ZPublisher import zpublish
 from ZPublisher.BaseRequest import BaseRequest
 from ZPublisher.HTTPResponse import HTTPResponse
 
@@ -18,6 +19,7 @@ def makeBaseRequest(root):
     return BaseRequest(environment)
 
 
+@zpublish
 class DummyObjectBasic(Implicit):
     """ Dummy class with docstring.
     """

--- a/src/ZPublisher/tests/testPostTraversal.py
+++ b/src/ZPublisher/tests/testPostTraversal.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 
 import Zope2
 from Acquisition import Implicit
+from ZPublisher import zpublish
 from ZPublisher.BaseRequest import BaseRequest
 from ZPublisher.HTTPResponse import HTTPResponse
 
@@ -34,6 +35,7 @@ def pt_chain_test(request, string):
     request.set('a', request.get('a', '') + string)
 
 
+@zpublish
 class DummyObjectBasic(Implicit):
     """ Dummy class with docstring.
     """
@@ -42,12 +44,14 @@ class DummyObjectBasic(Implicit):
         setattr(self, id, object)
         return getattr(self, id)
 
+    @zpublish
     def view(self):
         """ Attribute with docstring.
         """
         return 'view content'
 
 
+@zpublish
 class DummyObjectWithPTHook(DummyObjectBasic):
     """ Dummy class with docstring.
     """

--- a/src/ZPublisher/tests/test_pubevents.py
+++ b/src/ZPublisher/tests/test_pubevents.py
@@ -16,6 +16,7 @@ from zope.interface import Interface
 from zope.interface.verify import verifyObject
 from zope.publisher.interfaces import INotFound
 from zope.publisher.interfaces.browser import IDefaultBrowserLayer
+from ZPublisher import zpublish
 from ZPublisher.BaseRequest import BaseRequest
 from ZPublisher.HTTPRequest import WSGIRequest
 from ZPublisher.HTTPResponse import WSGIResponse
@@ -279,6 +280,7 @@ class TestGlobalRequestPubEventsAndExceptionUpgrading(FunctionalTestCase):
     def test_exception_views_and_event_handlers_get_upgraded_exceptions(self):
         self.expected_exception_type = zExceptions.HTTPVersionNotSupported
 
+        @zpublish
         def raiser(*args, **kwargs):
             "Allow publishing"
             class HTTPVersionNotSupported(Exception):

--- a/src/ZPublisher/tests/test_zpublish.py
+++ b/src/ZPublisher/tests/test_zpublish.py
@@ -1,0 +1,74 @@
+##############################################################################
+#
+# Copyright (c) 2024 Zope Foundation and Contributors.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+"""``zpublish`` related tests."""
+
+from inspect import signature
+from unittest import TestCase
+
+from .. import zpublish
+from .. import zpublish_mark
+from .. import zpublish_marked
+from .. import zpublish_wrap
+
+
+class ZpublishTests(TestCase):
+    def test_zpublish_true(self):
+        @zpublish
+        def f():
+            pass
+
+        self.assertIs(zpublish_mark(f), True)
+        self.assertTrue(zpublish_marked(f))
+
+    def test_zpublish_false(self):
+        @zpublish(False)
+        def f():
+            pass
+
+        self.assertIs(zpublish_mark(f), False)
+        self.assertTrue(zpublish_marked(f))
+
+    def test_zpublish_method(self):
+        @zpublish(methods="method")
+        def f():
+            pass
+
+        self.assertEqual(zpublish_mark(f), ("METHOD",))
+        self.assertTrue(zpublish_marked(f))
+
+    def test_zpublish_methods(self):
+        @zpublish(methods="m1 m2".split())
+        def f():
+            pass
+
+        self.assertEqual(zpublish_mark(f), ("M1", "M2"))
+        self.assertTrue(zpublish_marked(f))
+
+    def test_zpublish_marked(self):
+        def f():
+            pass
+
+        self.assertFalse(zpublish_marked(f))
+        zpublish(f)
+        self.assertTrue(zpublish_marked(f))
+
+    def test_zpublish_wrap(self):
+        def f():
+            pass
+
+        self.assertFalse(zpublish_marked(f))
+        wrapper = zpublish_wrap(f)
+        self.assertFalse(zpublish_marked(f))
+        self.assertIs(zpublish_mark(wrapper), True)
+        self.assertEqual(signature(wrapper), signature(f))
+        self.assertIs(wrapper, zpublish_wrap(wrapper))

--- a/src/ZPublisher/tests/test_zpublish.py
+++ b/src/ZPublisher/tests/test_zpublish.py
@@ -15,6 +15,8 @@
 from inspect import signature
 from unittest import TestCase
 
+from Shared.DC.Scripts.Signature import FuncCode
+
 from .. import zpublish
 from .. import zpublish_mark
 from .. import zpublish_marked
@@ -81,3 +83,22 @@ class ZpublishTests(TestCase):
         self.assertIs(zpublish_mark(wrapper), True)
         self.assertEqual(signature(wrapper), signature(f))
         self.assertIs(wrapper, zpublish_wrap(wrapper))
+        wrapper2 = zpublish_wrap(wrapper, conditional=False, methods="put")
+        self.assertIsNot(wrapper2, wrapper)
+        self.assertEqual(zpublish_mark(wrapper2), ("PUT",))
+
+        # test ``mapply`` signature
+
+        class WithMapplySignature:
+            __code__ = FuncCode(("a", "b", "c"), 2)
+            __defaults__ = None
+
+            def __call__(self, *args, **kw):
+                pass
+
+        f = WithMapplySignature()
+        wrapper = zpublish_wrap(f)
+        self.assertEqual(str(wrapper.__signature__), "(a, b)")
+        WithMapplySignature.__defaults__ = 2,
+        wrapper = zpublish_wrap(f)
+        self.assertEqual(str(wrapper.__signature__), "(a, b=2)")

--- a/src/ZPublisher/tests/test_zpublish.py
+++ b/src/ZPublisher/tests/test_zpublish.py
@@ -54,6 +54,15 @@ class ZpublishTests(TestCase):
         self.assertEqual(zpublish_mark(f), ("M1", "M2"))
         self.assertTrue(zpublish_marked(f))
 
+    def test_zpublish_mark(self):
+        def f():
+            pass
+
+        self.assertIsNone(zpublish_mark(f))
+        self.assertIs(zpublish_mark(f, True), True)
+        zpublish(f)
+        self.assertIs(zpublish_mark(f), True)
+
     def test_zpublish_marked(self):
         def f():
             pass

--- a/src/webdav/Collection.py
+++ b/src/webdav/Collection.py
@@ -142,7 +142,6 @@ class Collection(Resource):
 
         return RESPONSE
 
-    @zpublish
     @security.protected(webdav_access)
     def listDAVObjects(self):
         objectValues = getattr(self, 'objectValues', None)

--- a/src/webdav/Collection.py
+++ b/src/webdav/Collection.py
@@ -31,6 +31,7 @@ from zExceptions import MethodNotAllowed
 from zExceptions import NotFound
 from zope.datetime import rfc1123_date
 from zope.interface import implementer
+from ZPublisher import zpublish
 
 
 @implementer(IDAVCollection)
@@ -59,6 +60,7 @@ class Collection(Resource):
         # Initialize ETag header
         self.http__etag()
 
+    @zpublish
     @security.protected(view)
     def HEAD(self, REQUEST, RESPONSE):
         """Retrieve resource information without a response body."""
@@ -73,6 +75,7 @@ class Collection(Resource):
                 'Method not supported for this resource.')
         raise NotFound('The requested resource does not exist.')
 
+    @zpublish
     def PUT(self, REQUEST, RESPONSE):
         """The PUT method has no inherent meaning for collection
         resources, though collections are not specifically forbidden
@@ -81,6 +84,7 @@ class Collection(Resource):
         self.dav__init(REQUEST, RESPONSE)
         raise MethodNotAllowed('Method not supported for collections.')
 
+    @zpublish
     @security.protected(delete_objects)
     def DELETE(self, REQUEST, RESPONSE):
         """Delete a collection resource. For collection resources, DELETE
@@ -138,6 +142,7 @@ class Collection(Resource):
 
         return RESPONSE
 
+    @zpublish
     @security.protected(webdav_access)
     def listDAVObjects(self):
         objectValues = getattr(self, 'objectValues', None)

--- a/src/webdav/NullResource.py
+++ b/src/webdav/NullResource.py
@@ -52,6 +52,7 @@ from zExceptions import MethodNotAllowed
 from zExceptions import NotFound
 from zExceptions import Unauthorized
 from zope.contenttype import guess_content_type
+from ZPublisher import zpublish
 
 
 # XXX Originall in ZServer.Zope2.Startup.config
@@ -122,6 +123,7 @@ class NullResource(Persistent, Implicit, Resource):
 
         return ob
 
+    @zpublish
     @security.public
     def PUT(self, REQUEST, RESPONSE):
         """Create a new non-collection resource.
@@ -203,6 +205,7 @@ class NullResource(Persistent, Implicit, Resource):
         RESPONSE.setBody('')
         return RESPONSE
 
+    @zpublish
     @security.protected(add_folders)
     def MKCOL(self, REQUEST, RESPONSE):
         """Create a new collection resource."""
@@ -237,6 +240,7 @@ class NullResource(Persistent, Implicit, Resource):
         RESPONSE.setBody('')
         return RESPONSE
 
+    @zpublish
     @security.protected(webdav_lock_items)
     def LOCK(self, REQUEST, RESPONSE):
         """ LOCK on a Null Resource makes a LockNullResource instance """
@@ -338,11 +342,13 @@ class LockNullResource(NullResource, Item_w__name__):
     def title_or_id(self):
         return 'Foo'
 
+    @zpublish
     @security.protected(webdav_access)
     def PROPFIND(self, REQUEST, RESPONSE):
         """Retrieve properties defined on the resource."""
         return Resource.PROPFIND(self, REQUEST, RESPONSE)
 
+    @zpublish
     @security.protected(webdav_lock_items)
     def LOCK(self, REQUEST, RESPONSE):
         """ A Lock command on a LockNull resource should only be a
@@ -381,6 +387,7 @@ class LockNullResource(NullResource, Item_w__name__):
 
         return RESPONSE
 
+    @zpublish
     @security.protected(webdav_unlock_items)
     def UNLOCK(self, REQUEST, RESPONSE):
         """ Unlocking a Null Resource removes it from its parent """
@@ -406,6 +413,7 @@ class LockNullResource(NullResource, Item_w__name__):
             RESPONSE.setStatus(204)
         return RESPONSE
 
+    @zpublish
     @security.public
     def PUT(self, REQUEST, RESPONSE):
         """ Create a new non-collection resource, deleting the LockNull
@@ -478,6 +486,7 @@ class LockNullResource(NullResource, Item_w__name__):
         RESPONSE.setBody('')
         return RESPONSE
 
+    @zpublish
     @security.protected(add_folders)
     def MKCOL(self, REQUEST, RESPONSE):
         """ Create a new Collection (folder) resource.  Since this is being

--- a/src/webdav/Resource.py
+++ b/src/webdav/Resource.py
@@ -704,7 +704,6 @@ class Resource(Base, LockableItem):
         # If it doesn't exist, give up.
         return ''
 
-    @zpublish
     @security.protected(webdav_access)
     def listDAVObjects(self):
         return []

--- a/src/webdav/Resource.py
+++ b/src/webdav/Resource.py
@@ -60,12 +60,14 @@ from zope.event import notify
 from zope.interface import implementer
 from zope.lifecycleevent import ObjectCopiedEvent
 from zope.lifecycleevent import ObjectMovedEvent
+from ZPublisher import zpublish
 from ZPublisher.HTTPRangeSupport import HTTPRangeInterface
 
 
 ms_dav_agent = re.compile("Microsoft.*Internet Publishing.*")
 
 
+@zpublish
 @implementer(IDAVResource)
 class Resource(Base, LockableItem):
 
@@ -199,6 +201,7 @@ class Resource(Base, LockableItem):
             return 0
 
     # WebDAV class 1 support
+    @zpublish
     @security.protected(view)
     def HEAD(self, REQUEST, RESPONSE):
         """Retrieve resource information without a response body."""
@@ -230,6 +233,7 @@ class Resource(Base, LockableItem):
         RESPONSE.setStatus(200)
         return RESPONSE
 
+    @zpublish
     def PUT(self, REQUEST, RESPONSE):
         """Replace the GET response entity of an existing resource.
         Because this is often object-dependent, objects which handle
@@ -239,6 +243,7 @@ class Resource(Base, LockableItem):
         self.dav__init(REQUEST, RESPONSE)
         raise MethodNotAllowed('Method not supported for this resource.')
 
+    @zpublish
     @security.public
     def OPTIONS(self, REQUEST, RESPONSE):
         """Retrieve communication options."""
@@ -256,6 +261,7 @@ class Resource(Base, LockableItem):
         RESPONSE.setStatus(200)
         return RESPONSE
 
+    @zpublish
     @security.public
     def TRACE(self, REQUEST, RESPONSE):
         """Return the HTTP message received back to the client as the
@@ -267,6 +273,7 @@ class Resource(Base, LockableItem):
         self.dav__init(REQUEST, RESPONSE)
         raise MethodNotAllowed('Method not supported for this resource.')
 
+    @zpublish
     @security.protected(delete_objects)
     def DELETE(self, REQUEST, RESPONSE):
         """Delete a resource. For non-collection resources, DELETE may
@@ -303,6 +310,7 @@ class Resource(Base, LockableItem):
 
         return RESPONSE
 
+    @zpublish
     @security.protected(webdav_access)
     def PROPFIND(self, REQUEST, RESPONSE):
         """Retrieve properties defined on the resource."""
@@ -322,6 +330,7 @@ class Resource(Base, LockableItem):
         RESPONSE.setBody(result)
         return RESPONSE
 
+    @zpublish
     @security.protected(manage_properties)
     def PROPPATCH(self, REQUEST, RESPONSE):
         """Set and/or remove properties defined on the resource."""
@@ -345,12 +354,14 @@ class Resource(Base, LockableItem):
         RESPONSE.setBody(result)
         return RESPONSE
 
+    @zpublish
     def MKCOL(self, REQUEST, RESPONSE):
         """Create a new collection resource. If called on an existing
         resource, MKCOL must fail with 405 (Method Not Allowed)."""
         self.dav__init(REQUEST, RESPONSE)
         raise MethodNotAllowed('The resource already exists.')
 
+    @zpublish
     @security.public
     def COPY(self, REQUEST, RESPONSE):
         """Create a duplicate of the source resource whose state
@@ -463,6 +474,7 @@ class Resource(Base, LockableItem):
         RESPONSE.setBody('')
         return RESPONSE
 
+    @zpublish
     @security.public
     def MOVE(self, REQUEST, RESPONSE):
         """Move a resource to a new location. Though we may later try to
@@ -591,6 +603,7 @@ class Resource(Base, LockableItem):
 
     # WebDAV Class 2, Lock and Unlock
 
+    @zpublish
     @security.protected(webdav_lock_items)
     def LOCK(self, REQUEST, RESPONSE):
         """Lock a resource"""
@@ -653,6 +666,7 @@ class Resource(Base, LockableItem):
 
         return RESPONSE
 
+    @zpublish
     @security.protected(webdav_unlock_items)
     def UNLOCK(self, REQUEST, RESPONSE):
         """Remove an existing lock on a resource."""
@@ -673,6 +687,7 @@ class Resource(Base, LockableItem):
             RESPONSE.setStatus(204)     # No Content response code
         return RESPONSE
 
+    @zpublish
     @security.protected(webdav_access)
     def manage_DAVget(self):
         """Gets the document source or file data.
@@ -689,6 +704,7 @@ class Resource(Base, LockableItem):
         # If it doesn't exist, give up.
         return ''
 
+    @zpublish
     @security.protected(webdav_access)
     def listDAVObjects(self):
         return []


### PR DESCRIPTION
This PR addresses #774.

It introduces the decorator `ZPublisher.zpublish` to explicitly mark a class, method or function definition as designed to be publishable by `ZPublisher`. If a class is marked in this way, its instances become publishable.

In the long term, `zpublish` decoration should replace the implicit publication control via the existence of a docstring. If the environment variable `ZPUBLISHER_DEPRECATE_DOCSTRINGS` has a non-empty value, then a `DocstringWarning` (derived from `DeprecationWarning`) is issued when a object gets published because it has a docstring.  This should help component authors to find locations where explicit `zpublish` decoration may become necessary in the future. If `ZPUBLISHER_DEPRECATE_DOCSTRINGS` has a non-empty value and Python's warning filter does not yet have a special rule for `ZPublisher.BaseRequest.DocstringWarning`, then such a rule is added. If the value is a meaningful filter action, then it, otherwise `"default"`, is used as action for this rule.

Typically, `zpublish` is used to mark a class or function/method as designed for publication. However, a decoration with `zpublish(False)` explicitly marks the class (more precisely its instances) or function/method explicitly as not publishable, overriding a potentially existing docstring.
Following the review suggestion from @perrinjerome, `zpublish(methods=...)` where `...` is either a single request method name or a sequence of request method names marks a method as publishable only for the mentioned request methods.

The full signature of `zpublish` is `publish=True, *, methods=None`.  If *methods* in not `None`, *publish* must be `True`. In this case, *methods* is either a single request method name or a sequence of request method names; those request method names specify the request methods for which the object is publishable.

`ZPublisher` contains the related functions `zpublish_marked` and `zpublish_wrap`. `zpublish_marked` checks whether there is a zpublishable mark for an object, `zpublish_wrap`  can return a zpublishable signature preserving wrapper for a callable that lacks its own zpublishable mark. This is used by `registerClass` to automatically add zpublishable marks to a registered class and its constructors.

`zpublish` uses an attribute for publication control. Therefore, derived classes inherit the control by default, unlike as for docstrings.
Another consequence is that (other) decorators must preserve attributes of a decorated function; otherwise, the attribute set by `zpublish` may get lost.
Currently, the decorator `AccessControl.requestmethod.requestmethod` does not fulfill this requirement.
