### PR TITLE
Add configuration switch to turn off the built-in XML-RPC support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 5.12.1 (unreleased)
 -------------------
 
+- Add configuration switch to turn off the built-in XML-RPC support.
+
 - Add configuration switch for the maximum allowed number of form fields.
   ``multipart`` version 1.2.1 introduced a default value of 128, Zope now
   sets it to 1024.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,8 +7,8 @@ since the branch point at Zope 4.1.2.
 The change log for the previous version, Zope 4, is at
 https://github.com/zopefoundation/Zope/blob/4.x/CHANGES.rst
 
-5.12.1 (unreleased)
--------------------
+5.13 (unreleased)
+-----------------
 
 - Add configuration switch to turn off the built-in XML-RPC support.
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ def _read_file(filename):
 README = _read_file('README.rst')
 CHANGES = _read_file('CHANGES.rst')
 
-version = '5.12.1.dev0'
+version = '5.13.dev0'
 
 setup(
     name='Zope',

--- a/src/App/config.py
+++ b/src/App/config.py
@@ -63,6 +63,7 @@ class DefaultConfiguration:
         self.dbtab = None
         self.debug_mode = True
         self.locale = None
+        self.enable_xmlrpc = True
 
         # VerboseSecurity
         self.skip_ownership_checking = False

--- a/src/ZPublisher/HTTPRequest.py
+++ b/src/ZPublisher/HTTPRequest.py
@@ -885,12 +885,12 @@ class HTTPRequest(BaseRequest):
            and 'text/xml' in fs.headers.get('content-type', '') \
            and use_builtin_xmlrpc(self):
             # Ye haaa, XML-RPC!
+            if not CONFIG.enable_xmlrpc:
+                raise BadRequest('Unsupported request type')
+
             if meth is not None:
                 raise BadRequest('method directive not supported for '
                                  'xmlrpc request')
-
-            if not CONFIG.enable_xmlrpc:
-                raise BadRequest('Unsupported request type')
 
             try:
                 meth, self.args = xmlrpc.parse_input(fs.value)

--- a/src/ZPublisher/HTTPRequest.py
+++ b/src/ZPublisher/HTTPRequest.py
@@ -28,6 +28,7 @@ from xmlrpc.client import ResponseError
 
 from AccessControl.tainted import should_be_tainted as base_should_be_tainted
 from AccessControl.tainted import taint_string
+from App.config import getConfiguration
 from multipart import Headers
 from multipart import MultipartError
 from multipart import MultipartParser
@@ -108,6 +109,8 @@ _marker = []
 # if any trusted-proxies are defined in the configuration file.
 
 trusted_proxies = []
+
+CONFIG = getConfiguration()
 
 
 class NestedLoopExit(Exception):
@@ -885,6 +888,10 @@ class HTTPRequest(BaseRequest):
             if meth is not None:
                 raise BadRequest('method directive not supported for '
                                  'xmlrpc request')
+
+            if not CONFIG.enable_xmlrpc:
+                raise BadRequest('Unsupported request type')
+
             try:
                 meth, self.args = xmlrpc.parse_input(fs.value)
             except ResponseError as e:

--- a/src/Zope2/Startup/tests/test_schema.py
+++ b/src/Zope2/Startup/tests/test_schema.py
@@ -191,6 +191,20 @@ class WSGIStartupTestCase(unittest.TestCase):
         finally:
             webdav.enable_ms_public_header = default_setting
 
+    def test_enable_xmlrpc(self):
+        conf, handler = self.load_config_text("""\
+            instancehome <<INSTANCE_HOME>>
+            """)
+        handleWSGIConfig(None, handler)
+        self.assertTrue(conf.enable_xmlrpc)
+
+        conf, handler = self.load_config_text("""\
+            instancehome <<INSTANCE_HOME>>
+            enable-xmlrpc off
+            """)
+        handleWSGIConfig(None, handler)
+        self.assertFalse(conf.enable_xmlrpc)
+
     def test_dos_protection(self):
         from ZPublisher import HTTPRequest
 

--- a/src/Zope2/Startup/wsgischema.xml
+++ b/src/Zope2/Startup/wsgischema.xml
@@ -458,6 +458,22 @@
    <metadefault>off</metadefault>
   </key>
 
+  <key name="enable-xmlrpc" datatype="boolean" default="on">
+    <description>
+     Turn Zope's built-in XML-RPC support on or off.
+
+     Zope has built-in support for XML-RPC requests. It will attempt to use
+     XML-RPC for POST-requests with Content-Type header 'text/xml'. By
+     default the XML-RPC request support is enabled.
+
+     Due to the limited use of XML-RPC nowadays and its potential for abuse
+     by malicious actors you can set this directive to 'off' to turn off
+     support for XML-RPC. Incoming XML-RPC requests will be refused with
+     a BadRequest (HTTP status 400) response.
+    </description>
+    <metadefault>on</metadefault>
+  </key>
+
   <section type="dos_protection" handler="dos_protection"
            name="*" attribute="dos_protection" />
 

--- a/src/Zope2/utilities/skel/etc/zope.conf.in
+++ b/src/Zope2/utilities/skel/etc/zope.conf.in
@@ -250,6 +250,26 @@ instancehome $INSTANCE
 #    security-policy-implementation python
 #    verbose-security on
 
+
+# Directive: enable-xmlrpc
+#
+# Description:
+#     Turn Zope's built-in XML-RPC support on or off.
+#     Zope has built-in support for XML-RPC requests. It will attempt to use
+#     XML-RPC for POST-requests with Content-Type header 'text/xml'. By
+#     default the XML-RPC request support is enabled.
+#     Due to the limited use of XML-RPC nowadays and its potential for abuse
+#     by malicious actors you can set this directive to 'off' to turn off
+#     support for XML-RPC. Incoming XML-RPC requests will be refused with
+#     a BadRequest (HTTP status 400) response.
+#
+# Default: on
+#
+# Example:
+#
+#    enable-xmlrpc off
+
+
 <dos_protection>
 # 
 # Description:


### PR DESCRIPTION
Zope always had support for XML-RPC and other than registering a utility to decide whether to allow it there was no simple way to just turn it off. This PR adds a zope.conf switch to do just that.

The new configuration option is still "on" by default so no one will be surprised. You have to explicitly set it to "off" to disable XML-RPC requests. At that point those are answered by a BadRequest.

I want to add this switch because very few people actually use XML-RPC and I am seeing an increase in malicious and/or spam requests that are detected as XML-RPC in Zope's simple logic (POST with content type `text/xml`) and then cause uncontrolled exceptions in the XML parsing. IMHO everyone should turn this off unless it is really needed.