### PR TITLE
5.x: downgrade plone.versioncheck.

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -50,11 +50,12 @@ idna==3.11
 imagesize==1.5.0
 legacy-cgi==2.6.4
 mr.developer==2.0.4
+msgpack==1.1.2
 multipart==1.3.1
 packaging==26.0
 persistent==6.5
 plone.recipe.command==1.1
-plone.versioncheck==2.0.1
+plone.versioncheck==1.8.2
 pycparser==3.0
 python-gettext==5.0
 pytz==2026.1.post1

--- a/versions.cfg
+++ b/versions.cfg
@@ -39,9 +39,10 @@ imagesize = 1.5.0
 # Required by zope.testbrowser on Python 3.13 because WebOb still uses cgi.
 legacy-cgi = 2.6.4
 mr.developer = 2.0.4
+msgpack = 1.1.2
 packaging = 26.0
 plone.recipe.command = 1.1
-plone.versioncheck = 2.0.1
+plone.versioncheck = 1.8.2
 requests = 2.32.5
 roman-numerals = 4.1.0
 roman-numerals-py = 4.1.0


### PR DESCRIPTION
Version 2 has native namespaces, and here we want old pkg_resources style. Otherwise this may interfere with plone.recipe.command. See https://github.com/zopefoundation/Zope/issues/1288#issuecomment-4014148314

Note though: version 2 is much faster.