### PR TITLE
Enable ZMI History tab for ``OFS.Image.File``

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 5.11.2 (unreleased)
 -------------------
 
+- Enable ZMI History tab for ``OFS.Image.File``.
+  (`#396 <https://github.com/zopefoundation/Zope/pull/396>`_)
+
 - Fix error messages from spam/pen test requests.
 
 - Fix a ``ResourceWarning`` emitted when uploading large files.

--- a/src/OFS/dtml/fileEdit.dtml
+++ b/src/OFS/dtml/fileEdit.dtml
@@ -38,28 +38,26 @@
 			</div>
 		</div>
 
-		<dtml-let ct=getContentType>
-			<dtml-if "(ct.startswith('text') or ct.endswith('javascript')) and this().get_size() < 65536">
-				<div class="form-group">
-					<dtml-try>
-						<textarea id="content" <dtml-if content_type>data-contenttype="&dtml-content_type;"</dtml-if>
-							class="form-control zmi-file zmi-code col-sm-12"
-							name="filedata:text" wrap="off" rows="20"><dtml-var __str__ html_quote></textarea>
-					<dtml-except UnicodeDecodeError>
-						<div class="alert alert-warning" role="alert">
-							The file could not be decoded with '<dtml-var "error_value.encoding">'.
-						</div>
-					</dtml-try>
-				</div>
-			<dtml-else>
-				<div class="form-group row">
-					<label for="size" class="form-label	col-sm-3 col-md-2">File Size</label>
-					<div class="form-text col-sm-9 col-md-10">
-						<dtml-var size thousands_commas> bytes
+		<dtml-if manage_is_editable_inline>
+			<div class="form-group">
+				<dtml-try>
+					<textarea id="content" <dtml-if content_type>data-contenttype="&dtml-content_type;"</dtml-if>
+						class="form-control zmi-file zmi-code col-sm-12"
+						name="filedata:text" wrap="off" rows="20"><dtml-var __str__ html_quote></textarea>
+				<dtml-except UnicodeDecodeError>
+					<div class="alert alert-warning" role="alert">
+						The file could not be decoded with '<dtml-var "error_value.encoding">'.
 					</div>
+				</dtml-try>
+			</div>
+		<dtml-else>
+			<div class="form-group row">
+				<label for="size" class="form-label	col-sm-3 col-md-2">File Size</label>
+				<div class="form-text col-sm-9 col-md-10">
+					<dtml-var size thousands_commas> bytes
 				</div>
-			</dtml-if>
-		</dtml-let>
+			</div>
+		</dtml-if>
 
 		<div class="zmi-controls">
 			<dtml-if wl_isLocked>

--- a/src/OFS/tests/testFileAndImage.py
+++ b/src/OFS/tests/testFileAndImage.py
@@ -517,3 +517,16 @@ class FileEditTests(Testing.ZopeTestCase.FunctionalTestCase):
         self.assertIn('Saved changes', self.browser.contents)
         text_2 = self.browser.getControl(name='filedata:text').value
         self.assertEqual(text_2, 'hällo')
+
+    def test_File__manage_history(self):
+        self.app.file.update_data('beföre'.encode())
+        transaction.commit()
+        self.app.file.update_data('àftér'.encode())
+        transaction.commit()
+        self.browser.open('http://localhost/file/manage_main')
+        self.browser.getLink('History').click()
+        keys = self.browser.getControl(name='keys:list')
+        keys.value = [keys.options[0], keys.options[1]]
+        self.browser.getControl('Compare').click()
+        self.assertIn('beföre', self.browser.contents)
+        self.assertIn('àftér', self.browser.contents)


### PR DESCRIPTION
Modernize a bit the condition to display online text editor: support editing json inline and tolerate larger file content.