### PR TITLE
Upgrade mr.developer to 2.0.3.

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -44,7 +44,7 @@ idna==3.10
 imagesize==1.4.1
 importlib-metadata==8.6.1
 legacy-cgi==2.6.2
-mr.developer==2.0.2
+mr.developer==2.0.3
 multipart==1.2.1
 packaging==24.2
 persistent==6.1.1

--- a/versions.cfg
+++ b/versions.cfg
@@ -28,7 +28,7 @@ imagesize = 1.4.1
 importlib-metadata = 8.6.1
 # Required by zope.testbrowser on Python 3.13 because WebOb still uses cgi.
 legacy-cgi = 2.6.2
-mr.developer = 2.0.2
+mr.developer = 2.0.3
 packaging = 24.2
 plone.recipe.command = 1.1
 requests = 2.32.3


### PR DESCRIPTION
This fixes a ModuleNotFoundError with setuptools 80.2 or higher, for the removed `package_index` module. See https://github.com/fschulze/mr.developer/pull/213