### PR TITLE
Fix exception swallowing in expr_match

### DIFF
--- a/src/OFS/FindSupport.py
+++ b/src/OFS/FindSupport.py
@@ -198,7 +198,7 @@ def expr_match(ob, ed, c=InstanceDict, r=0):
         r = e.eval(md)
     finally:
         pop()
-        return r
+    return r
 
 
 def mtime_match(ob, t, q, fn=hasattr):


### PR DESCRIPTION
Fixes #1231 <!-- Needed for GitHub to link the issue to the PR -->

## Fix exception swallowing in expr_match
The `expr_match` function in `FindSupport.py` had a `return` statement inside a `finally` block, which would swallow any exceptions raised during `e.eval(md)`. This could mask important errors including `KeyboardInterrupt`. 

Fixed by moving the `return r` outside the `finally` block, allowing exceptions to properly propagate while still ensuring the `pop()` cleanup action executes. This matches Python&#39;s intended error handling behavior where `finally` should not suppress exceptions.

---

This change was produced by **Harry Patcher** 🧙‍♂️, an autonomous & anonymous AI engineering agent. No human was involved in creating this pull request.

Learn more about Harry Patcher and how he came up with this fix [here](https://harry-patcher.ai/viewer?url=aHR0cHM6Ly9naXN0LmdpdGh1Yi5jb20vaGFycnktcGF0Y2hlci8yNDdjNGIzNzFhODg5Y2U3MjAyYjM5YzZhOTZlMmE2Ni9yYXcvc3dlYmVuY2hfem9wZWZvdW5kYXRpb25fX1pvcGUtMTIzMS5qc29u&amp;pr=aHR0cHM6Ly9naXRodWIuY29tL3pvcGVmb3VuZGF0aW9uL1pvcGUvcHVsbC8xMjYy) 🔍.

Harry cannot yet respond to review feedback. If the patch isn’t relevant, reject the PR and optionally [let us know](https://forms.office.com/Pages/ResponsePage.aspx?id=UjyyTqXzvEm1VQsGEmephKlyfnndRsBKt5Fmxu7iHWpUMEdIRzFTUU9LNkxYMDZWQlZWT0gwSFJUTCQlQCN0PWcu&r1e8e3930f96f400aa91b5105dbd09b7d=https%3A//github.com/zopefoundation/Zope/pull/1262&rb85bea8de07843f9835f9d001f689f4c=https%3A//github.com/zopefoundation/Zope&r034de175aef248b29aaf36f2a5e92912=https%3A//github.com/zopefoundation/Zope/pull/1262&r9e0cc5d7ff8b484e81eb97531d4cefd7=https%3A//github.com/zopefoundation/Zope/pull/1262) 📬.