### PR TITLE
Work around `Products.CMFCore` and `Products.CMFPlone` design bug

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,11 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 - Fix authentication error viewing ZMI with a user defined outside of zope root.
   Fixes `#1195 <https://github.com/zopefoundation/Zope/issues/1195>`_.
 
+- Work around ``Products.CMFCore`` and ``Products.CMFPlone`` design bug
+  (registering non callable constructors).
+  For details, see
+  `#1202 <https://github.com/zopefoundation/Zope/issues/1202>`_.
+
 
 5.9 (2023-11-24)
 ----------------

--- a/src/App/tests/test_ProductContext.py
+++ b/src/App/tests/test_ProductContext.py
@@ -1,0 +1,190 @@
+##############################################################################
+#
+# Copyright (c) 2024 Zope Foundation and Contributors.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+"""Partial ``ProductContext`` tests.
+"""
+
+from types import ModuleType
+from types import SimpleNamespace
+from unittest import TestCase
+
+from ZPublisher import zpublish_marked
+
+from ..ProductContext import ProductContext
+
+
+class ProductContextTests(TestCase):
+    def setUp(self):
+        self.args = _Product(), _App(), ModuleType("pack")
+        self.pc = ProductContext(*self.args)
+        # ``ProductContext.registerClass`` has a lot of global
+        # side effects. We save the original values, set up values
+        # for our tests and restore the original values in ``teadDown``
+        # When further tests are added, the list likely needs to
+        # be extended
+        self._saved = {}
+        for ospec, val in {
+                "sys.modules['Products']": ModuleType("Products"),
+                "AccessControl.Permission._registeredPermissions": {},
+                "AccessControl.Permission._ac_permissions": (),
+                "AccessControl.Permission.ApplicationDefaultPermissions":
+                _ApplicationDefaultPermissions}.items():
+            obj = _resolve(ospec)
+            self._saved[ospec] = obj.get()
+            obj.set(val)
+
+    def tearDown(self):
+        for ospec, val in self._saved.items():
+            _resolve(ospec).set(val)
+
+    def test_initial_tuple(self):
+
+        def c():
+            pass
+
+        self.pc.registerClass(meta_type="test", permission="test",
+                              constructors=(("name", c),))
+        self._verify_reg("name", "c")
+
+    def test_initial_named(self):
+
+        def c():
+            pass
+
+        self.pc.registerClass(meta_type="test", permission="test",
+                              constructors=(c,))
+        self._verify_reg("c", "c")
+
+    def test_constructor_tuple(self):
+
+        def initial():
+            pass
+
+        def c():
+            pass
+
+        self.pc.registerClass(meta_type="test", permission="test",
+                              constructors=(initial, ("name", c),))
+        self._verify_reg("name", "c")
+
+    def test_constructor_named(self):
+
+        def initial():
+            pass
+
+        def c():
+            pass
+
+        self.pc.registerClass(meta_type="test", permission="test",
+                              constructors=(initial, c,))
+        self._verify_reg("c", "c")
+
+    def test_constructor_noncallable(self):
+
+        def initial():
+            pass
+
+        nc = SimpleNamespace(__name__="nc")
+        with self.assertWarns(DeprecationWarning):
+            self.pc.registerClass(meta_type="test", permission="test",
+                                  constructors=(initial, nc))
+        self._verify_reg("nc", nc)
+
+    def test_resource_tuple(self):
+
+        def initial():
+            pass
+
+        r = SimpleNamespace()
+        self.pc.registerClass(meta_type="test", permission="test",
+                              constructors=(initial,),
+                              resources=(("r", r),))
+        self._verify_reg("r", r)
+
+    def test_resource_named(self):
+
+        def initial():
+            pass
+
+        r = SimpleNamespace(__name__="r")
+        self.pc.registerClass(meta_type="test", permission="test",
+                              constructors=(initial,),
+                              resources=(r,))
+        self._verify_reg("r", r)
+
+    def _verify_reg(self, name, obj):
+        pack = self.args[-1]
+        m = pack._m
+        fo = m[name]
+        if isinstance(obj, str):
+            self.assertEqual(obj, fo.__name__)
+            self.assertTrue(zpublish_marked(fo))
+        else:
+            self.assertIs(obj, fo)
+
+
+class _Product:
+    """Product mockup."""
+    def __init__(self):
+        self.id = "pid"
+
+
+class _App:
+    """Application mockup"""
+
+
+class _ApplicationDefaultPermissions:
+    """ApplicationDefaultPermissions mockup."""
+
+
+class _Attr(SimpleNamespace):
+    """an attribute."""
+
+    def get(self):
+        return getattr(self.o, self.a)
+
+    def set(self, val):
+        setattr(self.o, self.a, val)
+
+
+class _Item(SimpleNamespace):
+    """a (mapping) item."""
+
+    def get(self):
+        # we use ``_Item`` for missiong
+        return self.o.get(self.a, _Item)
+
+    def set(self, val):
+        # we use ``_Item`` for missiong
+        if val is _Item:
+            del self.o[self.a]
+        else:
+            self.o[self.a] = val
+
+
+def _resolve(spec):
+    """resolve *spec* into an ``_Attr`` or ``_Item``.
+
+    *spec* is a dotted name, optionally followed by a subscription.
+    """
+    if "[" in spec:
+        dotted, sub = spec[:-1].split("[")
+    else:
+        dotted, sub = spec, None
+    o = None
+    segs = dotted.split(".")
+    for i in range(0, len(segs) - (0 if sub is not None else 1)):
+        seg = segs[i]
+        o = getattr(o, seg, None)
+        if o is None:
+            o = __import__(".".join(segs[:i + 1]), fromlist=(seg,))
+    return _Attr(o=o, a=segs[-1]) if sub is None else _Item(o=o, a=eval(sub))


### PR DESCRIPTION
Work around for #1202.

`Products.CMFCore` and `Products.CMFPlone` register non callable constructors with `App.ProductContext.ProductContext.registerClass` (even though the method's docstring clearly states that constructors must be callable).
Formerly, this was not a problem. But with the introduction of explicit zpublishable decoration, constructors are now required to be callable braking `Products.CMFCore` and `Products.CMFPlone`.

The PR introduces the new parameter `resources` of `registerClass`  which should be used instead of `constructors` to register non callable objects. It uses work around code to avoid braking `Products.CMFCore` and `Products.CMFPlone` (and maybe other packages) when they abuse the `constructors` parameter for non callable objects; a `DeprecationWarning` is issued in this case.

In addition, the PR cleans up `registerClass`'s docstring a bit: in the old days, when the product registry could still be persistent (controlled via a parameter), the constructors were required to be picklable. The feature was abandoned long ago (because of many problems) and consequently, constructors need no longer be picklable (indeed, the constructors generated for zpublishable decoration are not picklable). The PR removes the corresponding requirement from the docstring..

Finally, the PR removes the mention from the docstring that the `instance_class`  parameter were not used (which is obviously wrong). But, I am not sure whether this removal is optimal. It is possible that the author wanted to express that `instance_class` is not used directly (to construct instances) but only to provide useful defaults for other parameters. Feedback welcome.

I would like to stress that this is a work around for bugs in other packages. They should get fixed there and the work around code here eventually removed.