### PR TITLE
Do not fail when request has no ensure_publishable method.

### DIFF
--- a/src/ZPublisher/BaseRequest.py
+++ b/src/ZPublisher/BaseRequest.py
@@ -139,7 +139,8 @@ class DefaultPublishTraverse:
                     except TypeError:  # unsubscriptable
                         raise KeyError(name)
 
-        self.request.ensure_publishable(subobject)
+        if hasattr(self.request, "ensure_publishable"):
+            self.request.ensure_publishable(subobject)
         return subobject
 
     def browserDefault(self, request):


### PR DESCRIPTION
This may happen in tests.
In a Plone core development buildout with Zope master there are failures in `plone.dexterity`:

```
$ bin/test -s plone.dexterity -u
...
Error in test test_acquire_without_dav (plone.dexterity.tests.test_webdav.TestDAVTraversal.test_acquire_without_dav)
Traceback (most recent call last):
  File "/Users/maurits/.pyenv/versions/3.11.7/lib/python3.11/unittest/case.py", line 57, in testPartExecutor
    yield
  File "/Users/maurits/.pyenv/versions/3.11.7/lib/python3.11/unittest/case.py", line 623, in run
    self._callTestMethod(testMethod)
  File "/Users/maurits/.pyenv/versions/3.11.7/lib/python3.11/unittest/case.py", line 579, in _callTestMethod
    if method() is not None:
  File "/Users/maurits/shared-eggs/cp311/plone.dexterity-3.0.5-py3.11.egg/plone/dexterity/tests/test_webdav.py", line 1174, in test_acquire_without_dav
    r = traversal.publishTraverse(request, "item")
  File "/Users/maurits/shared-eggs/cp311/plone.dexterity-3.0.5-py3.11.egg/plone/dexterity/browser/traversal.py", line 40, in publishTraverse
    defaultTraversal = super().publishTraverse(request, name)
  File "/Users/maurits/community/plone-coredev/6.0/src/Zope/src/ZPublisher/BaseRequest.py", line 142, in publishTraverse
    self.request.ensure_publishable(subobject)
AttributeError: 'DAVTestRequest' object has no attribute 'ensure_publishable'

...

Error in test test_get_acquired (plone.dexterity.tests.test_webdav.TestDexterityPublishTraverse.test_get_acquired)
Traceback (most recent call last):
  File "/Users/maurits/.pyenv/versions/3.11.7/lib/python3.11/unittest/case.py", line 57, in testPartExecutor
    yield
  File "/Users/maurits/.pyenv/versions/3.11.7/lib/python3.11/unittest/case.py", line 623, in run
    self._callTestMethod(testMethod)
  File "/Users/maurits/.pyenv/versions/3.11.7/lib/python3.11/unittest/case.py", line 579, in _callTestMethod
    if method() is not None:
  File "/Users/maurits/shared-eggs/cp311/plone.dexterity-3.0.5-py3.11.egg/plone/dexterity/tests/test_webdav.py", line 1309, in test_get_acquired
    traversed = traversal.publishTraverse(self.get_request, "folder")
  File "/Users/maurits/shared-eggs/cp311/plone.dexterity-3.0.5-py3.11.egg/plone/dexterity/browser/traversal.py", line 40, in publishTraverse
    defaultTraversal = super().publishTraverse(request, name)
  File "/Users/maurits/community/plone-coredev/6.0/src/Zope/src/ZPublisher/BaseRequest.py", line 142, in publishTraverse
    self.request.ensure_publishable(subobject)
AttributeError: 'NoneType' object has no attribute 'ensure_publishable'
```

This could be fixed in the `plone.dexterity` tests.  But I expect that there will be quite a few add-ons that have their own mock request class that has no `ensure_publishable` method.