### PR TITLE
Fix broken links to "Using Basic Zope Objects"

### DIFF
--- a/docs/zopebook/DTML.rst
+++ b/docs/zopebook/DTML.rst
@@ -104,13 +104,13 @@ the difference?
 
 DTML Methods are used to carry out actions. They are
 *presentation* objects (as used in the vernacular of the
-`Using Basic Zope Objects <BasicObjects.html>`_ chapter).  If you want
+`Using Basic Zope Objects <BasicObject.html>`_ chapter).  If you want
 to render the properties or attributes of another object like a DTML
 Document or a Folder, you will use a DTML Method.  DTML Methods do
 not have their own properties.
 
 DTML Documents are *content* objects (in the vernacular used in
-the chapter entitled `Using Basic Zope Objects <BasicObjects.html>`_).
+the chapter entitled `Using Basic Zope Objects <BasicObject.html>`_).
 If you want to create a "stand-alone" text document, you
 might create a DTML Document object to hold the text.
 DTML Document objects have their own *properties* (attributes),

--- a/docs/zopebook/ScriptingZope.rst
+++ b/docs/zopebook/ScriptingZope.rst
@@ -197,7 +197,7 @@ might want to read files from disk, or access the network,
 or use some advanced libraries for things like regular
 expressions or image processing.  In these cases you can use
 *External Methods*.   We encountered External Methods briefly
-in the chapter entitled `Using Basic Zope Objects <BasicObjects.html>`_ .
+in the chapter entitled `Using Basic Zope Objects <BasicObject.html>`_ .
 Now we will explore them in more detail.
 
 To create and edit External Methods you need access


### PR DESCRIPTION
Some links had an extra "s" in the URL and thus were broken.

Note: The patch is so tiny as not to constitute a "creative work", as mentioned in the Zope Contributor Agreement. So, I don't think it is necessary to sign that (but I can do if you are so inclined).

- [ ] I signed and returned the [Zope Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the zopefoundation GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [ ] I followed the guidelines in [Developer guidelines](https://www.zope.dev/developer/guidelines.html).
- [ ] I successfully ran code quality checks on my changes locally.
- [ ] I successfully ran tests on my changes locally.
- [x] If needed, I added new tests for my changes.
- [x] If needed, I added documentation for my changes.
- [ ] I included a change log entry in my commits.

