### PR TITLE
Update three packages.

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -15,7 +15,7 @@ Pygments = 2.17.2
 Record = 4.0
 Sphinx = 7.2.6
 alabaster = 0.7.13
-certifi = 2023.11.17
+certifi = 2024.2.2
 charset-normalizer = 3.3.2
 collective.recipe.template = 2.2
 colorama = 0.4.6
@@ -25,7 +25,7 @@ five.localsitemanager = 4.0
 idna = 3.4
 imagesize = 1.4.1
 importlib-metadata = 6.8.0
-mr.developer = 2.0.1
+mr.developer = 2.0.2
 packaging = 23.2
 plone.recipe.command = 1.1
 requests = 2.31.0
@@ -43,7 +43,7 @@ urllib3 = 2.1.0
 z3c.checkversions = 2.1
 zc.recipe.testrunner = 3.0
 zipp = 3.17.0
-zope.testrunner = 6.2.1
+zope.testrunner = 6.4
 
 [versions:python38]
 # Sphinx >= 7.2 requires Python 3.9+


### PR DESCRIPTION
Plone currently overrides three versions compared to Zope master.
I know you prefer updating the versions once after a Zope release and then test with those until the next Zope release.  But maybe these can be considered.  I don't mind, just a suggestion.

* Latest certifi seems a logical one.
* mr.developer has a small fix: https://github.com/fschulze/mr.developer/blob/master/CHANGES.rst
* zope.testrunner has fixes for Python 3.13 and native namespaces: https://github.com/zopefoundation/zope.testrunner/blob/master/CHANGES.rst