### PR TITLE
set up `request["PARENTS"]` before request parameter processing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,12 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 5.11.1 (unreleased)
 -------------------
 
+ - Define ``request["PARENTS"]`` before request parameter processing
+   such that request failure subscribers (such as that of
+   ``Products.SiteErrorLog``) can determine the error context
+   for exceptions raised during request parameter processing
+   (see `#1235 <https://github.com/zopefoundation/Zope/issues/1235>`_).
+   
 
 5.11 (2024-10-11)
 -----------------

--- a/src/ZPublisher/WSGIPublisher.py
+++ b/src/ZPublisher/WSGIPublisher.py
@@ -247,6 +247,7 @@ def transaction_pubevents(request, response, tm=transaction.manager):
 
 def publish(request, module_info):
     obj, realm, debug_mode = module_info
+    request['PARENTS'] = [obj]
 
     request.processInputs()
     response = request.response
@@ -264,8 +265,6 @@ def publish(request, module_info):
     # Get the path list.
     # According to RFC1738 a trailing space in the path is valid.
     path = request.get('PATH_INFO')
-    request['PARENTS'] = [obj]
-
     obj = request.traverse(path, validated_hook=validate_user)
 
     # Set debug information from the active request on the open connection


### PR DESCRIPTION
Fixes #1235.