### PR TITLE
Resolve datetime library warnings

### DIFF
--- a/src/ZPublisher/cookie.py
+++ b/src/ZPublisher/cookie.py
@@ -125,7 +125,7 @@ class CookieParameterRegistry:
         otherwise, the return value is used as value representation.
 
         Some aliases are automatically derived from *name*:
-        convertion to lower, ``-`` to ``_`` conversion.
+        conversion to lower, ``-`` to ``_`` conversion.
         Further aliases can be defined via *aliases*.
 
         It is not an error to override existing registrations.
@@ -197,7 +197,8 @@ def rfc1123_converter(value):
     if isinstance(value, str):
         return value
     if isinstance(value, (int, float)):
-        value = datetime.datetime.utcfromtimestamp(value)
+        value = datetime.datetime.fromtimestamp(value,
+                                                datetime.timezone.utc)
     elif isinstance(value, DateTime):
         value = value.toZone("GMT").asdatetime()
     if not isinstance(value, datetime.datetime):
@@ -262,7 +263,7 @@ path_safe = compile("["
 def path_converter(value):
     """convert *value* to a cookie path.
 
-    The convertion is based on ``absolute_url_path``.
+    The conversion is based on ``absolute_url_path``.
     If *value* lacks this method, it is assumed to be a string.
     If the string contains ``%``, it is used as is; otherwise,
     it may be quoted by Python's ``urllib.parse.quote``.
@@ -300,7 +301,7 @@ registerCookieParameter("HttpOnly", bool_converter, ("http_only",))
 registerCookieParameter("Secure", bool_converter)
 
 
-# selection paramters
+# selection parameters
 class SelectionConverter:
     def __init__(self, *valid):
         self.valid = valid


### PR DESCRIPTION
# PR Summary
This small PR resolves the `datetime` library warnings:
```python
/home/runner/work/Zope/Zope/src/ZPublisher/cookie.py:200: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
```
It also fixes a few typos along the way.