### PR TITLE
Fix Content-Disposition header for clients without rfc6266 support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,9 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 - Fix redirections to URLs with host given as IP-literal with brackets.
   Fixes `#1191 <https://github.com/zopefoundation/Zope/issues/1191>`_.
 
+- Fix ``Content-Disposition`` filename for clients without rfc6266 support.
+  (`#1198 <https://github.com/zopefoundation/Zope/pull/1198>`_)
+
 
 5.9 (2023-11-24)
 ----------------

--- a/src/ZPublisher/HTTPResponse.py
+++ b/src/ZPublisher/HTTPResponse.py
@@ -142,7 +142,8 @@ def make_content_disposition(disposition, file_name):
         #
         # a special header has to be crafted
         # also see https://tools.ietf.org/html/rfc6266#appendix-D
-        encoded_file_name = file_name.encode('us-ascii', errors='ignore')
+        encoded_file_name = file_name.encode(
+            'us-ascii', errors='ignore').decode()
         header += f'; filename="{encoded_file_name}"'
         quoted_file_name = quote(file_name)
         header += f'; filename*=UTF-8\'\'{quoted_file_name}'

--- a/src/ZPublisher/tests/testHTTPResponse.py
+++ b/src/ZPublisher/tests/testHTTPResponse.py
@@ -1433,7 +1433,7 @@ class MakeDispositionHeaderTests(unittest.TestCase):
     def test_latin_one(self):
         self.assertEqual(
             make_content_disposition('inline', 'Dänemark.png'),
-            'inline; filename="b\'Dnemark.png\'"; filename*=UTF-8\'\'D%C3%A4nemark.png'  # noqa: E501
+            'inline; filename="Dnemark.png"; filename*=UTF-8\'\'D%C3%A4nemark.png'  # noqa: E501
         )
 
     def test_unicode(self):
@@ -1445,7 +1445,7 @@ class MakeDispositionHeaderTests(unittest.TestCase):
         """
         self.assertEqual(
             make_content_disposition('inline', 'ıq.png'),
-            'inline; filename="b\'q.png\'"; filename*=UTF-8\'\'%C4%B1q.png'
+            'inline; filename="q.png"; filename*=UTF-8\'\'%C4%B1q.png'
         )
 
 


### PR DESCRIPTION
Since https://github.com/zopefoundation/Zope/pull/893 the Content-Disposition header supports non-ascii filenames, by containing the filename in ascii and the filename in UTF-8, but the ascii version was produced by applying `str` on a `bytes` instance, so it looks like `b'file.txt'` instead of `file.txt`.