### PR TITLE
Update to Python 3.15

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,7 @@ jobs:
         - ["3.12", "py312"]
         - ["3.13", "py313"]
         - ["3.14", "py314"]
+        - ["3.15", "py315"]
         - ["3.11", "docs"]
         - ["3.11", "coverage"]
         exclude:
@@ -66,3 +67,32 @@ jobs:
         uvx coveralls --service=github
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build package artifacts
+      if: >
+        matrix.os[0] == 'ubuntu'
+        && matrix.config[1] == 'py314'
+      run: |
+        rm -f dist/*
+        pip install -U packaging "setuptools >= 78.1.1,< 82" wheel twine
+        python setup.py sdist
+        python setup.py bdist_wheel
+
+    - name: Upload package wheel
+      if: >
+        matrix.os[0] == 'ubuntu'
+        && matrix.config[1] == 'py314'
+      uses: actions/upload-artifact@v7
+      with:
+        name: Zope.whl
+        path: dist/*whl
+
+    - name: Upload package source distribution
+      if: >
+        matrix.os[0] == 'ubuntu'
+        && matrix.config[1] == 'py314'
+      uses: actions/upload-artifact@v7
+      with:
+        name: Zope.tar.gz
+        path: dist/*gz
+

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/src/zope/meta/zope-product
 [meta]
 template = "zope-product"
-commit-id = "ba10c93f"
+commit-id = "516c594a"
 
 [python]
 with-pypy = false
@@ -10,7 +10,7 @@ with-docs = true
 with-sphinx-doctests = false
 with-windows = true
 with-macos = true
-with-future-python = false
+with-future-python = true
 with-free-threaded-python = false
 
 [coverage]

--- a/constraints.txt
+++ b/constraints.txt
@@ -19,7 +19,11 @@ Products.BTreeFolder2==6.0
 Products.ZCatalog==7.3
 Pygments==2.20.0
 Record==4.2
-RestrictedPython==8.1
+RestrictedPython==8.1; python_version == '3.10'
+RestrictedPython==8.1; python_version == '3.11'
+RestrictedPython==8.1; python_version == '3.12'
+RestrictedPython==8.1; python_version == '3.13'
+RestrictedPython==8.3a1.dev0; python_version > '3.13'
 Sphinx==8.1.3; python_version == '3.10'
 Sphinx==9.0.4; python_version == '3.11'
 Sphinx==9.1.0; python_version > '3.11'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/src/zope/meta/zope-product
 [build-system]
 requires = [
-    "setuptools >= 78.1.1,< 81",
+    "setuptools >= 78.1.1,< 82",
     "wheel",
 ]
 build-backend = "setuptools.build_meta"

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -11,7 +11,11 @@ MultiMapping==5.1
 Paste==3.10.1
 PasteDeploy==3.1.0
 Persistence==5.4
-RestrictedPython==8.1
+RestrictedPython==8.1; python_version == '3.10'
+RestrictedPython==8.1; python_version == '3.11'
+RestrictedPython==8.1; python_version == '3.12'
+RestrictedPython==8.1; python_version == '3.13'
+RestrictedPython==8.3a1.dev0; python_version > '3.13'
 WSGIProxy2==0.5.1
 WebOb==1.8.9
 WebTest==3.0.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 # Generated with zope.meta (https://zopemeta.readthedocs.io/) from:
 # https://github.com/zopefoundation/meta/tree/master/src/zope/meta/zope-product
-
 [flake8]
 doctests = 1
 no-accept-encodings = True

--- a/tox.ini
+++ b/tox.ini
@@ -10,13 +10,14 @@ envlist =
     py312
     py313
     py314
+    py315
     docs
     coverage
 
 [testenv]
 skip_install = true
 deps =
-    setuptools >= 78.1.1,< 81
+    setuptools >= 78.1.1,< 82
     zc.buildout
     wheel
 setenv =
@@ -39,7 +40,7 @@ description = ensure that the distribution is ready to release
 basepython = python3
 skip_install = true
 deps =
-    setuptools >= 78.1.1,< 81
+    setuptools >= 78.1.1,< 82
     wheel
     twine
     build

--- a/versions-prod.cfg
+++ b/versions-prod.cfg
@@ -18,7 +18,7 @@ MultiMapping = 5.1
 Paste = 3.10.1
 PasteDeploy = 3.1.0
 Persistence = 5.4
-RestrictedPython = 8.1
+RestrictedPython = 8.3a1.dev0
 WebTest = 3.0.7
 WSGIProxy2 = 0.5.1
 WebOb = 1.8.9
@@ -83,3 +83,14 @@ zope.testbrowser = 8.0
 zope.testing = 6.1
 zope.traversing = 6.0
 zope.viewlet = 6.0
+
+[versions:python310]
+RestrictedPython = 8.1
+[versions:python311]
+RestrictedPython = 8.1
+[versions:python312]
+RestrictedPython = 8.1
+[versions:python313]
+RestrictedPython = 8.1
+[versions:python314]
+RestrictedPython = 8.1


### PR DESCRIPTION
Current blockers:

- [ ] https://github.com/shibukawa/imagesize_py/issues/85 `imagesize` requires `Python < 3.15`.