### PR TITLE
OFS/dtml/cacheable: Remove "New" from label

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,13 +10,15 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 5.11.2 (unreleased)
 -------------------
 
-
-5.11.1 (2024-11-03)
--------------------
+- OFS/cachable: fix *Cache this object using* label in ZMI.
 
 - Include versions constraints for production and non-production dependencies
   in ``constraints.txt``.
   (`#1234 <https://github.com/zopefoundation/Zope/pull/1234>`_)
+
+
+5.11.1 (2024-11-03)
+-------------------
 
 - Update to newest compatible versions of dependencies.
 

--- a/src/OFS/dtml/cacheable.dtml
+++ b/src/OFS/dtml/cacheable.dtml
@@ -5,10 +5,10 @@
 
 	<form action="&dtml-absolute_url;" method="post">
 
-		<div class="form-group row mt-4 mb-4" title="New Cache this object using">
+		<div class="form-group row mt-4 mb-4" title="Cache this object using">
 			<div class="input-group col-12">
 				<div class="input-group-prepend">
-					<span class="input-group-text">New Cache&nbsp;<span class="d-none d-sm-block">this object using </span></span>
+					<span class="input-group-text">Cache&nbsp;<span class="d-none d-sm-block">this object using </span></span>
 				</div>
 					<select class="form-control" id="manager_id" name="manager_id">
 						<option value="">None</option>


### PR DESCRIPTION
In https://github.com/zopefoundation/Zope/commit/6ac52aacbea61603b482332846cf356d78a744a6#diff-1cd7357f6a0c6126e3279998f27d3c17f5d48e4940356bbe6f0266101828fb02R9 the label was changed from `Cache this object using` to `New Cache this object using`, this looks like left-overs from debugging.