### PR TITLE
handle ViewNotCallableError as 404

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,7 +13,7 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 - Enable ZMI History tab for ``OFS.Image.File``.
   (`#396 <https://github.com/zopefoundation/Zope/pull/396>`_)
 
-- Fix error messages from spam/pen test requests.
+- Fix requests from spam/pentests to return BadRequest/400 errors
 
 - Fix a ``ResourceWarning`` emitted when uploading large files.
   (`#1242 <https://github.com/zopefoundation/Zope/issues/1242>`_)

--- a/src/ZPublisher/BaseRequest.py
+++ b/src/ZPublisher/BaseRequest.py
@@ -25,7 +25,6 @@ from Acquisition.interfaces import IAcquirer
 from ExtensionClass import Base
 from zExceptions import Forbidden
 from zExceptions import NotFound
-from zope.publisher.interfaces import ViewNotCallableError
 from zope.component import queryMultiAdapter
 from zope.event import notify
 from zope.interface import Interface
@@ -472,8 +471,8 @@ class BaseRequest:
                             adapter = DefaultPublishTraverse(object, self)
                     try:
                         object, default_path = adapter.browserDefault(self)
-                    except ViewNotCallableError:
-                        return response.badRequestError("View is not callable so likely is missing additional path elements")
+                    except NotImplementedError:
+                        return response.badRequestError("View is not callable so is likely missing extra traversal")
                     if default_path:
                         request._hacked_path = 1
                         if len(default_path) > 1:

--- a/src/ZPublisher/BaseRequest.py
+++ b/src/ZPublisher/BaseRequest.py
@@ -25,6 +25,7 @@ from Acquisition.interfaces import IAcquirer
 from ExtensionClass import Base
 from zExceptions import Forbidden
 from zExceptions import NotFound
+from zope.publisher.interfaces import ViewNotCallableError
 from zope.component import queryMultiAdapter
 from zope.event import notify
 from zope.interface import Interface
@@ -469,8 +470,10 @@ class BaseRequest:
                             # Zope2 doesn't set up its own adapters in a lot
                             # of cases so we will just use a default adapter.
                             adapter = DefaultPublishTraverse(object, self)
-
-                    object, default_path = adapter.browserDefault(self)
+                    try:
+                        object, default_path = adapter.browserDefault(self)
+                    except ViewNotCallableError:
+                        return response.badRequestError("View is not callable so likely is missing additional path elements")
                     if default_path:
                         request._hacked_path = 1
                         if len(default_path) > 1:

--- a/src/ZPublisher/BaseRequest.py
+++ b/src/ZPublisher/BaseRequest.py
@@ -472,9 +472,8 @@ class BaseRequest:
                     try:
                         object, default_path = adapter.browserDefault(self)
                     except NotImplementedError:
-                        return response.badRequestError(
-                            "View is not callable. Traverse more."
-                        )
+                        # Often from ViewNotCallableError
+                        return response.notFoundError(URL)
                     if default_path:
                         request._hacked_path = 1
                         if len(default_path) > 1:

--- a/src/ZPublisher/BaseRequest.py
+++ b/src/ZPublisher/BaseRequest.py
@@ -472,7 +472,9 @@ class BaseRequest:
                     try:
                         object, default_path = adapter.browserDefault(self)
                     except NotImplementedError:
-                        return response.badRequestError("View is not callable so is likely missing extra traversal")
+                        return response.badRequestError(
+                            "View is not callable. Traverse more."
+                        )
                     if default_path:
                         request._hacked_path = 1
                         if len(default_path) > 1:

--- a/src/ZPublisher/BaseRequest.py
+++ b/src/ZPublisher/BaseRequest.py
@@ -34,7 +34,6 @@ from zope.publisher.defaultview import queryDefaultViewName
 from zope.publisher.interfaces import EndRequestEvent
 from zope.publisher.interfaces import IPublishTraverse
 from zope.publisher.interfaces import NotFound as ztkNotFound
-from zope.publisher.interfaces import ViewNotCallableError
 from zope.publisher.interfaces.browser import IBrowserPublisher
 from zope.traversing.namespace import namespaceLookup
 from zope.traversing.namespace import nsParse


### PR DESCRIPTION
This can happen in Plone with spam/pentests hitting @@images without a further traversal.

```
ViewNotCallableError: __call__
  File "ZPublisher/WSGIPublisher.py", line 181, in transaction_pubevents
    yield
  File "ZPublisher/WSGIPublisher.py", line 391, in publish_module
    response = _publish(request, new_mod_info)
  File "ZPublisher/WSGIPublisher.py", line 269, in publish
    obj = request.traverse(path, validated_hook=validate_user)
  File "ZPublisher/BaseRequest.py", line 483, in traverse
    object, default_path = adapter.browserDefault(self)
  File "/app/eggs/zope.browserpage-4.4.0-py3.9.egg/zope/browserpage/metaconfigure.py", line 434, in browserDefault
    meth = getattr(self, attr)
  File "app/eggs/Zope-5.8.5-py3.9.egg/Products/Five/browser/metaconfigure.py", line 448, in __call__
    raise ViewNotCallableError('__call__')
```