### PR TITLE
Revert "Avoid casting the body to a string when it is already a strin…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,7 +38,6 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
   For details, see
   `#1202 <https://github.com/zopefoundation/Zope/issues/1202>`_.
 
-- Small optimization when encoding the response body.
 
 5.9 (2023-11-24)
 ----------------

--- a/src/ZPublisher/HTTPResponse.py
+++ b/src/ZPublisher/HTTPResponse.py
@@ -552,9 +552,7 @@ class HTTPBaseResponse(BaseResponse):
             except (TypeError, UnicodeError):
                 pass
         if not isinstance(body, bytes):
-            if not isinstance(body, str):
-                body = str(body)
-            body = self._encode_unicode(body)
+            body = self._encode_unicode(str(body))
 
         # At this point body is always binary
         b_len = len(body)


### PR DESCRIPTION
…g (#1208)"

This reverts commit fdb12681419aefee191dfb59afa629e228bab94e because it failed to be a real improvement.