### PR TITLE
Zope logo usage: CC-BY-4.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 
 - Update to newest compatible versions of dependencies.
 
+- Added CC-BY 4.0 license to the Zope logo. 
+
 
 5.10 (2024-05-18)
 -----------------

--- a/src/zmi/styles/resources/logo/docs/README.md
+++ b/src/zmi/styles/resources/logo/docs/README.md
@@ -45,3 +45,9 @@ The primary color is a vivid blue. If no color is avaliable (e.g. laser printer)
 1. RGB #00AAD4, CMYK: C100 M20 Y0 K0
 2. black variant for b/w laser printer
 3. white/inverted variant for dark/colorful backgrounds
+
+## Logo Usage CC-BY-4.0
+
+The use of the Zope logo is subject to the Zope Public License (ZPL) policy. The logo may be used for the purpose of promoting Zope and its related products and services. The logo may not be used in a way that implies endorsement by the Zope Foundation or the Zope community. The logo may not be used in a way that implies that the Zope Foundation or the Zope community is responsible for the actions of the third party using the logo. The logo may be applied according the Creative Commons Attribution 4.0 International License (CC-BY-4.0):
+https://creativecommons.org/licenses/by/4.0/
+


### PR DESCRIPTION
For promoting Zope with it's logo graphics a Creative Commons license model would be very helpful. 
Today any usage of the logo may be legally unclear and will require an explicit confirmation by Zope/Plone Foundation.
E.g. Wikipedia is asking now for this explicit confirmation by the copyright owners, if the file may be published/referenced:
https://de.wikipedia.org/wiki/Datei:Zope.svg#file

Instead of sending an email to the wikimeda foundation by the concerned people I propose a standard licensing model as recommended here (german language):
https://de.wikipedia.org/wiki/Hilfe:FAQ_zu_Bildern

To make the usage easier, I have added some general information to the logo-readme file.  Looking forward to any comments.