### PR TITLE
Small release process improvements

### DIFF
--- a/docs/maintenance.rst
+++ b/docs/maintenance.rst
@@ -64,6 +64,11 @@ Steps for creating a new Zope release
 
 - If the tests succeed, commit the changes.
 
+- Clear out documentation build artifacts to prevent adding these files to
+  the package::
+
+   $ rm -rf docs/_build
+
 - Upload the tagged release to PyPI::
 
     $ bin/release  # if you use zest.releaser
@@ -72,7 +77,7 @@ Steps for creating a new Zope release
 
     $ git tag -as <TAG-NAME> -m "- tagging release <TAG-NAME>"
     $ git push --tags
-    $ bin/zopepy setup.py egg_info -Db '' sdist bdist_wheel
+    $ bin/buildout setup setup.py sdist bdist_wheel
     $ bin/twine upload dist/Zope-<TAG-NAME>*
 
 - Update version information in the change log and setup.py::


### PR DESCRIPTION
I added an explicit step to delete documentation build artifacts because the current rules in `MANIFEST.in` will include a bunch of that. I have inadvertently generated release tarballs that are way too large (12.6 instead of 7.7 MB) due to including documentation build files for a long time.

I also switched from using `zopepy` to using `buildout setup` because `zopepy` requires running the buildout in place, which I rarely do anymore. I also removed the `egg_info -Db ''` part, I don't think it serves a useful purpose. If you believe it is important please let me know.