### PR TITLE
Disable XML-RPC support by default

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -21,8 +21,8 @@ jobs:
     name: linting
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
-    - uses: actions/setup-python@v6
+    - uses: actions/checkout@v7
+    - uses: actions/setup-python@v7
       with:
         python-version: '3.13'
     - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  #v3.0.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,12 +45,12 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: ${{ matrix.os[0] }}-${{ matrix.config[1] }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         persist-credentials: false
     - name: Install uv + caching
-      # astral/setup-uv@8.1.0
-      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
+      # astral/setup-uv@9.0.0
+      uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9
       with:
         enable-cache: true
         cache-dependency-glob: |

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/src/zope/meta/zope-product
 [meta]
 template = "zope-product"
-commit-id = "4a693eeb"
+commit-id = "bab2e429"
 
 [python]
 with-pypy = false

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,11 @@ https://github.com/zopefoundation/Zope/blob/5.x/CHANGES.rst.
 6.2 (unreleased)
 ----------------
 
+- Disable XML-RPC request support by default.
+  The protocol is rarely used and disabling it reduces the potential for
+  abuse. Set ``enable-xmlrpc`` to ``on`` in the Zope configuration if you
+  really need XML-RPC support.
+
 - Update to newest compatible versions of dependencies.
 
 - Switch to Trusted Publishing for publishing packages to PyPI.

--- a/docs/zdgbook/ObjectPublishing.rst
+++ b/docs/zdgbook/ObjectPublishing.rst
@@ -8,7 +8,7 @@ Introduction
 Zope puts your objects on the web. This is called **object
 publishing**. One of Zope's unique characteristics is the way it
 allows you to walk up to your objects and call methods on them with
-simple URLs. In addition to HTTP, Zope makes your objects available
+simple URLs. In addition to HTTP, Zope can make your objects available
 via XML-RPC.
 
 In this chapter you'll find out exactly how Zope publishes objects.
@@ -1313,7 +1313,8 @@ XML-RPC
 
 **XML-RPC** is a light-weight remote procedure call (RPC) protocol
 that uses **XML** to encode its calls and **HTTP** as a transport
-mechanism.
+mechanism. Starting with Zope version 6.2 you must explicitly enable
+it with the ``enable-xmlrpc`` Zope configuration setting.
 
 All objects in Zope support XML-RPC publishing. Generally you will
 select a published object as the end-point and select one of its

--- a/docs/zopebook/ScriptingZope.rst
+++ b/docs/zopebook/ScriptingZope.rst
@@ -1218,6 +1218,9 @@ many programs that let you you script HTTP from the command line.
 Using XML-RPC
 ~~~~~~~~~~~~~
 
+**NOTE:** Starting with Zope 6.2, XML-RPC is disabled by default. You can
+enable with the ``enable-xmlrpc`` Zope configuration setting.
+
 XML-RPC is a simple remote procedure call mechanism that works
 over HTTP and uses XML to encode information. XML-RPC clients
 have been implemented for many languages including Python,

--- a/src/App/config.py
+++ b/src/App/config.py
@@ -63,7 +63,7 @@ class DefaultConfiguration:
         self.dbtab = None
         self.debug_mode = True
         self.locale = None
-        self.enable_xmlrpc = True
+        self.enable_xmlrpc = False
 
         # VerboseSecurity
         self.skip_ownership_checking = False

--- a/src/ZPublisher/tests/testHTTPRequest.py
+++ b/src/ZPublisher/tests/testHTTPRequest.py
@@ -21,6 +21,7 @@ from urllib.parse import quote_plus
 
 from AccessControl.tainted import TaintedString
 from AccessControl.tainted import should_be_tainted
+from zExceptions import BadRequest
 from zExceptions import NotFound
 from zope.component import getGlobalSiteManager
 from zope.component import provideAdapter
@@ -806,6 +807,19 @@ class HTTPRequestTests(unittest.TestCase, HTTPRequestFactoryMixin):
         self.assertEqual(req.cookies['multi2'],
                          'cookie data with unquoted spaces')
 
+    def test_processInputs_xmlrpc_disabled(self):
+        TEST_METHOD_CALL = (
+            b'<?xml version="1.0"?>'
+            b'<methodCall><methodName>test</methodName></methodCall>'
+        )
+        environ = self._makePostEnviron(body=TEST_METHOD_CALL)
+        environ['CONTENT_TYPE'] = 'text/xml'
+        req = self._makeOne(stdin=BytesIO(TEST_METHOD_CALL), environ=environ)
+
+        # By default, XML-RPC is disabled.
+        with self.assertRaises(BadRequest):
+            req.processInputs()
+
     def test_processInputs_xmlrpc(self):
         TEST_METHOD_CALL = (
             b'<?xml version="1.0"?>'
@@ -814,7 +828,13 @@ class HTTPRequestTests(unittest.TestCase, HTTPRequestFactoryMixin):
         environ = self._makePostEnviron(body=TEST_METHOD_CALL)
         environ['CONTENT_TYPE'] = 'text/xml'
         req = self._makeOne(stdin=BytesIO(TEST_METHOD_CALL), environ=environ)
+
+        # Force-enable XML-RPC
+        from App.config import _config
+        _config.enable_xmlrpc = True
         req.processInputs()
+        _config.enable_xmlrpc = False
+
         self.assertEqual(req.PATH_INFO, '/test')
         self.assertEqual(req.args, ())
 
@@ -827,7 +847,13 @@ class HTTPRequestTests(unittest.TestCase, HTTPRequestFactoryMixin):
         environ['CONTENT_TYPE'] = 'text/xml'
         environ['QUERY_STRING'] = 'x=1'
         req = self._makeOne(stdin=BytesIO(TEST_METHOD_CALL), environ=environ)
+
+        # Force-enable XML-RPC
+        from App.config import _config
+        _config.enable_xmlrpc = True
         req.processInputs()
+        _config.enable_xmlrpc = False
+
         self.assertEqual(req.PATH_INFO, '/test')
         self.assertEqual(req.args, ())
         self.assertEqual(req.form["x"], '1')
@@ -841,8 +867,13 @@ class HTTPRequestTests(unittest.TestCase, HTTPRequestFactoryMixin):
         environ['CONTENT_TYPE'] = 'text/xml'
         environ['QUERY_STRING'] = ':method=method'
         req = self._makeOne(stdin=BytesIO(TEST_METHOD_CALL), environ=environ)
+
+        # Force-enable XML-RPC
+        from App.config import _config
+        _config.enable_xmlrpc = True
         with self.assertRaises(BadRequest):
             req.processInputs()
+        _config.enable_xmlrpc = False
 
     def test_processInputs_xmlrpc_ResponseError(self):
         # xmlrpc ResponseErrors should be caught and converted to
@@ -855,8 +886,13 @@ class HTTPRequestTests(unittest.TestCase, HTTPRequestFactoryMixin):
         environ = self._makePostEnviron(body=TEST_METHOD_CALL)
         environ['CONTENT_TYPE'] = 'text/xml'
         req = self._makeOne(stdin=BytesIO(TEST_METHOD_CALL), environ=environ)
+
+        # Force-enable XML-RPC
+        from App.config import _config
+        _config.enable_xmlrpc = True
         with self.assertRaises(BadRequest):
             req.processInputs()
+        _config.enable_xmlrpc = False
 
     def test_processInputs_SOAP(self):
         # ZPublisher does not really have SOAP support
@@ -1392,7 +1428,13 @@ class HTTPRequestTests(unittest.TestCase, HTTPRequestFactoryMixin):
         req = self._makeOne(
             stdin=BytesIO(self._xmlrpc_call),
             environ=dict(REQUEST_METHOD="POST", CONTENT_TYPE="text/xml"))
+
+        # Force-enable XML-RPC
+        from App.config import _config
+        _config.enable_xmlrpc = True
         req.processInputs()
+        _config.enable_xmlrpc = False
+
         self.assertTrue(is_xmlrpc_response(req.response))
         self.assertEqual(req.args, (41,))
         self.assertEqual(req.other["PATH_INFO"], "/examples/getStateName")
@@ -1401,8 +1443,14 @@ class HTTPRequestTests(unittest.TestCase, HTTPRequestFactoryMixin):
         req = self._makeOne(
             stdin=BytesIO(self._xmlrpc_call),
             environ=dict(REQUEST_METHOD="POST", CONTENT_TYPE="text/xml"))
+
+        # Force-enable XML-RPC
+        from App.config import _config
+        _config.enable_xmlrpc = True
         with self._xmlrpc_control(lambda request: True):
             req.processInputs()
+        _config.enable_xmlrpc = False
+
         self.assertTrue(is_xmlrpc_response(req.response))
 
     def test_processInputs_xmlrpc_controlled_disallowed(self):

--- a/src/ZPublisher/tests/testHTTPRequest.py
+++ b/src/ZPublisher/tests/testHTTPRequest.py
@@ -30,7 +30,6 @@ from zope.i18n.interfaces.locales import ILocale
 from zope.publisher.browser import BrowserLanguages
 from zope.publisher.interfaces.http import IHTTPRequest
 from zope.testing.cleanup import cleanUp
-from ZPublisher.HTTPRequest import BadRequest
 from ZPublisher.HTTPRequest import FileUpload
 from ZPublisher.HTTPRequest import search_type
 from ZPublisher.interfaces import IXmlrpcChecker

--- a/src/Zope2/Startup/tests/test_schema.py
+++ b/src/Zope2/Startup/tests/test_schema.py
@@ -196,7 +196,7 @@ class WSGIStartupTestCase(unittest.TestCase):
             instancehome <<INSTANCE_HOME>>
             """)
         handleWSGIConfig(None, handler)
-        self.assertTrue(conf.enable_xmlrpc)
+        self.assertFalse(conf.enable_xmlrpc)
 
         conf, handler = self.load_config_text("""\
             instancehome <<INSTANCE_HOME>>
@@ -204,6 +204,13 @@ class WSGIStartupTestCase(unittest.TestCase):
             """)
         handleWSGIConfig(None, handler)
         self.assertFalse(conf.enable_xmlrpc)
+
+        conf, handler = self.load_config_text("""\
+            instancehome <<INSTANCE_HOME>>
+            enable-xmlrpc on
+            """)
+        handleWSGIConfig(None, handler)
+        self.assertTrue(conf.enable_xmlrpc)
 
     def test_dos_protection(self):
         from ZPublisher import HTTPRequest

--- a/src/Zope2/Startup/wsgischema.xml
+++ b/src/Zope2/Startup/wsgischema.xml
@@ -449,17 +449,16 @@
    <metadefault>off</metadefault>
   </key>
 
-  <key name="enable-xmlrpc" datatype="boolean" default="on">
+  <key name="enable-xmlrpc" datatype="boolean" default="off">
     <description>
      Turn Zope's built-in XML-RPC support on or off.
 
      Zope has built-in support for XML-RPC requests. It will attempt to use
-     XML-RPC for POST-requests with Content-Type header 'text/xml'. By
-     default the XML-RPC request support is enabled.
+     XML-RPC for POST-requests with Content-Type header 'text/xml'.
 
-     Due to the limited use of XML-RPC nowadays and its potential for abuse
-     by malicious actors you can set this directive to 'off' to turn off
-     support for XML-RPC. Incoming XML-RPC requests will be refused with
+     By default XML-RPC request support is disabled due to the limited
+     use of the protocol nowadays and its potential for abuse by malicious
+     actors. When disabled, incoming XML-RPC requests will be refused with
      a BadRequest (HTTP status 400) response.
     </description>
     <metadefault>on</metadefault>

--- a/src/Zope2/utilities/skel/etc/zope.conf.in
+++ b/src/Zope2/utilities/skel/etc/zope.conf.in
@@ -256,18 +256,17 @@ instancehome $INSTANCE
 # Description:
 #     Turn Zope's built-in XML-RPC support on or off.
 #     Zope has built-in support for XML-RPC requests. It will attempt to use
-#     XML-RPC for POST-requests with Content-Type header 'text/xml'. By
-#     default the XML-RPC request support is enabled.
-#     Due to the limited use of XML-RPC nowadays and its potential for abuse
-#     by malicious actors you can set this directive to 'off' to turn off
-#     support for XML-RPC. Incoming XML-RPC requests will be refused with
-#     a BadRequest (HTTP status 400) response.
+#     XML-RPC for POST-requests with Content-Type header 'text/xml'.
+#     By default XML-RPC request support is disabled due to the limited
+#     use of the protocol nowadays and its potential for abuse
+#     by malicious actors. When disabled, incoming XML-RPC requests will be
+#     refused with a BadRequest (HTTP status 400) response.
 #
-# Default: on
+# Default: off
 #
 # Example:
 #
-#    enable-xmlrpc off
+#    enable-xmlrpc on
 
 
 <dos_protection>


### PR DESCRIPTION
The XML-RPC service has been gated behind a Zope setting for more than a year now (see https://github.com/zopefoundation/Zope/pull/1254). Out of (probably misplaced) fear that disabling XML-RPC by default may inconvenience people I left it enabled by default.

At this point I think that was a mistake. In more than 25 years working with Zope I do not think I have seen a single project that actually uses XML-RPC. Setting the default to `disabled` trades a rarely used feature against a reduction in abuse risk for all Zope users.
